### PR TITLE
1388: Change subscription_details_by_id_with_domain_model to support lists

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1-rc1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-rc{build}
 	{major}.{minor}.{patch}
 

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1-rc1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/api/helpers.py
+++ b/orchestrator/api/helpers.py
@@ -242,6 +242,9 @@ def getattr_in(obj: Any, attr: str, *args: List[Any]) -> Any:
     """Get an instance attribute value by path."""
 
     def _getattr(obj: object, attr: str) -> Any:
+        if isinstance(obj, list):
+            return obj[int(attr)]
+
         return getattr(obj, attr, None, *args)
 
     return functools.reduce(_getattr, [obj] + attr.split("."))
@@ -254,5 +257,8 @@ def product_block_paths(subscription: SubscriptionModel) -> List[Optional[str]]:
                 for k1, v1 in get_dict_items(v):
                     yield (f"{k}.{k1}", v1)
                 yield (k, v)
+            if isinstance(v, list):
+                for index, list_item in enumerate(v):
+                    yield (f"{k}.{index}", list_item)
 
     return [c[0] for c in get_dict_items(subscription.dict())]

--- a/test/unit_tests/schedules/test_scheduling.py
+++ b/test/unit_tests/schedules/test_scheduling.py
@@ -13,7 +13,7 @@ def test_scheduling_with_period(capsys, monkeypatch):
     @scheduler(name="test", time_unit="second", period=1)
     def test_scheduler():
         ref["called"] = True
-        print("I've run")  # noqa: T001
+        print("I've run")  # noqa: T001, T201
         return schedule.CancelJob
 
     ALL_SCHEDULERS.clear()


### PR DESCRIPTION
supporting lists is necessary for one to many relations

- change `getattr_in` to support lists.
- change `product_block_paths` to support lists.
- filter out all `in_use_by` ids which point to product block within it's own domain model instance (or subscription).