### PR TITLE
Add ProcessDataBroadcastThread

### DIFF
--- a/docs/architecture/application/websockets.md
+++ b/docs/architecture/application/websockets.md
@@ -1,0 +1,44 @@
+# Websockets
+
+Orchestrator provides a websocket interface through which the frontend can receive real-time updates. This includes:
+* The process overview pages
+* The process detail page
+* Engine status
+
+
+## Implementation
+
+To function properly in a scalable architecture, the websocket implentation consists of multiple layers,
+
+The main component is the `WebSocketManager` (WSM) which has the following responsibilities:
+1. Keep track of connected frontend clients
+2. Forward messages to all frontend clients
+3. Provide an interface to pass messages from a backend process (workflow/task)
+
+In a setup with multiple isolated Orchestrator instances the WSM is initialized multiple times as well, therefore clients can be connected to any arbitrary WSM instance.
+Letting a backend process broadcast messages to all clients thus requires a message broker, for which we use [Redis Pub/Sub](https://redis.io/docs/manual/pubsub).
+
+There are 2 WSM implementations: a `MemoryWebsocketManager` for development/testing, and a `BroadcastWebsocketManager` that connects to Redis. We'll continue to discuss the latter.
+
+* `BroadcastWebsocketManager.broadcast_data()` is called by backend processes, and publishes messages to a channel in Redis [1]
+* `BroadcastWebsocketManager.sender()` starts in a loop for each connected client, subscribes to a channel in Redis, and forwards messages into the websocket connection
+
+[1] Backend processes do not call this function directly, refer to the **ProcessDataBroadcastThread** section
+
+Roughly speaking a message travels through these components:
+```
+Process
+  -> BroadcastWebsocketManager.broadcast_data()
+  -> Redis channel
+  -> BroadcastWebsocketManager.sender()
+  -> Websocket connection
+  -> Frontend client
+```
+
+### ProcessDataBroadcastThread
+
+Backend processes are executed in a threadpool and therefore access the same WSM instance. This caused asyncio RuntimeErrors as the async Redis Pub/Sub implementation is not thread-safe.
+
+To solve this there is a dedicated `ProcessDataBroadcastThread` (attached to and managed by the `OrchestratorCore` app) to perform the actual `broadcast_data()` call.
+
+The API endpoints which start/resume/abort a process call `api_broadcast_process_data(request)` to acquire a function that can be used to submit process updates into a `threading.Queue` on which `ProcessDataBroadcastThread` listens.

--- a/orchestrator/api/api_v1/endpoints/fixed_input.py
+++ b/orchestrator/api/api_v1/endpoints/fixed_input.py
@@ -46,7 +46,7 @@ def fi_configuration() -> Dict[str, Any]:
             )
 
         for fi_name, fi_type in model._non_product_block_fields_.items():
-            fi_data = first_true(data["fixed_inputs"], None, lambda i: i["name"] == fi_name)
+            fi_data = first_true(data["fixed_inputs"], None, lambda i: i["name"] == fi_name)  # noqa: B023
             if not fi_data:
                 if issubclass(fi_type, Enum):
                     data["fixed_inputs"].append(
@@ -59,7 +59,7 @@ def fi_configuration() -> Dict[str, Any]:
                 else:
                     raise ValueError(f"{fi_name} of {product_name} should be an enum.")
 
-            if not first_true(data["by_tag"][product.tag], None, lambda i: fi_name in i):
+            if not first_true(data["by_tag"][product.tag], None, lambda i: fi_name in i):  # noqa: B023
                 data["by_tag"][product.tag].append({fi_name: True})
 
     # Check if required

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -44,6 +44,7 @@ from orchestrator.distlock import init_distlock_manager
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
 from orchestrator.exception_handlers import form_error_handler, problem_detail_handler
 from orchestrator.forms import FormException
+from orchestrator.services.processes import ProcessDataBroadcastThread
 from orchestrator.settings import AppSettings, app_settings, tracer_provider
 from orchestrator.version import GIT_COMMIT_HASH
 from orchestrator.websocket import init_websocket_manager
@@ -66,6 +67,7 @@ class OrchestratorCore(FastAPI):
     ) -> None:
         websocket_manager = init_websocket_manager(base_settings)
         distlock_manager = init_distlock_manager(base_settings)
