### PR TITLE
Fix optional list error when class or value is none

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.4.1-rc3
+current_version = 0.4.1-rc4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-rc{build}
 	{major}.{minor}.{patch}
 

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "0.4.1-rc3"
+__version__ = "0.4.1-rc4"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -387,13 +387,15 @@ class DomainModel(BaseModel):
                         possible_product_block_types[item.name]._from_other_lifecycle(item, status, subscription_id)
                     )
             else:
-                if is_optional_type(field_type):
+                if is_optional_type(field_type) and not is_union_type(field_type):
                     data[field_name] = None
                     field_type = first(get_args(field_type))
                 elif is_union_type(field_type):
+                    if is_optional_type(field_type):
+                        data[field_name] = None
                     field_types = get_args(field_type)
                     for f_type in field_types:
-                        if f_type.name == value.name:
+                        if value and not isinstance(None, f_type) and f_type.name == value.name:
                             field_type = f_type
                 if value:
                     data[field_name] = field_type._from_other_lifecycle(value, status, subscription_id)

--- a/test/unit_tests/api/test_subscriptions.py
+++ b/test/unit_tests/api/test_subscriptions.py
@@ -17,6 +17,7 @@ from orchestrator.db import (
     SubscriptionTable,
     db,
 )
+from orchestrator.db.models import SubscriptionInstanceRelationTable
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.services.subscriptions import RELATION_RESOURCE_TYPES, unsync
 from orchestrator.workflow import ProcessStatus
