### PR TITLE
Allow self-referencing product blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,24 +4,24 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3.9
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==21.9b0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: check-json
       - id: check-yaml
-        exclude: (charts/*|.gitlab-ci.yml)
+        exclude: (charts/*|.gitlab-ci.yml|mkdocs.yml)
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: detect-private-key
@@ -40,16 +40,21 @@ repos:
           - flake8-rst
           - flake8-rst-docstrings
           - flake8-tidy-imports
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.910
-  #   hooks:
-  #     - id: mypy
-  #       language_version: python3.9
-  #       additional_dependencies: [pydantic]
-  #       args:
-  #         - --no-warn-unused-ignores
-  #         - --allow-untyped-decorators
-  #       exclude: (test/*|migrations/*)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        language_version: python3.9
+        additional_dependencies:
+          - pydantic
+          - types-toml
+          - types-pytz
+          - types-python-dateutil
+          - types-requests
+        args:
+          - --no-warn-unused-ignores
+          - --allow-untyped-decorators
+        exclude: (test/*|migrations/*)
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:
@@ -58,10 +63,10 @@ repos:
       - id: python-check-mock-methods
       - id: rst-backticks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.2
+    rev: v0.8.0.4
     hooks:
       - id: shellcheck
   - repo: https://github.com/andreoliwa/nitpick
-    rev: v0.29.0
+    rev: v0.31.0
     hooks:
-      - id: nitpick
+      - id: nitpick-check

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -15,7 +15,21 @@ from datetime import datetime
 from itertools import groupby, zip_longest
 from operator import attrgetter
 from sys import version_info
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_type_hints,
+)
 from uuid import UUID, uuid4
 
 import structlog
@@ -170,7 +184,13 @@ class DomainModel(BaseModel):
 
                 annotations = get_annotations(cls)
 
-        for field_name, field_type in annotations.items():
+        # Retrieve type hints with evaluated ForwardRefs (for nested blocks)
+        type_hints = get_type_hints(cls, localns={cls.__name__: cls})
+
+        # But this also returns inherited fields so cross-check against the annotations
+        final_annotations = {k: type_hints[k] for k in annotations}
+
+        for field_name, field_type in final_annotations.items():
             if field_name.startswith("_"):
                 continue
 

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -68,7 +68,7 @@ def shutdown_thread_pool() -> None:
     """Gracefully shutdown existing ThreadPoolExecutor and delete it."""
     global _workflow_executor
     if isinstance(_workflow_executor, ThreadPoolExecutor):
-        _workflow_executor.shutdown(wait=True, cancel_futures=False)
+        _workflow_executor.shutdown(wait=True)
         _workflow_executor = None
 
 

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -64,7 +64,7 @@ def get_thread_pool() -> ThreadPoolExecutor:
     return _workflow_executor
 
 
-def shutdown_thread_pool():
+def shutdown_thread_pool() -> None:
     """Gracefully shutdown existing ThreadPoolExecutor and delete it."""
     global _workflow_executor
     if isinstance(_workflow_executor, ThreadPoolExecutor):

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -64,6 +64,14 @@ def get_thread_pool() -> ThreadPoolExecutor:
     return _workflow_executor
 
 
+def shutdown_thread_pool():
+    """Gracefully shutdown existing ThreadPoolExecutor and delete it."""
+    global _workflow_executor
+    if isinstance(_workflow_executor, ThreadPoolExecutor):
+        _workflow_executor.shutdown(wait=True, cancel_futures=False)
+        _workflow_executor = None
+
+
 def _db_create_process(stat: ProcessStat) -> None:
     p = ProcessTable(
         pid=stat.pid,

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -17,6 +17,7 @@ from orchestrator.db import (
     WorkflowTable,
     db,
 )
+from orchestrator.services.processes import shutdown_thread_pool
 from orchestrator.settings import app_settings
 from orchestrator.targets import Target
 from orchestrator.workflow import ProcessStatus, done, init, step, workflow
@@ -460,6 +461,9 @@ def test_resume_all_processes_multiple_calls(test_client, mocked_processes_resum
     assert responses[0].status_code == HTTPStatus.OK
     assert responses[0].json()["count"] == 3
     assert all(response.status_code == HTTPStatus.CONFLICT for response in responses[1:])
+
+    # Wait for async tasks to finish to prevent DB session conflicts
+    shutdown_thread_pool()
 
 
 def test_resume_all_processes_nothing_to_do(test_client):

--- a/test/unit_tests/domain/conftest.py
+++ b/test/unit_tests/domain/conftest.py
@@ -1,3 +1,7 @@
+from test.unit_tests.domain.products.product_blocks.product_block_list_nested import (  # noqa: F401  # noqa: F401
+    test_product_block_list_nested,
+    test_product_block_list_nested_db_parent,
+)
 from test.unit_tests.domain.products.product_blocks.product_block_one import (  # noqa: F401  # noqa: F401
     test_product_block_one,
     test_product_block_one_db,
@@ -21,6 +25,11 @@ from test.unit_tests.domain.products.product_blocks.product_sub_block_one import
 from test.unit_tests.domain.products.product_blocks.product_sub_block_two import (  # noqa: F401
     test_product_sub_block_two,
     test_product_sub_block_two_db,
+)
+from test.unit_tests.domain.products.product_types.product_type_list_nested import (  # noqa: F401
+    test_product_list_nested,
+    test_product_model_list_nested,
+    test_product_type_list_nested,
 )
 from test.unit_tests.domain.products.product_types.product_type_list_union import (  # noqa: F401
     test_product_list_union,

--- a/test/unit_tests/domain/conftest.py
+++ b/test/unit_tests/domain/conftest.py
@@ -1,12 +1,12 @@
-from test.unit_tests.domain.products.product_blocks.product_block_list_nested import (  # noqa: F401  # noqa: F401
+from test.unit_tests.domain.products.product_blocks.product_block_list_nested import (  # noqa: F401
     test_product_block_list_nested,
     test_product_block_list_nested_db_parent,
 )
-from test.unit_tests.domain.products.product_blocks.product_block_one import (  # noqa: F401  # noqa: F401
+from test.unit_tests.domain.products.product_blocks.product_block_one import (  # noqa: F401
     test_product_block_one,
     test_product_block_one_db,
 )
-from test.unit_tests.domain.products.product_blocks.product_block_one_nested import (  # noqa: F401  # noqa: F401
+from test.unit_tests.domain.products.product_blocks.product_block_one_nested import (  # noqa: F401
     test_product_block_one_nested,
     test_product_block_one_nested_db_parent,
 )

--- a/test/unit_tests/domain/conftest.py
+++ b/test/unit_tests/domain/conftest.py
@@ -2,6 +2,10 @@ from test.unit_tests.domain.products.product_blocks.product_block_one import (  
     test_product_block_one,
     test_product_block_one_db,
 )
+from test.unit_tests.domain.products.product_blocks.product_block_one_nested import (  # noqa: F401  # noqa: F401
+    test_product_block_one_nested,
+    test_product_block_one_nested_db_parent,
+)
 from test.unit_tests.domain.products.product_blocks.product_block_with_list_union import (  # noqa: F401
     test_product_block_with_list_union,
     test_product_block_with_list_union_db,
@@ -30,6 +34,11 @@ from test.unit_tests.domain.products.product_types.product_type_one import (  # 
     test_product_model,
     test_product_one,
     test_product_type_one,
+)
+from test.unit_tests.domain.products.product_types.product_type_one_nested import (  # noqa: F401
+    test_product_model_nested,
+    test_product_one_nested,
+    test_product_type_one_nested,
 )
 from test.unit_tests.domain.products.product_types.product_type_sub_list_union import (  # noqa: F401
     test_product_sub_list_union,

--- a/test/unit_tests/domain/products/product_blocks/product_block_list_nested.py
+++ b/test/unit_tests/domain/products/product_blocks/product_block_list_nested.py
@@ -1,0 +1,50 @@
+from typing import List, Optional
+
+import pytest
+
+from orchestrator.db import ProductBlockTable, db
+from orchestrator.domain.base import ProductBlockModel
+from orchestrator.types import SubscriptionLifecycle
+
+
+class ProductBlockListNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockListNestedForTest"):
+    sub_block_list: List["ProductBlockListNestedForTestInactive"]
+    int_field: Optional[int] = None
+
+
+class ProductBlockListNestedForTestProvisioning(
+    ProductBlockListNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    sub_block_list: List["ProductBlockListNestedForTestProvisioning"]  # type: ignore
+    int_field: int
+
+
+class ProductBlockListNestedForTest(
+    ProductBlockListNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+):
+    sub_block_list: List["ProductBlockListNestedForTest"]  # type: ignore
+    int_field: int
+
+
+@pytest.fixture
+def test_product_block_list_nested():
+    # Classes defined at module level, otherwise they remain in local namespace and
+    # `get_type_hints()` can't evaluate the ForwardRefs
+    return (
+        ProductBlockListNestedForTestInactive,
+        ProductBlockListNestedForTestProvisioning,
+        ProductBlockListNestedForTest,
+    )
+
+
+@pytest.fixture
+def test_product_block_list_nested_db_parent(resource_type_list, resource_type_int, resource_type_str):
+    parent_block = ProductBlockTable(
+        name="ProductBlockListNestedForTest", description="Test Block Parent", tag="TEST", status="active"
+    )
+    parent_block.resource_types = [resource_type_int]
+
+    db.session.add(parent_block)
+    db.session.commit()
+
+    return parent_block

--- a/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
+++ b/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
@@ -7,10 +7,8 @@ from orchestrator.domain.base import ProductBlockModel
 from orchestrator.types import SubscriptionLifecycle
 
 
-# TODO also test List
 class ProductBlockOneNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneNestedForTest"):
     sub_block: Optional["ProductBlockOneNestedForTestInactive"] = None
-    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestInactive")] = []
     int_field: Optional[int] = None
 
 
@@ -18,13 +16,11 @@ class ProductBlockOneNestedForTestProvisioning(
     ProductBlockOneNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
 ):
     sub_block: Optional["ProductBlockOneNestedForTestProvisioning"] = None
-    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestProvisioning")]
     int_field: int
 
 
 class ProductBlockOneNestedForTest(ProductBlockOneNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
     sub_block: Optional["ProductBlockOneNestedForTest"] = None
-    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTest")]
     int_field: int
 
 

--- a/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
+++ b/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
@@ -1,0 +1,48 @@
+from typing import ForwardRef, Optional
+
+import pytest
+
+from orchestrator.db import ProductBlockTable, db
+from orchestrator.domain.base import ProductBlockModel
+from orchestrator.types import SubscriptionLifecycle
+
+
+# TODO also test List
+class ProductBlockOneNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneNestedForTest"):
+    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTestInactive")] = None
+    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestInactive")] = []
+    int_field: Optional[int] = None
+
+
+class ProductBlockOneNestedForTestProvisioning(
+    ProductBlockOneNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTestProvisioning")] = None
+    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestProvisioning")]
+    int_field: int
+
+
+class ProductBlockOneNestedForTest(ProductBlockOneNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTest")] = None
+    # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTest")]
+    int_field: int
+
+
+@pytest.fixture
+def test_product_block_one_nested():
+    # Classes defined at module level, otherwise they remain in local namespace and
+    # `get_type_hints()` can't evaluate the ForwardRefs
+    return ProductBlockOneNestedForTestInactive, ProductBlockOneNestedForTestProvisioning, ProductBlockOneNestedForTest
+
+
+@pytest.fixture
+def test_product_block_one_nested_db_parent(resource_type_list, resource_type_int, resource_type_str):
+    parent_block = ProductBlockTable(
+        name="ProductBlockOneNestedForTest", description="Test Block Parent", tag="TEST", status="active"
+    )
+    parent_block.resource_types = [resource_type_int]
+
+    db.session.add(parent_block)
+    db.session.commit()
+
+    return parent_block

--- a/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
+++ b/test/unit_tests/domain/products/product_blocks/product_block_one_nested.py
@@ -1,4 +1,4 @@
-from typing import ForwardRef, Optional
+from typing import Optional
 
 import pytest
 
@@ -9,7 +9,7 @@ from orchestrator.types import SubscriptionLifecycle
 
 # TODO also test List
 class ProductBlockOneNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneNestedForTest"):
-    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTestInactive")] = None
+    sub_block: Optional["ProductBlockOneNestedForTestInactive"] = None
     # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestInactive")] = []
     int_field: Optional[int] = None
 
@@ -17,13 +17,13 @@ class ProductBlockOneNestedForTestInactive(ProductBlockModel, product_block_name
 class ProductBlockOneNestedForTestProvisioning(
     ProductBlockOneNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
 ):
-    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTestProvisioning")] = None
+    sub_block: Optional["ProductBlockOneNestedForTestProvisioning"] = None
     # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTestProvisioning")]
     int_field: int
 
 
 class ProductBlockOneNestedForTest(ProductBlockOneNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
-    sub_block: Optional[ForwardRef("ProductBlockOneNestedForTest")] = None
+    sub_block: Optional["ProductBlockOneNestedForTest"] = None
     # sub_block_list: List[ForwardRef("ProductBlockOneNestedForTest")]
     int_field: int
 

--- a/test/unit_tests/domain/products/product_types/product_type_list_nested.py
+++ b/test/unit_tests/domain/products/product_types/product_type_list_nested.py
@@ -1,0 +1,65 @@
+import pytest
+
+from orchestrator.db import FixedInputTable, ProductTable, db
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.domain.base import ProductModel, SubscriptionModel
+from orchestrator.domain.lifecycle import ProductLifecycle
+from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.domain.products.product_blocks.product_block_list_nested import (
+    ProductBlockListNestedForTest,
+    ProductBlockListNestedForTestInactive,
+    ProductBlockListNestedForTestProvisioning,
+)
+
+
+@pytest.fixture
+def test_product_type_list_nested():
+    class ProductTypeListNestedForTestInactive(SubscriptionModel, is_base=True):
+        test_fixed_input: bool
+        block: ProductBlockListNestedForTestInactive
+
+    class ProductTypeListNestedForTestProvisioning(
+        ProductTypeListNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+    ):
+        test_fixed_input: bool
+        block: ProductBlockListNestedForTestProvisioning
+
+    class ProductTypeListNestedForTest(
+        ProductTypeListNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        test_fixed_input: bool
+        block: ProductBlockListNestedForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductListNested"] = ProductTypeListNestedForTest
+    yield ProductTypeListNestedForTestInactive, ProductTypeListNestedForTestProvisioning, ProductTypeListNestedForTest
+    del SUBSCRIPTION_MODEL_REGISTRY["TestProductListNested"]
+
+
+@pytest.fixture
+def test_product_list_nested(test_product_block_list_nested_db_parent):
+    product = ProductTable(
+        name="TestProductListNested", description="Test ProductTable", product_type="Test", tag="TEST", status="active"
+    )
+
+    fixed_input = FixedInputTable(name="test_fixed_input", value="False")
+
+    product_block = test_product_block_list_nested_db_parent
+    product.fixed_inputs = [fixed_input]
+    product.product_blocks = [product_block]
+
+    db.session.add(product)
+    db.session.commit()
+
+    return product.product_id
+
+
+@pytest.fixture
+def test_product_model_list_nested(test_product_list_nested):
+    return ProductModel(
+        product_id=test_product_list_nested,
+        name="TestProductListNested",
+        description="Test ProductTable",
+        product_type="Test",
+        tag="TEST",
+        status=ProductLifecycle.ACTIVE,
+    )

--- a/test/unit_tests/domain/products/product_types/product_type_one_nested.py
+++ b/test/unit_tests/domain/products/product_types/product_type_one_nested.py
@@ -1,0 +1,65 @@
+import pytest
+
+from orchestrator.db import FixedInputTable, ProductTable, db
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.domain.base import ProductModel, SubscriptionModel
+from orchestrator.domain.lifecycle import ProductLifecycle
+from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.domain.products.product_blocks.product_block_one_nested import (
+    ProductBlockOneNestedForTest,
+    ProductBlockOneNestedForTestInactive,
+    ProductBlockOneNestedForTestProvisioning,
+)
+
+
+@pytest.fixture
+def test_product_type_one_nested():
+    class ProductTypeOneNestedForTestInactive(SubscriptionModel, is_base=True):
+        test_fixed_input: bool
+        block: ProductBlockOneNestedForTestInactive
+
+    class ProductTypeOneNestedForTestProvisioning(
+        ProductTypeOneNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+    ):
+        test_fixed_input: bool
+        block: ProductBlockOneNestedForTestProvisioning
+
+    class ProductTypeOneNestedForTest(
+        ProductTypeOneNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        test_fixed_input: bool
+        block: ProductBlockOneNestedForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOneNested"] = ProductTypeOneNestedForTest
+    yield ProductTypeOneNestedForTestInactive, ProductTypeOneNestedForTestProvisioning, ProductTypeOneNestedForTest
+    del SUBSCRIPTION_MODEL_REGISTRY["TestProductOneNested"]
+
+
+@pytest.fixture
+def test_product_one_nested(test_product_block_one_nested_db_parent):
+    product = ProductTable(
+        name="TestProductOneNested", description="Test ProductTable", product_type="Test", tag="TEST", status="active"
+    )
+
+    fixed_input = FixedInputTable(name="test_fixed_input", value="False")
+
+    product_block = test_product_block_one_nested_db_parent
+    product.fixed_inputs = [fixed_input]
+    product.product_blocks = [product_block]
+
+    db.session.add(product)
+    db.session.commit()
+
+    return product.product_id
+
+
+@pytest.fixture
+def test_product_model_nested(test_product_one_nested):
+    return ProductModel(
+        product_id=test_product_one_nested,
+        name="TestProductOneNested",
+        description="Test ProductTable",
+        product_type="Test",
+        tag="TEST",
+        status=ProductLifecycle.ACTIVE,
+    )

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -26,10 +26,10 @@ from orchestrator.domain.base import (
 )
 from orchestrator.domain.lifecycle import ProductLifecycle
 from orchestrator.types import SubscriptionLifecycle
-from test.unit_tests.domain.products.product_blocks.product_block_one_nested import (
-    ProductBlockOneNestedForTest,
-    ProductBlockOneNestedForTestInactive,
+from test.unit_tests.domain.products.product_blocks.product_block_list_nested import (
+    ProductBlockListNestedForTestInactive,
 )
+from test.unit_tests.domain.products.product_blocks.product_block_one_nested import ProductBlockOneNestedForTestInactive
 
 
 def test_product_block_metadata(test_product_block_one, test_product_one, test_product_block_one_db):
@@ -48,7 +48,7 @@ def test_product_block_metadata(test_product_block_one, test_product_one, test_p
     assert ProductBlockOneForTestInactive.tag == "TEST"
 
 
-def test_product_block_nested(test_product_model_nested, test_product_type_one_nested):
+def test_product_block_one_nested(test_product_model_nested, test_product_type_one_nested):
     """Test the behavior of nesting (self-referencing) product blocks.
 
     Notes:
@@ -82,7 +82,7 @@ def test_product_block_nested(test_product_model_nested, test_product_type_one_n
         start_date=None,
         status=SubscriptionLifecycle.INITIAL,
     )
-    model20.block = ProductBlockOneNestedForTest.new(
+    model20.block = ProductBlockOneNestedForTestInactive.new(
         subscription_id=model20.subscription_id,
         int_field=20,
         sub_block=model30.block,
@@ -169,8 +169,164 @@ def test_product_block_nested(test_product_model_nested, test_product_type_one_n
     assert newmodel11.block.sub_block.sub_block.sub_block is None
 
 
-# TODO add test for List of nested blocks
-# def test_product_block_nested_list(test_product_model_nested, test_product_type_one_nested):
+def test_product_block_list_nested(test_product_model_list_nested, test_product_type_list_nested):
+    """Test the behavior of nesting (self-referencing) a list of product blocks.
+
+    Notes:
+        - nesting only works when each block is attached to a different subscription
+    """
+    ProductTypeListNestedForTestInactive, _, ProductTypeListNestedForTest = test_product_type_list_nested
+
+    customer_id = uuid4()
+    # Create productblocks 30 and 31 that will both be nested in block 20 and 21
+    model30 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model30.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model30.subscription_id,
+        int_field=30,
+        sub_block_list=[],
+    )
+    model30 = SubscriptionModel.from_other_lifecycle(model30, SubscriptionLifecycle.ACTIVE)
+    model30.save()
+    model31 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model31.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model31.subscription_id,
+        int_field=31,
+        sub_block_list=[],
+    )
+    model31 = SubscriptionModel.from_other_lifecycle(model31, SubscriptionLifecycle.ACTIVE)
+    model31.save()
+    db.session.commit()
+
+    # Create productblocks 20 and 21 that both
+    # - refer to blocks 30 and 31
+    # - will be nested in blocks 10 and 11
+    model20 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model20.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model20.subscription_id,
+        int_field=20,
+        sub_block_list=[model30.block, model31.block],
+    )
+    model20 = SubscriptionModel.from_other_lifecycle(model20, SubscriptionLifecycle.ACTIVE)
+    model20.save()
+    model21 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model21.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model21.subscription_id,
+        int_field=21,
+        sub_block_list=[model30.block, model31.block],
+    )
+    model21 = SubscriptionModel.from_other_lifecycle(model21, SubscriptionLifecycle.ACTIVE)
+    model21.save()
+    db.session.commit()
+
+    # Create productblocks 10 and 11 that both refer to blocks 20 and 21
+    model10 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model10.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model10.subscription_id,
+        int_field=10,
+        sub_block_list=[model20.block, model21.block],
+    )
+    model10 = SubscriptionModel.from_other_lifecycle(model10, SubscriptionLifecycle.ACTIVE)
+    model10.save()
+    model11 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model11.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model11.subscription_id,
+        int_field=11,
+        sub_block_list=[model20.block, model21.block],
+    )
+    model11 = SubscriptionModel.from_other_lifecycle(model11, SubscriptionLifecycle.ACTIVE)
+    model11.save()
+    db.session.commit()
+
+    # Load blocks 10 and 11 and verify the nested blocks
+    newmodel10 = ProductTypeListNestedForTest.from_subscription(model10.subscription_id)
+    newmodel11 = ProductTypeListNestedForTest.from_subscription(model11.subscription_id)
+    assert newmodel10.block.int_field == 10
+    assert newmodel11.block.int_field == 11
+    assert newmodel10.block.sub_block_list[0].int_field == 20
+    assert newmodel10.block.sub_block_list[1].int_field == 21
+    assert newmodel11.block.sub_block_list[0].int_field == 20
+    assert newmodel11.block.sub_block_list[1].int_field == 21
+    assert sorted(
+        level3.int_field for level2 in newmodel10.block.sub_block_list for level3 in level2.sub_block_list
+    ) == [30, 30, 31, 31]
+    assert sorted(
+        level3.int_field for level2 in newmodel11.block.sub_block_list for level3 in level2.sub_block_list
+    ) == [30, 30, 31, 31]
+    # Assert a few blocks at deepest level to have an empty list
+    assert newmodel10.block.sub_block_list[0].sub_block_list[0].sub_block_list == []
+    assert newmodel11.block.sub_block_list[1].sub_block_list[1].sub_block_list == []
+
+    # Load block 20 and verify nested blocks
+    newmodel20 = ProductTypeListNestedForTest.from_subscription(model20.subscription_id)
+    assert newmodel20.block.int_field == 20
+    assert newmodel20.block.sub_block_list[0].int_field == 30
+    assert newmodel20.block.sub_block_list[1].int_field == 31
+    assert newmodel20.block.sub_block_list[0].sub_block_list == []
+
+    # Create productblock 32 and nest it in block 20 (but not 21!)
+    model32 = ProductTypeListNestedForTestInactive.from_product_id(
+        product_id=test_product_model_list_nested.product_id,
+        customer_id=customer_id,
+        insync=True,
+        start_date=None,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    model32.block = ProductBlockListNestedForTestInactive.new(
+        subscription_id=model30.subscription_id,
+        int_field=32,
+        sub_block_list=[],
+    )
+    model32 = SubscriptionModel.from_other_lifecycle(model32, SubscriptionLifecycle.ACTIVE)
+    model32.save()
+    newmodel20.block.sub_block_list.append(model32.block)
+    newmodel20.save()
+    db.session.commit()
+
+    # (again) Load blocks 10 and 11 and verify block 32 is present once
+    newmodel10 = ProductTypeListNestedForTest.from_subscription(model10.subscription_id)
+    newmodel11 = ProductTypeListNestedForTest.from_subscription(model11.subscription_id)
+    assert sorted(
+        level3.int_field for level2 in newmodel10.block.sub_block_list for level3 in level2.sub_block_list
+    ) == [30, 30, 31, 31, 32]
+    assert sorted(
+        level3.int_field for level2 in newmodel11.block.sub_block_list for level3 in level2.sub_block_list
+    ) == [30, 30, 31, 31, 32]
 
 
 def test_lifecycle(test_product_model, test_product_type_one, test_product_block_one):


### PR DESCRIPTION
Closes #108 by using `get_type_hints()` which evaluates any `ForwardRef` types to the actual type