### PR TITLE
Update websocket all processes

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -53,9 +53,8 @@ from orchestrator.schemas import (
 from orchestrator.security import oidc_user
 from orchestrator.services.processes import SYSTEM_USER, abort_process, load_process, resume_process, start_process
 from orchestrator.types import JSON
-from orchestrator.utils.json import json_dumps
 from orchestrator.utils.show_process import show_process
-from orchestrator.websocket import WS_CHANNELS, is_process_active, websocket_enabled, websocket_manager
+from orchestrator.websocket import WS_CHANNELS, websocket_enabled, websocket_manager
 from orchestrator.workflow import ProcessStatus
 
 router = APIRouter()
@@ -333,33 +332,3 @@ async def websocket_process_list(websocket: WebSocket, token: str = Query(...)) 
 
     channel = WS_CHANNELS.ALL_PROCESSES
     await websocket_manager.connect(websocket, channel)
-
-
-@router.websocket("/{pid}")
-@websocket_enabled
-async def websocket_process_detail(websocket: WebSocket, pid: UUID, token: str = Query(...)) -> None:
-    error = await websocket_manager.authorize(websocket, token)
-
-    await websocket.accept()
-
-    if error:
-        await websocket_manager.disconnect(websocket, reason=error)
-        return
-
-    try:
-        process = get_current_process_data(pid)
-    except Exception as error:
-        await websocket_manager.disconnect(websocket, reason={"error": vars(error)})
-        return
-
-    await websocket.send_text(json_dumps({"process": process}))
-    if not is_process_active(process):
-        await websocket.close()
-        return
-
-    channel = WS_CHANNELS.SINGLE_PROCESS(pid)
-    await websocket_manager.connect(websocket, channel)
-
-
-def get_current_process_data(pid: UUID) -> Dict[str, Any]:
-    return show(pid)

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -28,7 +28,7 @@ from fastapi_etag.dependency import CacheHit
 from more_itertools import chunked
 from oauth2_lib.fastapi import OIDCUserModel
 from sqlalchemy import String, cast
-from sqlalchemy.orm import contains_eager, defer, joinedload, load_only
+from sqlalchemy.orm import contains_eager, defer, joinedload
 from sqlalchemy.sql import expression
 from starlette.responses import Response
 
@@ -43,7 +43,6 @@ from orchestrator.db import (
     SubscriptionTable,
     db,
 )
-from orchestrator.forms import generate_form
 from orchestrator.schemas import (
     ProcessIdSchema,
     ProcessListItemSchema,
@@ -176,31 +175,9 @@ def assignees() -> List[str]:
 @router.get("/{pid}", response_model=ProcessSchema)
 def show(pid: UUID) -> Dict[str, Any]:
     process = _get_process(pid)
-
     p = load_process(process)
 
-    steps = [
-        {
-            "name": step.name,
-            "executed": int(step.executed_at.timestamp()),
-            "status": step.status,
-            "state": step.state,
-            "commit_hash": step.commit_hash,
-        }
-        for step in process.steps
-    ]
-
-    if p.log:
-        form = p.log[0].form
-        steps += list(map(lambda step: {"name": step.name, "status": "pending"}, p.log))
-    else:
-        form = None
-
-    data = show_process(process)
-    data["current_state"] = p.state.unwrap()
-    data["steps"] = steps
-    data["form"] = generate_form(form, p.state.unwrap(), [])
-
+    data = show_process(process, p)
     return data
 
 
@@ -354,8 +331,6 @@ async def websocket_process_list(websocket: WebSocket, token: str = Query(...)) 
         await websocket_manager.disconnect(websocket, reason=error)
         return
 
-    await websocket.send_text(json_dumps({"failedProcesses": get_failed_processes()}))
-
     channel = WS_CHANNELS.ALL_PROCESSES
     await websocket_manager.connect(websocket, channel)
 
@@ -388,13 +363,3 @@ async def websocket_process_detail(websocket: WebSocket, pid: UUID, token: str =
 
 def get_current_process_data(pid: UUID) -> Dict[str, Any]:
     return show(pid)
-
-
-def get_failed_processes() -> List[Dict[str, Any]]:
-    return (
-        ProcessTable.query.options(
-            load_only(ProcessTable.pid, ProcessTable.last_status),
-        )
-        .filter(ProcessTable.last_status.in_(["failed", "inconsistent_data", "api_unavailable"]))
-        .all()
-    )

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -30,11 +30,7 @@ from orchestrator.targets import Target
 from orchestrator.types import State
 from orchestrator.utils.datetime import nowtz
 from orchestrator.utils.errors import error_state_to_dict
-from orchestrator.websocket import (
-    create_process_step_websocket_data,
-    send_process_step_data_to_websocket,
-    websocket_manager,
-)
+from orchestrator.websocket import create_process_websocket_data, send_process_data_to_websocket, websocket_manager
 from orchestrator.workflow import Failed
 from orchestrator.workflow import Process as WFProcess
 from orchestrator.workflow import ProcessStat, ProcessStatus, Step, StepList, Success, Workflow, abort_wf, runwf
@@ -172,8 +168,8 @@ def _db_log_step(stat: ProcessStat, step: Step, process_state: WFProcess) -> WFP
         raise
 
     if websocket_manager.enabled:
-        websocket_data = create_process_step_websocket_data(p, current_step, step.form)
-        send_process_step_data_to_websocket(p.pid, websocket_data)
+        websocket_data = create_process_websocket_data(p, stat)
+        send_process_data_to_websocket(p.pid, websocket_data)
 
     # Return the state as stored in the database
     return process_state.__class__(current_step.state)

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -168,7 +168,8 @@ def _db_log_step(stat: ProcessStat, step: Step, process_state: WFProcess) -> WFP
         raise
 
     if websocket_manager.enabled:
-        websocket_data = create_process_websocket_data(p, stat)
+        new_pStat = load_process(p)
+        websocket_data = create_process_websocket_data(p, new_pStat)
         send_process_data_to_websocket(p.pid, websocket_data)
 
     # Return the state as stored in the database

--- a/orchestrator/utils/show_process.py
+++ b/orchestrator/utils/show_process.py
@@ -42,12 +42,11 @@ def show_process(process: ProcessTable, pStat: ProcessStat) -> dict:
     form = None
     if pStat.log:
         form = pStat.log[0].form
-
         pstat_steps = list(map(lambda step: {"name": step.name, "status": "pending"}, pStat.log))
-        for step in steps:
-            if step["name"] == pstat_steps[0]["name"]:
-                pstat_steps.pop(0)
         steps += pstat_steps
+
+    current_state = pStat.state.unwrap() if pStat.state else None
+    generated_form = generate_form(form, current_state, []) if form and current_state else None
 
     return {
         "id": process.pid,
@@ -73,6 +72,6 @@ def show_process(process: ProcessTable, pStat: ProcessStat) -> dict:
             for s in process.process_subscriptions
         ],
         "is_task": process.is_task,
-        "form": generate_form(form, pStat.state.unwrap(), []),
-        "current_state": pStat.state.unwrap(),
+        "form": generated_form,
+        "current_state": current_state,
     }

--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -84,7 +84,7 @@ def is_process_active(p: Dict) -> bool:
 
 def send_process_data_to_websocket(pid: UUID, data: Dict) -> None:
     loop = new_event_loop()
-    channels = [WS_CHANNELS.ALL_PROCESSES, WS_CHANNELS.ENGINE_SETTINGS]
+    channels = [WS_CHANNELS.ALL_PROCESSES]
     loop.run_until_complete(websocket_manager.broadcast_data(channels, data))
     try:
         loop.close()

--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -35,10 +35,6 @@ class WS_CHANNELS:
     ALL_PROCESSES = "processes"
     ENGINE_SETTINGS = "engine-settings"
 
-    @staticmethod
-    def SINGLE_PROCESS(pid: UUID) -> str:
-        return f"process_detail:{pid}"
-
 
 async def empty_fn(*args: tuple, **kwargs: Dict[str, Any]) -> None:
     return
@@ -87,13 +83,8 @@ def is_process_active(p: Dict) -> bool:
 
 
 def send_process_data_to_websocket(pid: UUID, data: Dict) -> None:
-    channel = WS_CHANNELS.SINGLE_PROCESS(pid)
-
-    if not is_process_active(data["process"]):
-        data["close"] = True
-
     loop = new_event_loop()
-    channels = [channel, WS_CHANNELS.ALL_PROCESSES, WS_CHANNELS.ENGINE_SETTINGS]
+    channels = [WS_CHANNELS.ALL_PROCESSES, WS_CHANNELS.ENGINE_SETTINGS]
     loop.run_until_complete(websocket_manager.broadcast_data(channels, data))
     try:
         loop.close()
@@ -108,7 +99,7 @@ async def empty_handler() -> None:
 def websocket_enabled(handler: Any) -> Any:
     @wraps(handler)
     @wraps(empty_handler)
-    async def wrapper(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+    async def wrapper(*args: tuple, **kwargs: Dict[str, Any]) -> Any:
         if websocket_manager.enabled:
             return await handler(*args, **kwargs)
         else:


### PR DESCRIPTION
- improve process data in all processes websocket endpoint.
- remove logic to send failed processes as the first websocket message, initial data will come from http request.
- rename create_process_step_websocket_data to create_process_websocket_data.
- rename send_process_data_to_websocket to create_process_websocket_data.
- move logic done within process show endpoint to the show_process function, so it will also be used for the all processes websocket.
- change the create_process_websocket_data to only return process data, the step data is already in the process data.
- remove unnecessary process detail websocket endpoint.
- remove engine settings from channels in send_process_data_to_websocket function, it does not need process data.
- Load new process stat in processes service before creating websocket data.