+        self.broadcast_thread = ProcessDataBroadcastThread(websocket_manager)
         super().__init__(
             title=title,
             description=description,
@@ -74,8 +76,13 @@ class OrchestratorCore(FastAPI):
             redoc_url=redoc_url,
             version=version,
             default_response_class=default_response_class,
-            on_startup=[websocket_manager.connect_redis, distlock_manager.connect_redis],
+            on_startup=[
+                websocket_manager.connect_redis,
+                distlock_manager.connect_redis,
+                self.broadcast_thread.start,
+            ],
             on_shutdown=[
+                self.broadcast_thread.stop,
                 websocket_manager.disconnect_redis,
                 websocket_manager.disconnect_all,
                 distlock_manager.disconnect_redis,

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -552,14 +552,7 @@ def api_broadcast_process_data(request: Request) -> Optional[BroadcastFunc]:
 
     The callable should be created in API endpoints and provided to start_process,
     resume_process, etc. through the `broadcast_func` param.
-
-    TODO
-     - use this in unit-tests as well
     """
-    if websocket_manager.broadcaster_type != "redis":
-        # Don't use the thread for in-memory broadcasting
-        return None
-
     broadcast_queue: queue.Queue = request.app.broadcast_thread.queue
 
     def _queue_put(pid: UUID, data: Dict) -> None:

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -547,7 +547,7 @@ class ProcessDataBroadcastThread(threading.Thread):
         self.is_alive()
 
 
-def api_broadcast_process_data(request: Request) -> BroadcastFunc:
+def api_broadcast_process_data(request: Request) -> Optional[BroadcastFunc]:
     """Given a FastAPI request, creates a threadsafe callable for broadcasting process data.
 
     The callable should be created in API endpoints and provided to start_process,
@@ -555,8 +555,11 @@ def api_broadcast_process_data(request: Request) -> BroadcastFunc:
 
     TODO
      - use this in unit-tests as well
-     - test resume-all
     """
+    if websocket_manager.broadcaster_type != "redis":
+        # Don't use the thread for in-memory broadcasting
+        return None
+
     broadcast_queue: queue.Queue = request.app.broadcast_thread.queue
 
     def _queue_put(pid: UUID, data: Dict) -> None:

--- a/orchestrator/types.py
+++ b/orchestrator/types.py
@@ -14,6 +14,7 @@
 from enum import Enum
 from http import HTTPStatus
 from typing import Any, Callable, Dict, Generator, List, Literal, Optional, Tuple, Type, TypedDict, TypeVar, Union
+from uuid import UUID
 
 try:
     # python3.10 introduces types.UnionType for the new union and optional type defs.
@@ -40,6 +41,7 @@ ErrorState = Union[str, Exception, Tuple[str, Union[int, HTTPStatus]]]
 ErrorDict = Dict[str, Union[str, int, List[Dict[str, Any]], "InputForm", None]]
 StateStepFunc = Callable[[State], State]
 StepFunc = Callable[..., Optional[State]]
+BroadcastFunc = Callable[[UUID, Dict], None]
 
 
 class strEnum(str, Enum):

--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 from asyncio import new_event_loop
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, cast
+from typing import Any, Dict, Optional, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -20,6 +20,7 @@ from structlog import get_logger
 
 from orchestrator.db import ProcessTable
 from orchestrator.settings import AppSettings, app_settings
+from orchestrator.types import BroadcastFunc
 from orchestrator.utils.show_process import show_process
 from orchestrator.websocket.websocket_manager import WebSocketManager
 from orchestrator.workflow import ProcessStat, ProcessStatus
@@ -84,7 +85,7 @@ def is_process_active(p: Dict) -> bool:
 def send_process_data_to_websocket(
     pid: UUID,
     data: Dict,
-    broadcast_func: Optional[Callable] = None,
+    broadcast_func: Optional[BroadcastFunc] = None,
 ) -> None:
     """Broadcast data of the current process to connected websocket clients."""
     if broadcast_func:

--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -10,10 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from asyncio import new_event_loop
 from functools import wraps
-from typing import Any, Dict, Optional, cast
+from typing import Any, Callable, Dict, Optional, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -82,14 +81,24 @@ def is_process_active(p: Dict) -> bool:
     return p["status"] in [ProcessStatus.RUNNING, ProcessStatus.SUSPENDED, ProcessStatus.WAITING]
 
 
-def send_process_data_to_websocket(pid: UUID, data: Dict) -> None:
-    loop = new_event_loop()
-    channels = [WS_CHANNELS.ALL_PROCESSES]
-    loop.run_until_complete(websocket_manager.broadcast_data(channels, data))
-    try:
-        loop.close()
-    except Exception:  # noqa: S110
-        pass
+def send_process_data_to_websocket(
+    pid: UUID,
+    data: Dict,
+    broadcast_func: Optional[Callable] = None,
+) -> None:
+    """Broadcast data of the current process to connected websocket clients."""
+    if broadcast_func:
+        logger.debug("Broadcast process data through broadcast_func", pid=str(pid))
+        broadcast_func(pid, data)
+    else:
+        logger.debug("Broadcast process data directly to websocket_manager", pid=str(pid))
+        loop = new_event_loop()
+        channels = [WS_CHANNELS.ALL_PROCESSES]
+        loop.run_until_complete(websocket_manager.broadcast_data(channels, data))
+        try:
+            loop.close()
+        except Exception:  # noqa: S110
+            pass
 
 
 async def empty_handler() -> None:

--- a/orchestrator/workflows/tasks/validate_products.py
+++ b/orchestrator/workflows/tasks/validate_products.py
@@ -146,7 +146,9 @@ def check_db_fixed_input_config() -> State:
     for tag in product_tags:
         data["by_tag"][tag] = []
     for fi in fixed_inputs:
-        fi_data: Dict = first_true(fixed_input_configuration["fixed_inputs"], {}, lambda i: i["name"] == fi.name)
+        fi_data: Dict = first_true(
+            fixed_input_configuration["fixed_inputs"], {}, lambda i: i["name"] == fi.name  # noqa: B023
+        )
         if not fi_data:
             errors.append(fi)
 

--- a/test/unit_tests/api/test_processes_ws.py
+++ b/test/unit_tests/api/test_processes_ws.py
@@ -285,6 +285,7 @@ def test_websocket_process_detail_with_abort(test_client, test_workflow):
 
 
 def test_websocket_process_list_multiple_workflows(test_client, test_workflow, test_workflow_2):
+    # This tests the ProcessDataBroadcastThread as well
     if websocket_manager.broadcaster_type != "memory":
         pytest.skip("test does not work with redis")
 

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -235,7 +235,10 @@ def db_session(database):
 def fastapi_app(database, db_uri):
     app_settings.DATABASE_URI = db_uri
     app = OrchestratorCore(base_settings=app_settings)
-    return app
+    # Start ProcessDataBroadcastThread to test websocket_manager with memory backend
+    app.broadcast_thread.start()
+    yield app
+    app.broadcast_thread.stop()
 
 
 @pytest.fixture(scope="session")

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -563,7 +563,12 @@ def test_safe_logstep():
         assert result == mock.sentinel.result
         mock__db_log_step.assert_has_calls(
             [
-                mock.call(pstat, step, state),
+                mock.call(
+                    pstat,
+                    step,
+                    state,
+                    None,  # broadcast_func, which is None for in-memory broadcasting
+                ),
                 mock.call(
                     pstat,
                     step,
@@ -574,6 +579,7 @@ def test_safe_logstep():
                             "traceback": mock.ANY,
                         }
                     ),
+                    None,  # broadcast_func, which is None for in-memory broadcasting
                 ),
             ]
         )

--- a/test/unit_tests/workflows/test_config_db_code.py
+++ b/test/unit_tests/workflows/test_config_db_code.py
@@ -65,7 +65,9 @@ def test_db_fixed_input_config():
         data["by_tag"][tag] = []
 
     for fi in fixed_inputs:
-        fi_data = first_true(fixed_input_configuration["fixed_inputs"], None, lambda i: i["name"] == fi.name)
+        fi_data = first_true(
+            fixed_input_configuration["fixed_inputs"], None, lambda i: i["name"] == fi.name  # noqa: B023
+        )
         assert fi_data, fi
         assert fi.value in fi_data["values"], fi
 


### PR DESCRIPTION
Starting many workflows in bulk causes asyncio RuntimeErrors when 2 workflows try to broadcast a process step update at the same time. The root problem lies in the WebsocketManager being shared between threads, indirectly also sharing an `asyncio.Queue` object from `asyncio_redis`'s pubsub implementation. But this object is not thread-safe and causes different eventloops to clash when they access it at the same time.

A solution proposed in this PR is to have a dedicated thread for broadcasting process data.

* Adds a background thread `ProcessDataBroadcastThread` for publishing messages to redis. It contains a `threading.Queue` through which it receives process data messages 
* The thread is attached to the OrchestratorCore application which manages its lifecycle
* Processes related API endpoints submit process data to the thread though the shared `threading.Queue` object