@@ -31,8 +32,10 @@ from test.unit_tests.config import (
 
 SERVICE_SUBSCRIPTION_ID = str(uuid4())
 PORT_A_SUBSCRIPTION_ID = str(uuid4())
+PORT_A_SUBSCRIPTION_BLOCK_ID = str(uuid4())
 PROVISIONING_PORT_A_SUBSCRIPTION_ID = str(uuid4())
 SSP_SUBSCRIPTION_ID = str(uuid4())
+SSP_SUBSCRIPTION_BLOCK_ID = str(uuid4())
 IP_PREFIX_SUBSCRIPTION_ID = str(uuid4())
 INVALID_SUBSCRIPTION_ID = str(uuid4())
 INVALID_PORT_SUBSCRIPTION_ID = str(uuid4())
@@ -229,6 +232,232 @@ def seed():
     db.session.add(lp_subscription)
     db.session.add(invalid_subscription)
     db.session.add(invalid_tagged_subscription)
+    db.session.commit()
+
+    RELATION_RESOURCE_TYPES.extend(
+        [
+            PORT_SUBSCRIPTION_ID,
+            IP_PREFIX_SUBSCRIPTION_ID,
+            INTERNETPINNEN_PREFIX_SUBSCRIPTION_ID,
+            PARENT_IP_PREFIX_SUBSCRIPTION_ID,
+            PEER_GROUP_SUBSCRIPTION_ID,
+        ]
+    )
+
+    return ip_prefix_product
+
+
+# seeder to test direct relations using SubscriptionInstanceRelationTable instead of resource type.
+@pytest.fixture
+def seed_with_direct_relations():
+    # These resource types are special
+    resources = [
+        ResourceTypeTable(resource_type=IMS_CIRCUIT_ID, description="Desc"),
+    ]
+    product_blocks = [
+        ProductBlockTable(name="ProductBlockA", description="description a", status="active", resource_types=resources)
+    ]
+    fixed_inputs = [FixedInputTable(name="product_type", value="MSP100G")]
+    # Wf needs to exist in code and needs to be a legacy wf with mapping
+
+    lp_product = ProductTable(
+        name="LightpathProduct",
+        description="Service product that lives on ports",
+        product_type="LightPath",
+        tag="LightPath",  # This is special since in_use_by/depends_on subscription code handles specific tags
+        status="active",
+        product_blocks=product_blocks,
+        fixed_inputs=fixed_inputs,
+    )
+    port_a_product = ProductTable(
+        product_id=PRODUCT_ID,
+        name="PortAProduct",
+        description="Port A description",
+        product_type="Port",
+        tag="SP",  # This is special since in_use_by/depends_on subscription code handles specific tags
+        status="active",
+        product_blocks=product_blocks,
+        fixed_inputs=fixed_inputs,
+    )
+    port_b_product = ProductTable(
+        name="PortBProduct",
+        description="Port B description",
+        product_type="Port",
+        tag="PORTB",
+        status="active",
+        product_blocks=product_blocks,
+        fixed_inputs=fixed_inputs,
+    )
+
+    # Special resource type handled by get subscription by ipam prefix endpoint
+    ip_prefix_resources = [ResourceTypeTable(resource_type=IPAM_PREFIX_ID, description="Prefix id")]
+    ip_prefix_product_blocks = [
+        ProductBlockTable(
+            name="ProductBlockB", description="description b", status="active", resource_types=ip_prefix_resources
+        )
+    ]
+    ip_prefix_product = ProductTable(
+        name="IPPrefixProduct",
+        description="ProductTable that is used by service product",
+        product_type="IP_PREFIX",
+        tag="IP_PREFIX",
+        status="active",
+        product_blocks=ip_prefix_product_blocks,
+    )
+    ip_prefix_subscription = SubscriptionTable(
+        subscription_id=IP_PREFIX_SUBSCRIPTION_ID,
+        description="desc",
+        status="active",
+        insync=True,
+        product=ip_prefix_product,
+        customer_id=CUSTOMER_ID,
+        instances=[
+            SubscriptionInstanceTable(
+                product_block=ip_prefix_product_blocks[0],
+                values=[SubscriptionInstanceValueTable(resource_type=ip_prefix_resources[0], value="26")],
+            )
+        ],
+    )
+
+    port_a_subscription = SubscriptionTable(
+        subscription_id=PORT_A_SUBSCRIPTION_ID,
+        description="desc",
+        status="initial",
+        insync=True,
+        product=port_a_product,
+        customer_id=CUSTOMER_ID,
+        instances=[
+            SubscriptionInstanceTable(
+                subscription_instance_id=PORT_A_SUBSCRIPTION_BLOCK_ID,
+                product_block=product_blocks[0],
+                values=[SubscriptionInstanceValueTable(resource_type=resources[0], value="54321")],
+            )
+        ],
+    )
+
+    provisioning_port_a_subscription = SubscriptionTable(
+        subscription_id=PROVISIONING_PORT_A_SUBSCRIPTION_ID,
+        description="desc",
+        status="provisioning",
+        insync=False,
+        product=port_a_product,
+        customer_id=CUSTOMER_ID,
+        instances=[
+            SubscriptionInstanceTable(
+                product_block=product_blocks[0],
+                values=[SubscriptionInstanceValueTable(resource_type=resources[0], value="12345")],
+            )
+        ],
+    )
+
+    ssp_subscription = SubscriptionTable(
+        subscription_id=SSP_SUBSCRIPTION_ID,
+        description="desc",
+        status="active",
+        insync=True,
+        product=port_b_product,
+        customer_id=CUSTOMER_ID,
+        instances=[
+            SubscriptionInstanceTable(
+                subscription_instance_id=SSP_SUBSCRIPTION_BLOCK_ID,
+                product_block=product_blocks[0],
+                values=[SubscriptionInstanceValueTable(resource_type=resources[0], value="54321")],
+            )
+        ],
+    )
+
+    lp_subscription_instance_ssp_id = str(uuid4())
+    lp_subscription_instance_values_ssp = [
+        SubscriptionInstanceValueTable(resource_type=resources[0], value="54321"),
+    ]
+    lp_subscription_instance_ssp = SubscriptionInstanceTable(
+        subscription_instance_id=lp_subscription_instance_ssp_id,
+        product_block=product_blocks[0],
+        values=lp_subscription_instance_values_ssp,
+    )
+    lp_subscription_instance_ssp_depends_on = SubscriptionInstanceRelationTable(
+        in_use_by_id=lp_subscription_instance_ssp_id,
+        depends_on_id=PORT_A_SUBSCRIPTION_BLOCK_ID,
+        order_id=0,
+        domain_model_attr="service_port",
+    )
+
+    lp_subscription_instance_msp_id = str(uuid4())
+    lp_subscription_instance_values_msp = [
+        SubscriptionInstanceValueTable(resource_type=resources[0], value="54321"),
+    ]
+    lp_subscription_instance_msp = SubscriptionInstanceTable(
+        subscription_instance_id=lp_subscription_instance_msp_id,
+        product_block=product_blocks[0],
+        values=lp_subscription_instance_values_msp,
+    )
+    lp_subscription_instance_msp_depends_on = SubscriptionInstanceRelationTable(
+        in_use_by_id=lp_subscription_instance_msp_id,
+        depends_on_id=SSP_SUBSCRIPTION_BLOCK_ID,
+        order_id=0,
+        domain_model_attr="service_port",
+    )
+    lp_subscription = SubscriptionTable(
+        subscription_id=SERVICE_SUBSCRIPTION_ID,
+        description="desc",
+        status="active",
+        insync=True,
+        product=lp_product,
+        customer_id=CUSTOMER_ID,
+        instances=[lp_subscription_instance_ssp, lp_subscription_instance_msp],
+    )
+
+    invalid_subscription = SubscriptionTable(
+        subscription_id=INVALID_SUBSCRIPTION_ID,
+        description="desc",
+        status="active",
+        insync=True,
+        product=port_a_product,
+        customer_id=CUSTOMER_ID,
+        instances=[],
+    )
+
+    invalid_tagged_product = ProductTable(
+        product_id=str(uuid4()),
+        name="INVALID_PRODUCT",
+        description="invalid descr",
+        product_type="Port",
+        tag="NEWMSP",
+        status="active",
+        product_blocks=product_blocks,
+        fixed_inputs=fixed_inputs,
+    )
+
+    invalid_tagged_subscription = SubscriptionTable(
+        subscription_id=INVALID_PORT_SUBSCRIPTION_ID,
+        description="desc",
+        status="active",
+        insync=False,
+        product=invalid_tagged_product,
+        customer_id=CUSTOMER_ID,
+        instances=[
+            SubscriptionInstanceTable(
+                product_block=product_blocks[0],
+                values=[SubscriptionInstanceValueTable(resource_type=resources[0], value="54321")],
+            )
+        ],
+    )
+
+    db.session.add(port_a_product)
+    db.session.add(ip_prefix_product)
+    db.session.add(ip_prefix_subscription)
+    db.session.add(invalid_tagged_product)
+    db.session.add(port_b_product)
+    db.session.add(lp_product)
+    db.session.add(port_a_subscription)
+    db.session.add(provisioning_port_a_subscription)
+    db.session.add(ssp_subscription)
+    db.session.add(lp_subscription)
+    db.session.add(invalid_subscription)
+    db.session.add(invalid_tagged_subscription)
+    db.session.commit()
+    db.session.add(lp_subscription_instance_ssp_depends_on)
+    db.session.add(lp_subscription_instance_msp_depends_on)
     db.session.commit()
 
     RELATION_RESOURCE_TYPES.extend(
@@ -445,17 +674,17 @@ def test_insync_invalid_tagged(seed, test_client):
 
 def test_in_use_by_subscriptions(seed, test_client):
     response = test_client.get(f"/api/subscriptions/in_use_by/{PORT_A_SUBSCRIPTION_ID}")
-    depends_subs = response.json()
-    assert len(depends_subs) == 1
-    assert SERVICE_SUBSCRIPTION_ID == depends_subs[0]["subscription_id"]
+    in_use_by_subs = response.json()
+    assert len(in_use_by_subs) == 1
+    assert SERVICE_SUBSCRIPTION_ID == in_use_by_subs[0]["subscription_id"]
 
 
 def test_subscriptions_for_in_used_by_ids(seed, test_client, caplog):
     instance_id = str(SubscriptionInstanceTable.query.first().subscription_instance_id)
     response = test_client.post("/api/subscriptions/subscriptions_for_in_used_by_ids", json=[instance_id])
-    depends_subs = response.json()
-    assert depends_subs[instance_id]
-    assert depends_subs[instance_id]["product"]["product_type"] == "IP_PREFIX"
+    in_use_by_subs = response.json()
+    assert in_use_by_subs[instance_id]
+    assert in_use_by_subs[instance_id]["product"]["product_type"] == "IP_PREFIX"
     assert "Not all subscription_instance_id's could be resolved." not in caplog.text
 
 
@@ -463,8 +692,8 @@ def test_subscriptions_for_in_used_by_ids_with_wrong_instance_ids(seed, test_cli
     response = test_client.post(
         "/api/subscriptions/subscriptions_for_in_used_by_ids", json=["5373600d-c9ee-4ceb-96bd-1d3256baccec"]
     )
-    depends_subs = response.json()
-    assert len(depends_subs) == 0
+    in_use_by_subs = response.json()
+    assert len(in_use_by_subs) == 0
     assert "Not all subscription_instance_id's could be resolved." in caplog.text
     assert "[UUID('5373600d-c9ee-4ceb-96bd-1d3256baccec')]" in caplog.text
 
@@ -518,6 +747,79 @@ def test_depends_on_subscriptions_not_insync(seed, test_client):
 
 
 def test_depends_on_subscriptions_insync(seed, test_client):
+    response = test_client.get(f"/api/subscriptions/workflows/{SERVICE_SUBSCRIPTION_ID}")
+    assert response.status_code == HTTPStatus.OK
+
+    insync_info = response.json()
+    assert "reason" not in insync_info
+    assert "locked_relations" not in insync_info
+
+
+def test_in_use_by_subscriptions_direct_relations(seed_with_direct_relations, test_client):
+    response = test_client.get(f"/api/subscriptions/in_use_by/{PORT_A_SUBSCRIPTION_ID}")
+    in_use_by_subs = response.json()
+    assert len(in_use_by_subs) == 1
+    assert SERVICE_SUBSCRIPTION_ID == in_use_by_subs[0]["subscription_id"]
+
+
+def test_subscriptions_for_in_used_by_ids_direct_relations(seed_with_direct_relations, test_client, caplog):
+    instance_id = str(SubscriptionInstanceTable.query.first().subscription_instance_id)
+    response = test_client.post("/api/subscriptions/subscriptions_for_in_used_by_ids", json=[instance_id])
+    depends_subs = response.json()
+    assert depends_subs[instance_id]
+    assert depends_subs[instance_id]["product"]["product_type"] == "IP_PREFIX"
+    assert "Not all subscription_instance_id's could be resolved." not in caplog.text
+
+
+def test_in_use_by_subscriptions_not_insync_direct_relations(seed_with_direct_relations, test_client):
+    # ensure that the used subscription of the MSP is out of sync
+    service = SubscriptionTable.query.get(SERVICE_SUBSCRIPTION_ID)
+    service.insync = False
+    db.session.commit()
+
+    # test the api endpoint
+    response = test_client.get(f"/api/subscriptions/workflows/{PORT_A_SUBSCRIPTION_ID}")
+    assert response.status_code == HTTPStatus.OK
+    insync_info = response.json()
+    assert "reason" in insync_info
+    assert len(insync_info["locked_relations"]) == 1
+    assert insync_info["locked_relations"][0] == SERVICE_SUBSCRIPTION_ID
+
+
+def test_in_use_by_subscriptions_insync_direct_relations(seed_with_direct_relations, test_client):
+    response = test_client.get(f"/api/subscriptions/workflows/{PORT_A_SUBSCRIPTION_ID}")
+    assert response.status_code == HTTPStatus.OK
+
+    insync_info = response.json()
+    assert "reason" not in insync_info
+    assert "locked_relations" not in insync_info
+
+
+def test_depends_on_subscriptions_direct_relations(seed_with_direct_relations, test_client):
+    response = test_client.get(f"/api/subscriptions/depends_on/{SERVICE_SUBSCRIPTION_ID}")
+    depends_on_subs = list(map(lambda sub: sub["subscription_id"], response.json()))
+    assert len(depends_on_subs) == 2
+
+    assert PORT_A_SUBSCRIPTION_ID in depends_on_subs
+    assert SSP_SUBSCRIPTION_ID in depends_on_subs
+
+
+def test_depends_on_subscriptions_not_insync_direct_relations(seed_with_direct_relations, test_client):
+    # ensure that the depends on subscription of the LP is out of sync
+    msp = SubscriptionTable.query.with_for_update().get(PORT_A_SUBSCRIPTION_ID)
+    msp.insync = False
+    db.session.commit()
+
+    # test the api endpoint
+    response = test_client.get(f"/api/subscriptions/workflows/{SERVICE_SUBSCRIPTION_ID}")
+    assert response.status_code == HTTPStatus.OK
+    insync_info = response.json()
+    assert "reason" in insync_info
+    assert len(insync_info["locked_relations"]) == 1
+    assert insync_info["locked_relations"][0] == PORT_A_SUBSCRIPTION_ID
+
+
+def test_depends_on_subscriptions_insync_direct_relations(seed_with_direct_relations, test_client):
     response = test_client.get(f"/api/subscriptions/workflows/{SERVICE_SUBSCRIPTION_ID}")
     assert response.status_code == HTTPStatus.OK
 

--- a/test/unit_tests/domain/test_base_with_union.py
+++ b/test/unit_tests/domain/test_base_with_union.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from orchestrator.db import db
 from orchestrator.types import SubscriptionLifecycle
@@ -34,8 +35,9 @@ def test_product_model_with_union_type_directly_below(
         ),
     )
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValidationError) as error:
         UnionProduct.from_other_lifecycle(union_subscription_inactive, SubscriptionLifecycle.ACTIVE)
+    assert error.value.errors()[0]["msg"] == "none is not an allowed value"
 
     new_sub_block = SubBlockOneForTest.new(
         subscription_id=union_subscription_inactive.subscription_id, int_field=1, str_field="2"


### PR DESCRIPTION
Changed so the `ValueError` that shows `'NoneType' object has no attribute 'name'` when you have a list that does not have `None` to a `ValidationError`.

- add tests for direct relations in `api/test_subsctiptions`