### PR TITLE
Add CLI command to generate domain model migrations

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.11-rc1
+current_version = 0.4.11-rc2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/docs/architecture/application/cli.md
+++ b/docs/architecture/application/cli.md
@@ -11,7 +11,9 @@ It will inspect your DB and the existing domain models, analyse the differences 
 Features:
 - detect a new Domain Model attribute / resource type
 - detect a renamed Domain Model attribute / resource type
+- detect a removed Domain Model attribute / resource type
 - detect a new Domain Model
+- detect a removed Domain Model
 - ability to ask for human input when needed
 - Below in the documentation these features are discussed in more detail.
 
@@ -206,28 +208,15 @@ The command will first go through all products and map the differences with the 
 ```
 
 You will be prompted with inputs when updates are found.
-- new product example:
+- rename of fixed input input (renaming `affiliation` to `affiliationing` in User Product):
     ``` bash
-    --- PRODUCT ['User group'] INPUTS ---
-    Product description: User group product
-    Product type: UserGroup
-    Product tag: GROUP
+    --- UPDATE FIXED INPUT DECISIONS ('N'= create and delete) ---
+    rename fixed input ['affiliation'] to ['affiliationing'] for product ['User internal'] (y/N):
     ```
-- new product block:
+- rename of resource type input(renaming `age` to `user_age` in User Block), only works when the resource type is renamed in all Blocks:
     ``` bash
-    --- PRODUCT BLOCK ['UserGroupBlock'] INPUTS ---
-    Product block description: User group settings
-    Product block tag: UGS
-    ```
-- new fixed input (the type isn't checked, so typing an incorrect value will insert in db):
-    ``` bash
-    --- PRODUCT ['User internal'] FIXED INPUT ['affiliation'] ---
-    Fixed input value: internal
-    ```
-- new resource type:
-    ``` bash
-    --- RESOURCE TYPE ['group_name'] ---
-    Resource type description: Unique name of user group
+    --- UPDATE RESOURCE TYPE DECISIONS ('No'= create and delete) ---
+    Change resource type ['age'] to ['user_age'] (y/N):
     ```
 
 it will log the differences on info level:

--- a/docs/architecture/application/cli.md
+++ b/docs/architecture/application/cli.md
@@ -30,7 +30,7 @@ BACKUP DATABASE BEFORE USING THE MIGRATION!.
 
 ### Example
 
-You need products in the `SUBSCRIPTION_MODEL_REGISTRY`, for this example I will use these models (taken out of [example-orchestrator]()):
+You need products in the `SUBSCRIPTION_MODEL_REGISTRY`, for this example I will use these models (taken out of [example-orchestrator](https://github.com/hanstrompert/example-orchestrator)):
 - UserGroup Block:
     ```python
     from orchestrator.domain.base import SubscriptionModel, ProductBlockModel

--- a/docs/architecture/application/cli.md
+++ b/docs/architecture/application/cli.md
@@ -1,0 +1,311 @@
+# CLI
+
+CLI commands
+
+
+## db migrate-domain-models command
+Create migration file based on `SubscriptionModel.diff_product_in_database()` of the models within `SUBSCRIPTION_MODEL_REGISTRY`.
+You will be prompted with inputs for new models and resource type updates.
+
+BACKUP DATABASE BEFORE USING THE MIGRATION!.
+
+### Args:
+- `message`: Message/description of the generated migration.
+- `--test`: Optional boolean if you don't want to generate a migration file.
+- `--inputs`: stringified dict to prefill inputs.
+    The inputs and updates argument is mostly used for testing, prefilling the given inputs, here examples:
+    - new product: `inputs = { "new_product_name": { "description": "add description", "product_type": "add_type", "tag": "add_tag" }}`
+    - new product fixed input: `inputs = { "new_product_name": { "new_fixed_input_name": "value" }}`
+    - new product block: `inputs = { "new_product_block_name": { "description": "add description", "tag": "add_tag" } }`
+    - new resource type: `inputs = { "new_resource_type_name": { "description": "add description", "value": "add default value", "new_product_block_name": "add default value for block" }}`
+        - `new_product_block_name` prop inserts value specifically for that block.
+        - `value` prop is inserted as default for all existing instances it is added to.
+- `--updates`: stringified dict to prefill inputs.
+    - renaming a fixed input:
+        - `updates = { "fixed_inputs": { "product_name": { "old_fixed_input_name": "new_fixed_input_name" } } }`
+    - renaming a resource type to a new resource type:
+        - `inputs = { "new_resource_type_name": { "description": "add description" }}`
+        - `updates = { "resource_types": { "old_resource_type_name": "new_resource_type_name" } }`
+    - renaming a resource type to existing resource type: `updates = { "resource_types": { "old_resource_type_name": "new_resource_type_name" } }`
+
+### Example
+
+You need products in the `SUBSCRIPTION_MODEL_REGISTRY`, for this example I will use these models (taken out of [example-orchestrator]()):
+- UserGroup Block:
+    ```python
+    from orchestrator.domain.base import SubscriptionModel, ProductBlockModel
+    from orchestrator.types import SubscriptionLifecycle
+
+
+    class UserGroupBlockInactive(
+        ProductBlockModel,
+        lifecycle=[SubscriptionLifecycle.INITIAL],
+        product_block_name="UserGroupBlock",
+    ):
+        group_name: str | None = None
+        group_id: int | None = None
+
+
+    class UserGroupBlockProvisioning(
+        UserGroupBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+    ):
+        group_name: str
+        group_id: int | None = None
+
+
+    class UserGroupBlock(
+        UserGroupBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        group_name: str
+        group_id: int
+    ```
+
+- UserGroup Product:
+    ```python
+    from orchestrator.domain.base import SubscriptionModel
+    from orchestrator.types import SubscriptionLifecycle
+
+    from products.product_blocks.user_group import (
+        UserGroupBlock,
+        UserGroupBlockInactive,
+        UserGroupBlockProvisioning,
+    )
+
+
+    class UserGroupInactive(
+        SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.INITIAL]
+    ):
+        settings: UserGroupBlockInactive
+
+
+    class UserGroupProvisioning(
+        UserGroupInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+    ):
+        settings: UserGroupBlockProvisioning
+
+
+    class UserGroup(UserGroupProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        settings: UserGroupBlock
+    ```
+
+- User Block:
+    ```python
+    from orchestrator.domain.base import ProductBlockModel
+    from orchestrator.types import SubscriptionLifecycle
+
+    from products.product_blocks.user_group import (
+        UserGroupBlock,
+        UserGroupBlockInactive,
+        UserGroupBlockProvisioning,
+    )
+
+
+    class UserBlockInactive(
+        ProductBlockModel,
+        lifecycle=[SubscriptionLifecycle.INITIAL],
+        product_block_name="UserBlock",
+    ):
+        group: UserGroupBlockInactive
+        username: str | None = None
+        age: int | None = None
+        user_id: int | None = None
+
+
+    class UserBlockProvisioning(
+        UserBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+    ):
+        group: UserGroupBlockProvisioning
+        username: str
+        age: int | None = None
+        user_id: int | None = None
+
+
+    class UserBlock(UserBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        group: UserGroupBlock
+        username: str
+        age: int | None = None
+        user_id: int
+    ```
+
+- User Product:
+    ```python
+    from orchestrator.domain.base import SubscriptionModel
+    from orchestrator.types import SubscriptionLifecycle, strEnum
+
+    from products.product_blocks.user import (
+        UserBlock,
+        UserBlockInactive,
+        UserBlockProvisioning,
+    )
+
+
+    class Affiliation(strEnum):
+        internal = "internal"
+        external = "external"
+
+
+    class UserInactive(SubscriptionModel, is_base=True):
+        affiliation: Affiliation
+        settings: UserBlockInactive
+
+
+    class UserProvisioning(UserInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
+        affiliation: Affiliation
+        settings: UserBlockProvisioning
+
+
+    class User(UserProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        affiliation: Affiliation
+        settings: UserBlock
+    ```
+
+- `SUBSCRIPTION_MODEL_REGISTRY`:
+    ```python
+    from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+
+    from products.product_types.user import User
+    from products.product_types.user_group import UserGroup
+
+    # Register models to actual definitions for deserialization purposes
+    SUBSCRIPTION_MODEL_REGISTRY.update(
+        {
+            "User group": UserGroup,
+            "User internal": User,
+            "User external": User,
+        }
+    )
+    ```
+
+Running the command:
+- only with a message
+    ``` bash
+    python main.py db migrate-domain-models "message"
+    ```
+
+- Running it as test
+    ``` bash
+    python main.py db migrate-domain-models "message" --test
+    ```
+
+- Running the command with inputs prefilled
+    ``` bash
+    python main.py db migrate-domain-models "message" --inputs "{ "" }"
+    ```
+
+The command will first go through all products and map the differences with the database. debug log example:
+```bash
+XXXX-XX-XX XX:XX:XX [debug] ProductTable blocks diff [orchestrator.domain.base] fixed_inputs_in_db=set() fixed_inputs_model=set() missing_fixed_inputs_in_db=set() missing_fixed_inputs_in_model=set() missing_product_blocks_in_db=set() missing_product_blocks_in_model=set() product_block_db=User group product_blocks_in_db={'UserGroupBlock'} product_blocks_in_model={'UserGroupBlock'}
+```
+
+You will be prompted with inputs when updates are found.
+- new product example:
+    ``` bash
+    --- PRODUCT ['User group'] INPUTS ---
+    Product description: User group product
+    Product type: UserGroup
+    Product tag: GROUP
+    ```
+- new product block:
+    ``` bash
+    --- PRODUCT BLOCK ['UserGroupBlock'] INPUTS ---
+    Product block description: User group settings
+    Product block tag: UGS
+    ```
+- new fixed input (the type isn't checked, so typing an incorrect value will insert in db):
+    ``` bash
+    --- PRODUCT ['User internal'] FIXED INPUT ['affiliation'] ---
+    Fixed input value: internal
+    ```
+- new resource type:
+    ``` bash
+    --- RESOURCE TYPE ['group_name'] ---
+    Resource type description: Unique name of user group
+    ```
+
+it will log the differences on info level:
+``` bash
+XXXX-XX-XX XX:XX:XX [info] create_products                [orchestrator.cli.migrate_domain_models] create_products={'User group': <class 'products.product_types.user_group.UserGroup'>, 'User internal': <class 'products.product_types.user.User'>, 'User external': <class 'products.product_types.user.User'>}
+XXXX-XX-XX XX:XX:XX [info] delete_products                [orchestrator.cli.migrate_domain_models] delete_products=set()
+XXXX-XX-XX XX:XX:XX [info] create_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] create_product_fixed_inputs={'affiliation': {'User external', 'User internal'}}
+XXXX-XX-XX XX:XX:XX [info] update_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] update_product_fixed_inputs={}
+XXXX-XX-XX XX:XX:XX [info] delete_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] delete_product_fixed_inputs={}
+XXXX-XX-XX XX:XX:XX [info] create_product_to_block_relations [orchestrator.cli.migrate_domain_models] create_product_to_block_relations={'UserGroupBlock': {'User group'}, 'UserBlock': {'User external', 'User internal'}}
+XXXX-XX-XX XX:XX:XX [info] delete_product_to_block_relations [orchestrator.cli.migrate_domain_models] delete_product_to_block_relations={}
+XXXX-XX-XX XX:XX:XX [info] create_resource_types          [orchestrator.cli.migrate_domain_models] create_resource_types={'username', 'age', 'group_name', 'user_id', 'group_id'}
+XXXX-XX-XX XX:XX:XX [info] rename_resource_types          [orchestrator.cli.migrate_domain_models] rename_resource_types={}
+XXXX-XX-XX XX:XX:XX [info] delete_resource_types          [orchestrator.cli.migrate_domain_models] delete_resource_types=set()
+XXXX-XX-XX XX:XX:XX [info] create_resource_type_relations [orchestrator.cli.migrate_domain_models] create_resource_type_relations={'group_name': {'UserGroupBlock'}, 'group_id': {'UserGroupBlock'}, 'username': {'UserBlock'}, 'age': {'UserBlock'}, 'user_id': {'UserBlock'}}
+XXXX-XX-XX XX:XX:XX [info] delete_resource_type_relations [orchestrator.cli.migrate_domain_models] delete_resource_type_relations={}
+XXXX-XX-XX XX:XX:XX [info] create_product_blocks          [orchestrator.cli.migrate_domain_models] create_blocks={'UserGroupBlock': <class 'products.product_blocks.user_group.UserGroupBlock'>, 'UserBlock': <class 'products.product_blocks.user.UserBlock'>}
+XXXX-XX-XX XX:XX:XX [info] delete_product_blocks          [orchestrator.cli.migrate_domain_models] delete_blocks=set()
+XXXX-XX-XX XX:XX:XX [info] create_product_block_relations [orchestrator.cli.migrate_domain_models] create_product_block_relations={'UserGroupBlock': {'UserBlock'}}
+XXXX-XX-XX XX:XX:XX [info] delete_product_block_relations [orchestrator.cli.migrate_domain_models] delete_product_block_relations={}
+```
+
+now it will start generating the SQL, logging the SQL on debug level and prompt user for new resources:
+- new product example:
+    ``` bash
+    --- PRODUCT ['User group'] INPUTS ---
+    Product description: User group product
+    Product type: UserGroup
+    Product tag: GROUP
+    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO products (name, description, product_type, tag, status) VALUES ('User group', 'User group product', 'UserGroup', 'GROUP', 'active') RETURNING products.product_id
+    ```
+- new fixed input (the type isn't checked, so typing an incorrect value will insert in db):
+    ``` bash
+    --- PRODUCT ['User internal'] FIXED INPUT ['affiliation'] ---
+    Fixed input value: internal
+    --- PRODUCT ['User external'] FIXED INPUT ['affiliation'] ---
+    Fixed input value: external]
+    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO fixed_inputs (name, value, product_id) VALUES ('affiliation', 'internal', (SELECT products.product_id FROM products WHERE products.name IN ('User internal'))), ('affiliation', 'external', (SELECT products.product_id FROM products WHERE products.name IN ('User external')))
+    ```
+- new product block:
+    ``` bash
+    --- PRODUCT BLOCK ['UserGroupBlock'] INPUTS ---
+    Product block description: User group settings
+    Product block tag: UGS
+    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO product_blocks (name, description, tag, status) VALUES ('UserGroupBlock', 'User group settings', 'UGS', 'active') RETURNING product_blocks.product_block_id
+    ```
+- new resource type:
+    ``` bash
+    --- RESOURCE TYPE ['group_name'] ---
+    Resource type description: Unique name of user group
+    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO resource_types (resource_type, description) VALUES ('group_name', 'Unique name of user group') RETURNING resource_types.resource_type_id
+    ```
+- default value for resource type per product block (necessary for adding a default value to existing instances):
+    ``` bash
+    Resource type ['group_name'] default value for block ['UserGroupBlock']: group
+    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.resource_type_helpers] sql_string=
+                    WITH subscription_instance_ids AS (
+                        SELECT subscription_instances.subscription_instance_id
+                        FROM   subscription_instances
+                        WHERE  subscription_instances.product_block_id IN (
+                            SELECT product_blocks.product_block_id
+                            FROM   product_blocks
+                            WHERE  product_blocks.name = 'UserGroupBlock'
+                        )
+                    )
+
+                    INSERT INTO
+                        subscription_instance_values (subscription_instance_id, resource_type_id, value)
+                    SELECT
+                        subscription_instance_ids.subscription_instance_id,
+                        resource_types.resource_type_id,
+                        'group'
+                    FROM resource_types
+                    CROSS JOIN subscription_instance_ids
+                    WHERE resource_types.resource_type = 'group_name'
+    ```
+
+Last part generates the migration with the generated SQL:
+``` bash
+--- GENERATING SQL MIGRATION FILE ---
+XXXX-XX-XX XX:XX:XX [info] Version Locations [orchestrator.cli.database] locations=/home/tjeerddie/projects_surf/example-orchestrator/migrations/versions/schema /home/tjeerddie/projects_surf/example-orchestrator/.venv/lib/python3.10/site-packages/orchestrator/migrations/versions/schema
+  Generating /home/tjeerddie/projects_surf/example-orchestrator/migrations/versions/schema/2022-10-27_a8946b2d1647_test.py ...  done
+--- MIGRATION GENERATED (DON'T FORGET TO BACKUP DATABASE BEFORE MIGRATING!) ---
+```
+
+when using `--test` it will instead show:
+``` bash
+--- TEST DOES NOT GENERATE SQL MIGRATION ---
+```

--- a/docs/architecture/application/cli.md
+++ b/docs/architecture/application/cli.md
@@ -4,8 +4,16 @@ CLI commands
 
 
 ## db migrate-domain-models command
-Create migration file based on `SubscriptionModel.diff_product_in_database()` of the models within `SUBSCRIPTION_MODEL_REGISTRY`.
-You will be prompted with inputs for new models and resource type updates.
+
+The purpose of this CLI script is to automatically generate the data migrations that you'll need when you add or change a Domain Model.
+It will inspect your DB and the existing domain models, analyse the differences and it will generate an Alembic data migration in the correct folder.
+
+Features:
+- detect a new Domain Model attribute / resource type
+- detect a renamed Domain Model attribute / resource type
+- detect a new Domain Model
+- ability to ask for human input when needed
+- Below in the documentation these features are discussed in more detail.
 
 BACKUP DATABASE BEFORE USING THE MIGRATION!.
 
@@ -194,7 +202,7 @@ Running the command:
 
 The command will first go through all products and map the differences with the database. debug log example:
 ```bash
-XXXX-XX-XX XX:XX:XX [debug] ProductTable blocks diff [orchestrator.domain.base] fixed_inputs_in_db=set() fixed_inputs_model=set() missing_fixed_inputs_in_db=set() missing_fixed_inputs_in_model=set() missing_product_blocks_in_db=set() missing_product_blocks_in_model=set() product_block_db=User group product_blocks_in_db={'UserGroupBlock'} product_blocks_in_model={'UserGroupBlock'}
+2022-10-27 11:45:10 [debug] ProductTable blocks diff [orchestrator.domain.base] fixed_inputs_in_db=set() fixed_inputs_model=set() missing_fixed_inputs_in_db=set() missing_fixed_inputs_in_model=set() missing_product_blocks_in_db=set() missing_product_blocks_in_model=set() product_block_db=User group product_blocks_in_db={'UserGroupBlock'} product_blocks_in_model={'UserGroupBlock'}
 ```
 
 You will be prompted with inputs when updates are found.
@@ -224,22 +232,22 @@ You will be prompted with inputs when updates are found.
 
 it will log the differences on info level:
 ``` bash
-XXXX-XX-XX XX:XX:XX [info] create_products                [orchestrator.cli.migrate_domain_models] create_products={'User group': <class 'products.product_types.user_group.UserGroup'>, 'User internal': <class 'products.product_types.user.User'>, 'User external': <class 'products.product_types.user.User'>}
-XXXX-XX-XX XX:XX:XX [info] delete_products                [orchestrator.cli.migrate_domain_models] delete_products=set()
-XXXX-XX-XX XX:XX:XX [info] create_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] create_product_fixed_inputs={'affiliation': {'User external', 'User internal'}}
-XXXX-XX-XX XX:XX:XX [info] update_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] update_product_fixed_inputs={}
-XXXX-XX-XX XX:XX:XX [info] delete_product_fixed_inputs    [orchestrator.cli.migrate_domain_models] delete_product_fixed_inputs={}
-XXXX-XX-XX XX:XX:XX [info] create_product_to_block_relations [orchestrator.cli.migrate_domain_models] create_product_to_block_relations={'UserGroupBlock': {'User group'}, 'UserBlock': {'User external', 'User internal'}}
-XXXX-XX-XX XX:XX:XX [info] delete_product_to_block_relations [orchestrator.cli.migrate_domain_models] delete_product_to_block_relations={}
-XXXX-XX-XX XX:XX:XX [info] create_resource_types          [orchestrator.cli.migrate_domain_models] create_resource_types={'username', 'age', 'group_name', 'user_id', 'group_id'}
-XXXX-XX-XX XX:XX:XX [info] rename_resource_types          [orchestrator.cli.migrate_domain_models] rename_resource_types={}
-XXXX-XX-XX XX:XX:XX [info] delete_resource_types          [orchestrator.cli.migrate_domain_models] delete_resource_types=set()
-XXXX-XX-XX XX:XX:XX [info] create_resource_type_relations [orchestrator.cli.migrate_domain_models] create_resource_type_relations={'group_name': {'UserGroupBlock'}, 'group_id': {'UserGroupBlock'}, 'username': {'UserBlock'}, 'age': {'UserBlock'}, 'user_id': {'UserBlock'}}
-XXXX-XX-XX XX:XX:XX [info] delete_resource_type_relations [orchestrator.cli.migrate_domain_models] delete_resource_type_relations={}
-XXXX-XX-XX XX:XX:XX [info] create_product_blocks          [orchestrator.cli.migrate_domain_models] create_blocks={'UserGroupBlock': <class 'products.product_blocks.user_group.UserGroupBlock'>, 'UserBlock': <class 'products.product_blocks.user.UserBlock'>}
-XXXX-XX-XX XX:XX:XX [info] delete_product_blocks          [orchestrator.cli.migrate_domain_models] delete_blocks=set()
-XXXX-XX-XX XX:XX:XX [info] create_product_block_relations [orchestrator.cli.migrate_domain_models] create_product_block_relations={'UserGroupBlock': {'UserBlock'}}
-XXXX-XX-XX XX:XX:XX [info] delete_product_block_relations [orchestrator.cli.migrate_domain_models] delete_product_block_relations={}
+2022-10-27 11:45:10 [info] create_products                   [orchestrator.cli.migrate_domain_models] create_products={'User group': <class 'products.product_types.user_group.UserGroup'>, 'User internal': <class 'products.product_types.user.User'>, 'User external': <class 'products.product_types.user.User'>}
+2022-10-27 11:45:10 [info] delete_products                   [orchestrator.cli.migrate_domain_models] delete_products=set()
+2022-10-27 11:45:10 [info] create_product_fixed_inputs       [orchestrator.cli.migrate_domain_models] create_product_fixed_inputs={'affiliation': {'User external', 'User internal'}}
+2022-10-27 11:45:10 [info] update_product_fixed_inputs       [orchestrator.cli.migrate_domain_models] update_product_fixed_inputs={}
+2022-10-27 11:45:10 [info] delete_product_fixed_inputs       [orchestrator.cli.migrate_domain_models] delete_product_fixed_inputs={}
+2022-10-27 11:45:10 [info] create_product_to_block_relations [orchestrator.cli.migrate_domain_models] create_product_to_block_relations={'UserGroupBlock': {'User group'}, 'UserBlock': {'User external', 'User internal'}}
+2022-10-27 11:45:10 [info] delete_product_to_block_relations [orchestrator.cli.migrate_domain_models] delete_product_to_block_relations={}
+2022-10-27 11:45:10 [info] create_resource_types             [orchestrator.cli.migrate_domain_models] create_resource_types={'username', 'age', 'group_name', 'user_id', 'group_id'}
+2022-10-27 11:45:10 [info] rename_resource_types             [orchestrator.cli.migrate_domain_models] rename_resource_types={}
+2022-10-27 11:45:10 [info] delete_resource_types             [orchestrator.cli.migrate_domain_models] delete_resource_types=set()
+2022-10-27 11:45:10 [info] create_resource_type_relations    [orchestrator.cli.migrate_domain_models] create_resource_type_relations={'group_name': {'UserGroupBlock'}, 'group_id': {'UserGroupBlock'}, 'username': {'UserBlock'}, 'age': {'UserBlock'}, 'user_id': {'UserBlock'}}
+2022-10-27 11:45:10 [info] delete_resource_type_relations    [orchestrator.cli.migrate_domain_models] delete_resource_type_relations={}
+2022-10-27 11:45:10 [info] create_product_blocks             [orchestrator.cli.migrate_domain_models] create_blocks={'UserGroupBlock': <class 'products.product_blocks.user_group.UserGroupBlock'>, 'UserBlock': <class 'products.product_blocks.user.UserBlock'>}
+2022-10-27 11:45:10 [info] delete_product_blocks             [orchestrator.cli.migrate_domain_models] delete_blocks=set()
+2022-10-27 11:45:10 [info] create_product_block_relations    [orchestrator.cli.migrate_domain_models] create_product_block_relations={'UserGroupBlock': {'UserBlock'}}
+2022-10-27 11:45:10 [info] delete_product_block_relations    [orchestrator.cli.migrate_domain_models] delete_product_block_relations={}
 ```
 
 now it will start generating the SQL, logging the SQL on debug level and prompt user for new resources:
@@ -249,7 +257,7 @@ now it will start generating the SQL, logging the SQL on debug level and prompt 
     Product description: User group product
     Product type: UserGroup
     Product tag: GROUP
-    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO products (name, description, product_type, tag, status) VALUES ('User group', 'User group product', 'UserGroup', 'GROUP', 'active') RETURNING products.product_id
+    2022-10-27 11:45:10 [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO products (name, description, product_type, tag, status) VALUES ('User group', 'User group product', 'UserGroup', 'GROUP', 'active') RETURNING products.product_id
     ```
 - new fixed input (the type isn't checked, so typing an incorrect value will insert in db):
     ``` bash
@@ -257,25 +265,25 @@ now it will start generating the SQL, logging the SQL on debug level and prompt 
     Fixed input value: internal
     --- PRODUCT ['User external'] FIXED INPUT ['affiliation'] ---
     Fixed input value: external]
-    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO fixed_inputs (name, value, product_id) VALUES ('affiliation', 'internal', (SELECT products.product_id FROM products WHERE products.name IN ('User internal'))), ('affiliation', 'external', (SELECT products.product_id FROM products WHERE products.name IN ('User external')))
+    2022-10-27 11:45:10 [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO fixed_inputs (name, value, product_id) VALUES ('affiliation', 'internal', (SELECT products.product_id FROM products WHERE products.name IN ('User internal'))), ('affiliation', 'external', (SELECT products.product_id FROM products WHERE products.name IN ('User external')))
     ```
 - new product block:
     ``` bash
     --- PRODUCT BLOCK ['UserGroupBlock'] INPUTS ---
     Product block description: User group settings
     Product block tag: UGS
-    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO product_blocks (name, description, tag, status) VALUES ('UserGroupBlock', 'User group settings', 'UGS', 'active') RETURNING product_blocks.product_block_id
+    2022-10-27 11:45:10 [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO product_blocks (name, description, tag, status) VALUES ('UserGroupBlock', 'User group settings', 'UGS', 'active') RETURNING product_blocks.product_block_id
     ```
 - new resource type:
     ``` bash
     --- RESOURCE TYPE ['group_name'] ---
     Resource type description: Unique name of user group
-    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO resource_types (resource_type, description) VALUES ('group_name', 'Unique name of user group') RETURNING resource_types.resource_type_id
+    2022-10-27 11:45:10 [debug] generated SQL [orchestrator.cli.domain_gen_helpers.helpers] sql_string=INSERT INTO resource_types (resource_type, description) VALUES ('group_name', 'Unique name of user group') RETURNING resource_types.resource_type_id
     ```
 - default value for resource type per product block (necessary for adding a default value to existing instances):
     ``` bash
     Resource type ['group_name'] default value for block ['UserGroupBlock']: group
-    XXXX-XX-XX XX:XX:XX [debug] generated SQL [orchestrator.cli.domain_gen_helpers.resource_type_helpers] sql_string=
+    2022-10-27 11:45:10 [debug] generated SQL [orchestrator.cli.domain_gen_helpers.resource_type_helpers] sql_string=
                     WITH subscription_instance_ids AS (
                         SELECT subscription_instances.subscription_instance_id
                         FROM   subscription_instances
@@ -300,7 +308,7 @@ now it will start generating the SQL, logging the SQL on debug level and prompt 
 Last part generates the migration with the generated SQL:
 ``` bash
 --- GENERATING SQL MIGRATION FILE ---
-XXXX-XX-XX XX:XX:XX [info] Version Locations [orchestrator.cli.database] locations=/home/tjeerddie/projects_surf/example-orchestrator/migrations/versions/schema /home/tjeerddie/projects_surf/example-orchestrator/.venv/lib/python3.10/site-packages/orchestrator/migrations/versions/schema
+2022-10-27 11:45:10 [info] Version Locations [orchestrator.cli.database] locations=/home/tjeerddie/projects_surf/example-orchestrator/migrations/versions/schema /home/tjeerddie/projects_surf/example-orchestrator/.venv/lib/python3.10/site-packages/orchestrator/migrations/versions/schema
   Generating /home/tjeerddie/projects_surf/example-orchestrator/migrations/versions/schema/2022-10-27_a8946b2d1647_test.py ...  done
 --- MIGRATION GENERATED (DON'T FORGET TO BACKUP DATABASE BEFORE MIGRATING!) ---
 ```

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "0.4.11-rc1"
+__version__ = "0.4.11-rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/cli/database.py
+++ b/orchestrator/cli/database.py
@@ -208,7 +208,7 @@ def migrate_domain_models(
 
     You will be prompted with inputs for new models and resource type updates.
 
-    with the above feature, inputs is mostly for testing to prefill the given inputs, but here examples:
+    The inputs argument is mostly used for testing the prefill of given inputs, here examples:
         - new product: `inputs = { "new_product": { "description": "add description", "product_type": "add_type", "tag": "add_tag" }}`
         - new product fixed input: `inputs = { "new_fixed_input_name": { "description": "add description", "value": "add value" }}`
         - new product block: `inputs = { "new_product_block_name": { "description": "add description", "tag": "add_tag" } }`

--- a/orchestrator/cli/database.py
+++ b/orchestrator/cli/database.py
@@ -212,19 +212,30 @@ def migrate_domain_models(
     You will be prompted with inputs for new models and resource type updates.
     Resource type updates are only handled when it's renamed in all product blocks.
 
-    The inputs and updates argument is mostly used for testing the prefill of given inputs, here examples:
+    Args:
+    - `message`: Message/description of the generated migration.
+    - `--test`: Optional boolean if you don't want to generate a migration file.
+    - `--inputs`: stringified dict to prefill inputs.
+        The inputs and updates argument is mostly used for testing, prefilling the given inputs, here examples:
         - new product: `inputs = { "new_product_name": { "description": "add description", "product_type": "add_type", "tag": "add_tag" }}`
         - new product fixed input: `inputs = { "new_product_name": { "new_fixed_input_name": "value" }}`
         - new product block: `inputs = { "new_product_block_name": { "description": "add description", "tag": "add_tag" } }`
         - new resource type: `inputs = { "new_resource_type_name": { "description": "add description", "value": "add default value", "new_product_block_name": "add default value for block" }}`
             - `new_product_block_name` prop inserts value specifically for that block.
             - `value` prop is inserted as default for all existing instances it is added to.
-        - updating a fixed input:
+
+    - `--updates`: stringified dict to prefill inputs.
+        - renaming a fixed input:
             - `updates = { "fixed_inputs": { "product_name": { "old_fixed_input_name": "new_fixed_input_name" } } }`
-        - updating a resource type to a new resource type:
+        - renaming a resource type to a new resource type:
             - `inputs = { "new_resource_type_name": { "description": "add description" }}`
             - `updates = { "resource_types": { "old_resource_type_name": "new_resource_type_name" } }`
-        - updating a resource type to existing resource type: `updates = { "resource_types": { "old_resource_type_name": "new_resource_type_name" } }`
+        - renaming a resource type to existing resource type: `updates = { "resource_types": { "old_resource_type_name": "new_resource_type_name" } }`
+
+    Returns None unless `--test` is used, in which case it returns:
+        - tuple:
+            - list of upgrade SQL statements in string format.
+            - list of downgrade SQL statements in string format.
     """
 
     inputs_dict = json.loads(inputs) if isinstance(inputs, str) else {}

--- a/orchestrator/cli/database.py
+++ b/orchestrator/cli/database.py
@@ -200,7 +200,7 @@ def history(
 
 @app.command(help="Create revision based on diff_product_in_database.")
 def migrate_domain_models(
-    message: Optional[str] = typer.Option("update domain models", help="Migration name"),
+    message: str = typer.Argument("update domain models", help="Migration name"),
     test: Optional[bool] = typer.Option(False, help="Optional boolean if you don't want to generate a migration file"),
     inputs: Optional[str] = typer.Option("{}", help="stringified dict to prefill inputs"),
 ) -> Union[Tuple[List[str], List[str]], None]:

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -1,0 +1,91 @@
+from typing import Dict, List, Set, Union
+
+from more_itertools import flatten
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.expression import Delete, Insert, Update
+
+from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_compile
+from orchestrator.cli.domain_gen_helpers.product_helpers import get_product_id, get_product_ids
+from orchestrator.db.models import FixedInputTable
+
+
+def generate_create_fixed_inputs_sql(
+    fixed_inputs: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]], revert: bool = False
+) -> List[str]:
+    def create_fixed_input(fixed_input: str, product_names: Set[str]) -> str:
+        def create_product_insert_dict(product_name: str) -> Dict[str, Union[str, Query]]:
+            product_id_sql = get_product_id(product_name)
+
+            if revert:
+                value = (
+                    FixedInputTable.query.where(
+                        FixedInputTable.name == fixed_input, FixedInputTable.product_id == product_id_sql
+                    )
+                    .with_entities(FixedInputTable.value)
+                    .one()
+                )[0]
+            else:
+                print(f"--- PRODUCT ['{product_name}'] FIXED INPUT ['{fixed_input}'] ---")  # noqa: T001, T201
+                value = inputs.get(fixed_input, {}).get("value") or get_user_input("Fixed input value: ")
+
+            return {"name": fixed_input, "value": value, "product_id": product_id_sql}
+
+        fixed_input_dicts = [create_product_insert_dict(product_name) for product_name in product_names]
+        return str(sql_compile(Insert(FixedInputTable).values(fixed_input_dicts)))
+
+    return [create_fixed_input(*item) for item in fixed_inputs.items()]
+
+
+def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[str]:
+    def delete_fixed_input(fixed_input: str, product_names: Set[str]) -> str:
+        product_ids_sql = get_product_ids(product_names)
+        return str(
+            sql_compile(
+                Delete(FixedInputTable).where(
+                    FixedInputTable.product_id.in_(product_ids_sql),
+                    FixedInputTable.name == fixed_input,
+                )
+            )
+        )
+
+    return [delete_fixed_input(*item) for item in fixed_inputs.items()]
+
+
+def generate_update_fixed_inputs_sql(product_fixed_inputs: Dict[str, Dict[str, str]]) -> List[str]:
+    def update_fixed_inputs(product_name: str, fixed_inputs: Dict[str, str]) -> List[str]:
+        product_id_sql = get_product_id(product_name)
+
+        def update_fixed_input(old_name: str, new_name: str) -> str:
+            return sql_compile(
+                Update(FixedInputTable)
+                .where(
+                    FixedInputTable.product_id == (product_id_sql),
+                    FixedInputTable.name == old_name,
+                )
+                .values(name=new_name)
+            )
+
+        return [update_fixed_input(*fixed_input) for fixed_input in fixed_inputs.items()]
+
+    return list(flatten([update_fixed_inputs(*item) for item in product_fixed_inputs.items()]))
+
+
+def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Dict[str, str]]:
+    print("--- UPDATE FIXED INPUT DECISIONS ---")  # noqa: T001, T201
+
+    def should_rename(product_name: str, product_diff: Dict[str, Set[str]]) -> Dict[str, str]:
+        db_props = list(product_diff.get("missing_fixed_inputs_in_model", []))
+        model_props = list(product_diff.get("missing_fixed_inputs_in_db", []))
+
+        if len(db_props) == 1 and len(model_props) == 1:
+            should_rename = get_user_input(
+                f"rename fixed input {db_props} to {model_props} for product ['{product_name}'] (y/N): ",
+                "n",
+            )
+            if should_rename == "y":
+                product_diffs[product_name]["missing_fixed_inputs_in_model"] = set()
+                product_diffs[product_name]["missing_fixed_inputs_in_db"] = set()
+                return {db_props[0]: model_props[0]}
+        return {}
+
+    return {name: should_rename(name, diff) for name, diff in product_diffs.items()}

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -25,7 +25,7 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
             - key: old fixed input name.
             - value: new fixed input name.
     """
-    print("--- UPDATE FIXED INPUT DECISIONS ---")  # noqa: T001, T201
+    print("--- UPDATE FIXED INPUT DECISIONS ('N'= create and delete) ---")  # noqa: T001, T201
 
     def should_rename(product_name: str, product_diff: Dict[str, Set[str]]) -> Dict[str, str]:
         db_props = list(product_diff.get("missing_fixed_inputs_in_model", []))

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -42,7 +42,8 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
                 return {db_props[0]: model_props[0]}
         return {}
 
-    return {name: should_rename(name, diff) for name, diff in product_diffs.items()}
+    updates = {name: should_rename(name, diff) for name, diff in product_diffs.items()}
+    return {k: v for k, v in updates.items() if v}
 
 
 def generate_create_fixed_inputs_sql(
@@ -78,7 +79,7 @@ def generate_create_fixed_inputs_sql(
                 )[0]
             else:
                 print(f"--- PRODUCT ['{product_name}'] FIXED INPUT ['{fixed_input}'] ---")  # noqa: T001, T201
-                value = inputs.get(fixed_input, {}).get("value") or get_user_input("Fixed input value: ")
+                value = inputs.get(product_name, {}).get(fixed_input) or get_user_input("Fixed input value: ")
 
             return {"name": fixed_input, "value": value, "product_id": product_id_sql}
 

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -9,9 +9,61 @@ from orchestrator.cli.domain_gen_helpers.product_helpers import get_product_id, 
 from orchestrator.db.models import FixedInputTable
 
 
+def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Dict[str, str]]:
+    """Map fixed inputs to update.
+
+    Args:
+        - block_diffs: Dict with product block differences.
+            - key: product block name
+            - value: Dict with differences between model and database.
+                - key: difference name, 'missing_fixed_inputs_in_model' and 'missing_fixed_inputs_in_db' are used to check if a fixed input can be renamed.
+                - value: Set of fixed input names.
+
+    Returns: Dict with updated fixed inputs mapped by product.
+        - key: product name.
+        - value: Dict with updated fixed inputs.
+            - key: old fixed input name.
+            - value: new fixed input name.
+    """
+    print("--- UPDATE FIXED INPUT DECISIONS ---")  # noqa: T001, T201
+
+    def should_rename(product_name: str, product_diff: Dict[str, Set[str]]) -> Dict[str, str]:
+        db_props = list(product_diff.get("missing_fixed_inputs_in_model", []))
+        model_props = list(product_diff.get("missing_fixed_inputs_in_db", []))
+
+        if len(db_props) == 1 and len(model_props) == 1:
+            should_rename = get_user_input(
+                f"rename fixed input {db_props} to {model_props} for product ['{product_name}'] (y/N): ",
+                "n",
+            )
+            if should_rename == "y":
+                product_diffs[product_name]["missing_fixed_inputs_in_model"] = set()
+                product_diffs[product_name]["missing_fixed_inputs_in_db"] = set()
+                return {db_props[0]: model_props[0]}
+        return {}
+
+    return {name: should_rename(name, diff) for name, diff in product_diffs.items()}
+
+
 def generate_create_fixed_inputs_sql(
     fixed_inputs: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]], revert: bool = False
 ) -> List[str]:
+    """Generate sql strings to create product blocks.
+
+    Args:
+        - fixed_inputs: Dict with product names by fixed input.
+            - key: fixed input value.
+            - value: product names.
+        - inputs: Optional Dict to prefill fixed input 'value' per product.
+            - key: fixed input name.
+            - value: Dict with prefilled value.
+                - key: 'value' as key.
+                - value: prefilled value.
+        - revert: boolean to create sql string with value filled by the database.
+
+    Returns: List of sql strings to create fixed inputs.
+    """
+
     def create_fixed_input(fixed_input: str, product_names: Set[str]) -> str:
         def create_product_insert_dict(product_name: str) -> Dict[str, Union[str, Query]]:
             product_id_sql = get_product_id(product_name)
@@ -37,6 +89,16 @@ def generate_create_fixed_inputs_sql(
 
 
 def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to delete fixed inputs.
+
+    Args:
+        - fixed_inputs: Dict with product names by fixed input.
+            - key: fixed input value.
+            - value: product names.
+
+    Returns: List of SQL strings to delete fixed inputs.
+    """
+
     def delete_fixed_input(fixed_input: str, product_names: Set[str]) -> str:
         product_ids_sql = get_product_ids(product_names)
         return str(
@@ -52,6 +114,16 @@ def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[
 
 
 def generate_update_fixed_inputs_sql(product_fixed_inputs: Dict[str, Dict[str, str]]) -> List[str]:
+    """Generate SQL to update fixed inputs.
+
+    Args:
+        - product_fixed_inputs: Dict with product names by fixed input.
+            - key: fixed input value.
+            - value: product names.
+
+    Returns: List of SQL strings to update fixed inputs.
+    """
+
     def update_fixed_inputs(product_name: str, fixed_inputs: Dict[str, str]) -> List[str]:
         product_id_sql = get_product_id(product_name)
 
@@ -68,24 +140,3 @@ def generate_update_fixed_inputs_sql(product_fixed_inputs: Dict[str, Dict[str, s
         return [update_fixed_input(*fixed_input) for fixed_input in fixed_inputs.items()]
 
     return list(flatten([update_fixed_inputs(*item) for item in product_fixed_inputs.items()]))
-
-
-def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Dict[str, str]]:
-    print("--- UPDATE FIXED INPUT DECISIONS ---")  # noqa: T001, T201
-
-    def should_rename(product_name: str, product_diff: Dict[str, Set[str]]) -> Dict[str, str]:
-        db_props = list(product_diff.get("missing_fixed_inputs_in_model", []))
-        model_props = list(product_diff.get("missing_fixed_inputs_in_db", []))
-
-        if len(db_props) == 1 and len(model_props) == 1:
-            should_rename = get_user_input(
-                f"rename fixed input {db_props} to {model_props} for product ['{product_name}'] (y/N): ",
-                "n",
-            )
-            if should_rename == "y":
-                product_diffs[product_name]["missing_fixed_inputs_in_model"] = set()
-                product_diffs[product_name]["missing_fixed_inputs_in_db"] = set()
-                return {db_props[0]: model_props[0]}
-        return {}
-
-    return {name: should_rename(name, diff) for name, diff in product_diffs.items()}

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -48,7 +48,7 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
 def generate_create_fixed_inputs_sql(
     fixed_inputs: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]], revert: bool = False
 ) -> List[str]:
-    """Generate sql strings to create product blocks.
+    """Generate SQL to create fixed inputs.
 
     Args:
         - fixed_inputs: Dict with product names by fixed input.
@@ -59,9 +59,9 @@ def generate_create_fixed_inputs_sql(
             - value: Dict with prefilled value.
                 - key: 'value' as key.
                 - value: prefilled value.
-        - revert: boolean to create sql string with value filled by the database.
+        - revert: boolean to create SQL string with value filled by the database.
 
-    Returns: List of sql strings to create fixed inputs.
+    Returns: List of SQL to create fixed inputs.
     """
 
     def create_fixed_input(fixed_input: str, product_names: Set[str]) -> str:

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -13,8 +13,8 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
     """Map fixed inputs to update.
 
     Args:
-        - block_diffs: Dict with product block differences.
-            - key: product block name
+        - product_diffs: Dict with product differences.
+            - key: product name
             - value: Dict with differences between model and database.
                 - key: difference name, 'missing_fixed_inputs_in_model' and 'missing_fixed_inputs_in_db' are used to check if a fixed input can be renamed.
                 - value: Set of fixed input names.

--- a/orchestrator/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/helpers.py
@@ -1,0 +1,50 @@
+from itertools import groupby
+from typing import Dict, Optional, Set
+
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Query
+
+
+def sql_compile(sql: Query) -> str:
+    return str(sql.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})).replace("\n", "")
+
+
+def generic_mapper(prop_name: str, model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    model_by_resource = [
+        (prop_name_value, model_name)
+        for model_name, diff in model_diffs.items()
+        for prop_name_value in diff.get(prop_name, [])  # type: ignore
+    ]
+    grouped = groupby(model_by_resource, lambda x: x[0])
+    return {k: {val[1] for val in v} for k, v in grouped}
+
+
+def get_user_input(text: str, default: Optional[str] = None) -> Optional[str]:
+    while True:
+        answer = input(text)
+        if answer or default:
+            return answer or default
+
+
+def map_create_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_fixed_inputs_in_db", model_diffs)
+
+
+def map_delete_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_fixed_inputs_in_model", model_diffs)
+
+
+def map_create_resource_type_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_resource_types_in_db", model_diffs)
+
+
+def map_delete_resource_type_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_resource_types_in_model", model_diffs)
+
+
+def map_create_product_block_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_product_blocks_in_db", model_diffs)
+
+
+def map_delete_product_block_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+    return generic_mapper("missing_product_blocks_in_model", model_diffs)

--- a/orchestrator/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/helpers.py
@@ -23,7 +23,7 @@ def get_user_input(text: str, default: Optional[str] = None) -> Optional[str]:
     while True:
         answer = input(text)
         if answer or default:
-            return answer or default
+            return answer.strip() or default
 
 
 def map_create_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:

--- a/orchestrator/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/helpers.py
@@ -1,12 +1,18 @@
 from itertools import groupby
 from typing import Dict, Optional, Set
 
+import structlog
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Query
 
+logger = structlog.get_logger(__name__)
+
 
 def sql_compile(sql: Query) -> str:
-    return str(sql.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})).replace("\n", "")
+    sql_string = str(sql.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    sql_string = sql_string.replace("\n", "")
+    logger.debug("generated SQL", sql_string=sql_string)
+    return sql_string
 
 
 def generic_mapper(prop_name: str, model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
@@ -23,7 +29,7 @@ def get_user_input(text: str, default: Optional[str] = None) -> Optional[str]:
     while True:
         answer = input(text)
         if answer or default:
-            return answer.strip() or default
+            return answer.strip() if answer else default
 
 
 def map_create_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:

--- a/orchestrator/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/helpers.py
@@ -13,7 +13,7 @@ def generic_mapper(prop_name: str, model_diffs: Dict[str, Dict[str, Set[str]]]) 
     model_by_resource = [
         (prop_name_value, model_name)
         for model_name, diff in model_diffs.items()
-        for prop_name_value in diff.get(prop_name, [])  # type: ignore
+        for prop_name_value in diff.get(prop_name, [])
     ]
     grouped = groupby(model_by_resource, lambda x: x[0])
     return {k: {val[1] for val in v} for k, v in grouped}

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -1,0 +1,133 @@
+from typing import Any, Dict, List, Set, Type, Union, get_args
+
+from more_itertools import first
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.expression import Delete, Insert
+
+from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_compile
+from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges
+from orchestrator.db.models import ProductBlockRelationTable, ProductBlockTable, SubscriptionInstanceTable
+from orchestrator.domain.base import ProductBlockModel, get_depends_on_product_block_type_list
+from orchestrator.types import is_list_type, is_union_type
+
+
+def get_product_block_id(block_name: str) -> Query:
+    return get_product_block_ids([block_name])
+
+
+def get_product_block_ids(block_names: Union[List[str], Set[str]]) -> Query:
+    return (
+        ProductBlockTable.query.where(ProductBlockTable.name.in_(block_names))
+        .with_entities(ProductBlockTable.product_block_id)
+        .scalar_subquery()
+    )
+
+
+def map_create_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> Dict[str, Type[ProductBlockModel]]:
+    existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
+    existing_product_blocks = [block_name[0] for block_name in existing_product_blocks]
+    return {
+        block_name: block for block_name, block in product_blocks.items() if block_name not in existing_product_blocks
+    }
+
+
+def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> List[str]:
+    product_blocks_names = product_blocks.keys()
+    existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
+    return [name[0] for name in existing_product_blocks if name[0] not in product_blocks_names]
+
+
+def get_product_block_names(block_class: Type[ProductBlockModel]) -> List[str]:
+    if is_list_type(block_class):
+        args = get_args(block_class)
+        if not args:
+            return []
+
+        list_block_class = first(args)
+        if is_union_type(list_block_class):
+            return [block.name for block in get_args(list_block_class) if not isinstance(None, block)]
+        return [list_block_class.name]
+    if is_union_type(block_class):
+        return [block.name for block in get_args(block_class) if not isinstance(None, block)]
+    return [block_class.name]
+
+
+def map_product_block_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
+    for block_name, block_class in changes.create_product_blocks.items():
+        for field_name in block_class._non_product_block_fields_.keys():
+            if field_name not in changes.create_resource_type_relations:
+                changes.create_resource_type_relations[field_name] = set()
+            changes.create_resource_type_relations[field_name].add(block_name)
+
+        product_blocks_in_model = block_class._get_depends_on_product_block_types()
+        product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
+        for product_block in product_blocks_types_in_model:
+            depends_on_block_names = get_product_block_names(product_block)
+            for depends_on_block_name in depends_on_block_names:
+                if depends_on_block_name not in changes.create_product_block_relations:
+                    changes.create_product_block_relations[depends_on_block_name] = set()
+                changes.create_product_block_relations[depends_on_block_name].add(block_name)
+    return changes
+
+
+def generate_create_product_blocks_sql(
+    create_product_blocks: Dict[str, Any], inputs: Dict[str, Dict[str, str]]
+) -> List[str]:
+    def create_product_block(name: str) -> str:
+        print(f"--- PRODUCT BLOCK ['{name}'] INPUTS ---")  # noqa: T001, T201
+        prefilled_values = inputs.get(name, {})
+        description = prefilled_values.get("description") or get_user_input("Product block description: ")
+        tag = prefilled_values.get("tag") or get_user_input("Product block tag: ")
+        return sql_compile(
+            Insert(ProductBlockTable).values(
+                {
+                    "name": name,
+                    "description": description,
+                    "tag": tag,
+                    "status": "active",
+                }
+            )
+        )
+
+    return [create_product_block(name) for name in create_product_blocks.keys()]
+
+
+def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List[str]:
+    if not delete_product_blocks:
+        return []
+    return [
+        sql_compile(
+            Delete(SubscriptionInstanceTable).where(
+                SubscriptionInstanceTable.product_block_id.in_(get_product_block_ids(delete_product_blocks))
+            )
+        ),
+        sql_compile(Delete(ProductBlockTable).where(ProductBlockTable.name.in_(delete_product_blocks))),
+    ]
+
+
+def generate_create_product_block_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+    def create_block_relation(depends_block_name: str, block_names: Set[str]) -> str:
+        depends_block_id_sql = get_product_block_id(depends_block_name)
+
+        def create_block_relation_dict(block_name: str) -> Dict[str, Query]:
+            block_id_sql = get_product_block_id(block_name)
+            return {"in_use_by_id": block_id_sql, "depends_on_id": depends_block_id_sql}
+
+        product_product_block_relation_dicts = [create_block_relation_dict(block_name) for block_name in block_names]
+        return sql_compile(Insert(ProductBlockRelationTable).values(product_product_block_relation_dicts))
+
+    return [create_block_relation(*item) for item in create_block_relations.items()]
+
+
+def generate_delete_product_block_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+    def delete_block_relation(delete_block_name: str, block_names: Set[str]) -> str:
+        in_use_by_ids_sql = get_product_block_ids(block_names)
+        delete_block_id_sql = get_product_block_id(delete_block_name)
+        return sql_compile(
+            Delete(ProductBlockRelationTable).where(
+                ProductBlockRelationTable.in_use_by_id.in_(in_use_by_ids_sql),
+                ProductBlockRelationTable.depends_on_id.in_(delete_block_id_sql),
+            )
+        )
+
+    return [delete_block_relation(*item) for item in delete_block_relations.items()]

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -55,7 +55,7 @@ def map_create_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]
     }
 
 
-def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> List[str]:
+def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> Set[str]:
     """Map product blocks to delete.
 
     Args:
@@ -64,7 +64,7 @@ def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]
     Returns: List of product block names to delete.
     """
     existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
-    return [name[0] for name in existing_product_blocks if name[0] not in product_blocks]
+    return {name[0] for name in existing_product_blocks if name[0] not in product_blocks}
 
 
 def map_product_block_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
@@ -124,7 +124,7 @@ def generate_create_product_blocks_sql(
     return [create_product_block(name) for name in create_product_blocks]
 
 
-def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List[str]:
+def generate_delete_product_blocks_sql(delete_product_blocks: Set[str]) -> List[str]:
     """Generate SQL to delete product blocks.
 
     Args:

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -80,17 +80,12 @@ def map_product_block_additional_relations(changes: DomainModelChanges) -> Domai
 
     for block_name, block_class in changes.create_product_blocks.items():
         for field_name in block_class._non_product_block_fields_.keys():
-            if field_name not in changes.create_resource_type_relations:
-                changes.create_resource_type_relations[field_name] = set()
-            changes.create_resource_type_relations[field_name].add(block_name)
+            changes.create_resource_type_relations.setdefault(field_name, set()).add(block_name)
 
         product_blocks_in_model = block_class._get_depends_on_product_block_types()
         product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
         for product_block in product_blocks_types_in_model:
-            depends_on_block_name = product_block.name
-            if depends_on_block_name not in changes.create_product_block_relations:
-                changes.create_product_block_relations[depends_on_block_name] = set()
-            changes.create_product_block_relations[depends_on_block_name].add(block_name)
+            changes.create_product_block_relations.setdefault(product_block.name, set()).add(block_name)
     return changes
 
 

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List, Set, Type, Union, get_args
+from typing import Any, Dict, List, Set, Type, Union
 
-from more_itertools import first
+from more_itertools import flatten
 from sqlalchemy.orm import Query
 from sqlalchemy.sql.expression import Delete, Insert
 
@@ -8,7 +8,6 @@ from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_comp
 from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges
 from orchestrator.db.models import ProductBlockRelationTable, ProductBlockTable, SubscriptionInstanceTable
 from orchestrator.domain.base import ProductBlockModel, get_depends_on_product_block_type_list
-from orchestrator.types import is_list_type, is_union_type
 
 
 def get_product_block_id(block_name: str) -> Query:
@@ -24,6 +23,13 @@ def get_product_block_ids(block_names: Union[List[str], Set[str]]) -> Query:
 
 
 def map_create_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> Dict[str, Type[ProductBlockModel]]:
+    """Map product blocks to create.
+
+    Args:
+        - product_blocks: Dict of product blocks mapped by product block name.
+
+    Returns: Dict of product blocks by product block name to create.
+    """
     existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
     existing_product_blocks = [block_name[0] for block_name in existing_product_blocks]
     return {
@@ -32,27 +38,29 @@ def map_create_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]
 
 
 def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> List[str]:
+    """Map product blocks to delete.
+
+    Args:
+        - product_blocks: Dict of product blocks mapped by product block name.
+
+    Returns: List of product block names to delete.
+    """
     product_blocks_names = product_blocks.keys()
     existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
     return [name[0] for name in existing_product_blocks if name[0] not in product_blocks_names]
 
 
-def get_product_block_names(block_class: Type[ProductBlockModel]) -> List[str]:
-    if is_list_type(block_class):
-        args = get_args(block_class)
-        if not args:
-            return []
-
-        list_block_class = first(args)
-        if is_union_type(list_block_class):
-            return [block.name for block in get_args(list_block_class) if not isinstance(None, block)]
-        return [list_block_class.name]
-    if is_union_type(block_class):
-        return [block.name for block in get_args(block_class) if not isinstance(None, block)]
-    return [block_class.name]
-
-
 def map_product_block_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
+    """Map additional relations for created product blocks.
+
+    Adds resource type and product block relations.
+
+    Args:
+        - changes: DomainModelChanges class with all changes.
+
+    Returns: Updated DomainModelChanges.
+    """
+
     for block_name, block_class in changes.create_product_blocks.items():
         for field_name in block_class._non_product_block_fields_.keys():
             if field_name not in changes.create_resource_type_relations:
@@ -62,17 +70,29 @@ def map_product_block_additional_relations(changes: DomainModelChanges) -> Domai
         product_blocks_in_model = block_class._get_depends_on_product_block_types()
         product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
         for product_block in product_blocks_types_in_model:
-            depends_on_block_names = get_product_block_names(product_block)
-            for depends_on_block_name in depends_on_block_names:
-                if depends_on_block_name not in changes.create_product_block_relations:
-                    changes.create_product_block_relations[depends_on_block_name] = set()
-                changes.create_product_block_relations[depends_on_block_name].add(block_name)
+            depends_on_block_name = product_block.name
+            if depends_on_block_name not in changes.create_product_block_relations:
+                changes.create_product_block_relations[depends_on_block_name] = set()
+            changes.create_product_block_relations[depends_on_block_name].add(block_name)
     return changes
 
 
 def generate_create_product_blocks_sql(
     create_product_blocks: Dict[str, Any], inputs: Dict[str, Dict[str, str]]
 ) -> List[str]:
+    """Generate sql strings to create product blocks.
+
+    Args:
+        - create_product_blocks: List of product block names.
+        - inputs: Optional Dict to prefill 'description' and 'tag' per product block.
+            - key: product block name.
+            - value: Dict with 'description' and 'tag'.
+                - key: product block property.
+                - value: value for the property.
+
+    Returns: List of sql strings to create product blocks.
+    """
+
     def create_product_block(name: str) -> str:
         print(f"--- PRODUCT BLOCK ['{name}'] INPUTS ---")  # noqa: T001, T201
         prefilled_values = inputs.get(name, {})
@@ -93,6 +113,14 @@ def generate_create_product_blocks_sql(
 
 
 def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List[str]:
+    """Generate sql strings to delete product blocks.
+
+    Args:
+        - delete_product_blocks: List of product block names.
+
+    Returns: List of sql strings to delete product blocks.
+    """
+
     if not delete_product_blocks:
         return []
     return [
@@ -106,6 +134,16 @@ def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List
 
 
 def generate_create_product_block_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate sql strings to create product block to product block relations.
+
+    Args:
+        - create_block_relations: Dict with product blocks by product block
+            - key: product block name.
+            - value: Set of product block names to relate with.
+
+    Returns: List of sql strings to create relation between product blocks.
+    """
+
     def create_block_relation(depends_block_name: str, block_names: Set[str]) -> str:
         depends_block_id_sql = get_product_block_id(depends_block_name)
 
@@ -119,7 +157,81 @@ def generate_create_product_block_relations_sql(create_block_relations: Dict[str
     return [create_block_relation(*item) for item in create_block_relations.items()]
 
 
+def generate_create_product_block_instance_relations_sql(product_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate sql strings strings to create resource type instance values for existing instances.
+
+    Args:
+        - product_block_relations: Dict with product blocks by resource type
+            - key: product block name.
+            - value: Set of product block names to relate to.
+
+    Returns: .
+    """
+
+    def create_subscription_instance_relations(depends_block_name: str, block_names: Set[str]) -> List[str]:
+        depends_block_id_sql = get_product_block_id(depends_block_name)
+
+        def map_subscription_instances(block_name: str) -> List[Dict[str, Union[str, Query]]]:
+            in_use_by_id_sql = get_product_block_id(block_name)
+            subscription_ids: list[SubscriptionInstanceTable] = (
+                SubscriptionInstanceTable.query.where(SubscriptionInstanceTable.product_block_id.in_(in_use_by_id_sql))
+                .with_entities(SubscriptionInstanceTable.subscription_id)
+                .all()
+            )
+            if not subscription_ids:
+                return []
+            return [
+                {"subscription_id": subscription_instance.subscription_id, "product_block_id": in_use_by_id_sql}
+                for subscription_instance in subscription_ids
+            ]
+
+        def map_subscription_instance_relations(block_name: str) -> List[Dict[str, Union[str, Query]]]:
+            block_id_sql = get_product_block_id(block_name)
+            subscription_instance_ids: list[SubscriptionInstanceTable] = (
+                SubscriptionInstanceTable.query.where(SubscriptionInstanceTable.product_block_id.in_(block_id_sql))
+                .with_entities(SubscriptionInstanceTable.subscription_instance_id)
+                .all()
+            )
+            if not subscription_instance_ids:
+                return []
+            return [
+                {"in_use_by_id": instance_id.subscription_instance_id, "depends_on_id": depends_block_id_sql}
+                for instance_id in subscription_instance_ids
+            ]
+
+        subscription_instance_dicts = list(
+            flatten([map_subscription_instances(block_name) for block_name in block_names])
+        )
+        subscription_relation_dicts = list(
+            flatten([map_subscription_instance_relations(block_name) for block_name in block_names])
+        )
+
+        subscription_instances = ""
+        if subscription_relation_dicts:
+            subscription_instances = sql_compile(Insert(SubscriptionInstanceTable).values(subscription_instance_dicts))
+
+        subscription_block_relations = ""
+        if subscription_relation_dicts:
+            subscription_block_relations = sql_compile(
+                Insert(SubscriptionInstanceTable).values(subscription_instance_dicts)
+            )
+        return [subscription_instances, subscription_block_relations]
+
+    rt_relations = flatten(create_subscription_instance_relations(*item) for item in product_block_relations.items())
+    return [rt_relation for rt_relation in rt_relations if rt_relation]
+
+
 def generate_delete_product_block_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate sql strings to delete product block to product blocks relations.
+
+    Args:
+        - delete_block_relations: Dict with product blocks by product block
+            - key: Product block name.
+            - value: Set of product block names to relate with.
+
+    Returns: List of sql strings to delete relations between product blocks.
+    """
+
     def delete_block_relation(delete_block_name: str, block_names: Set[str]) -> str:
         in_use_by_ids_sql = get_product_block_ids(block_names)
         delete_block_id_sql = get_product_block_id(delete_block_name)

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -45,9 +45,8 @@ def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]
 
     Returns: List of product block names to delete.
     """
-    product_blocks_names = product_blocks.keys()
     existing_product_blocks = ProductBlockTable.query.with_entities(ProductBlockTable.name).all()
-    return [name[0] for name in existing_product_blocks if name[0] not in product_blocks_names]
+    return [name[0] for name in existing_product_blocks if name[0] not in product_blocks]
 
 
 def map_product_block_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
@@ -80,7 +79,7 @@ def map_product_block_additional_relations(changes: DomainModelChanges) -> Domai
 def generate_create_product_blocks_sql(
     create_product_blocks: Dict[str, Any], inputs: Dict[str, Dict[str, str]]
 ) -> List[str]:
-    """Generate sql strings to create product blocks.
+    """Generate SQL to create product blocks.
 
     Args:
         - create_product_blocks: List of product block names.
@@ -90,7 +89,7 @@ def generate_create_product_blocks_sql(
                 - key: product block property.
                 - value: value for the property.
 
-    Returns: List of sql strings to create product blocks.
+    Returns: List of SQL to create product blocks.
     """
 
     def create_product_block(name: str) -> str:
@@ -109,16 +108,16 @@ def generate_create_product_blocks_sql(
             )
         )
 
-    return [create_product_block(name) for name in create_product_blocks.keys()]
+    return [create_product_block(name) for name in create_product_blocks]
 
 
 def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List[str]:
-    """Generate sql strings to delete product blocks.
+    """Generate SQL to delete product blocks.
 
     Args:
         - delete_product_blocks: List of product block names.
 
-    Returns: List of sql strings to delete product blocks.
+    Returns: List of SQL to delete product blocks.
     """
 
     if not delete_product_blocks:
@@ -134,14 +133,14 @@ def generate_delete_product_blocks_sql(delete_product_blocks: List[str]) -> List
 
 
 def generate_create_product_block_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
-    """Generate sql strings to create product block to product block relations.
+    """Generate SQL to create product block to product block relations.
 
     Args:
         - create_block_relations: Dict with product blocks by product block
             - key: product block name.
             - value: Set of product block names to relate with.
 
-    Returns: List of sql strings to create relation between product blocks.
+    Returns: List of SQL to create relation between product blocks.
     """
 
     def create_block_relation(depends_block_name: str, block_names: Set[str]) -> str:
@@ -158,7 +157,7 @@ def generate_create_product_block_relations_sql(create_block_relations: Dict[str
 
 
 def generate_create_product_block_instance_relations_sql(product_block_relations: Dict[str, Set[str]]) -> List[str]:
-    """Generate sql strings strings to create resource type instance values for existing instances.
+    """Generate SQL to create resource type instance values for existing instances.
 
     Args:
         - product_block_relations: Dict with product blocks by resource type
@@ -222,14 +221,14 @@ def generate_create_product_block_instance_relations_sql(product_block_relations
 
 
 def generate_delete_product_block_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
-    """Generate sql strings to delete product block to product blocks relations.
+    """Generate SQL to delete product block to product blocks relations.
 
     Args:
         - delete_block_relations: Dict with product blocks by product block
             - key: Product block name.
             - value: Set of product block names to relate with.
 
-    Returns: List of sql strings to delete relations between product blocks.
+    Returns: List of SQL to delete relations between product blocks.
     """
 
     def delete_block_relation(delete_block_name: str, block_names: Set[str]) -> str:

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -1,0 +1,101 @@
+from typing import Dict, List, Set, Type, Union
+
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.expression import Delete, Insert
+
+from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_compile
+from orchestrator.cli.domain_gen_helpers.product_block_helpers import get_product_block_id
+from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges
+from orchestrator.db.models import ProductTable, product_product_block_association
+from orchestrator.domain.base import SubscriptionModel, get_depends_on_product_block_type_list
+
+
+def get_product_id(product_name: str) -> Query:
+    return get_product_ids([product_name])
+
+
+def get_product_ids(product_names: Union[List[str], Set[str]]) -> Query:
+    return (
+        ProductTable.query.where(ProductTable.name.in_(product_names))
+        .with_entities(ProductTable.product_id)
+        .scalar_subquery()
+    )
+
+
+def map_product_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
+    for product_name, product_class in changes.create_products.items():
+        for field_name in product_class._non_product_block_fields_.keys():
+            if field_name not in changes.create_resource_types:
+                changes.create_product_fixed_inputs[field_name] = set()
+            changes.create_product_fixed_inputs[field_name].add(product_name)
+
+        product_blocks_in_model = product_class._get_depends_on_product_block_types()
+        product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
+        for product_block in product_blocks_types_in_model:
+            depends_on_block_name = product_block.name
+            if depends_on_block_name not in changes.create_product_to_block_relations:
+                changes.create_product_to_block_relations[depends_on_block_name] = set()
+            changes.create_product_to_block_relations[depends_on_block_name].add(product_name)
+    return changes
+
+
+def generate_create_products_sql(
+    create_products: Dict[str, Type[SubscriptionModel]], inputs: Dict[str, Dict[str, str]]
+) -> List[str]:
+    def create_product(name: str) -> str:
+        values = inputs.get(name, {})
+
+        print(f"--- PRODUCT ['{name}'] INPUTS ---")  # noqa: T001, T201
+        description = values.get("description") or get_user_input("Product description: ")
+        product_type = values.get("product_type") or get_user_input("Product type: ")
+        tag = values.get("tag") or get_user_input("Product tag: ")
+        return sql_compile(
+            Insert(ProductTable).values(
+                {
+                    "name": name,
+                    "description": description,
+                    "product_type": product_type,
+                    "tag": tag,
+                    "status": "active",
+                }
+            )
+        )
+
+    return [create_product(name) for name in create_products.keys()]
+
+
+def generate_delete_products_sql(delete_products: List[str]) -> List[str]:
+    def delete_product_block(product_name: str) -> str:
+        return sql_compile(Delete(ProductTable).where(ProductTable.name == product_name))
+
+    return [delete_product_block(product_name) for product_name in delete_products]
+
+
+def generate_create_product_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+    def create_block_relation(block_name: str, product_names: Set[str]) -> str:
+        block_id_sql = get_product_block_id(block_name)
+
+        def create_block_relation_dict(product_name: str) -> Dict[str, Query]:
+            product_id_sql = get_product_id(product_name)
+            return {"product_block_id": block_id_sql, "product_id": product_id_sql}
+
+        product_product_block_relation_dicts = [
+            create_block_relation_dict(product_name) for product_name in product_names
+        ]
+        return sql_compile(Insert(product_product_block_association).values(product_product_block_relation_dicts))
+
+    return [create_block_relation(*item) for item in create_block_relations.items()]
+
+
+def generate_delete_product_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+    def delete_block_relation(delete_block_name: str, product_names: Set[str]) -> str:
+        product_ids_sql = get_product_ids(product_names)
+        block_id_sql = get_product_block_id(delete_block_name)
+        return sql_compile(
+            Delete(product_product_block_association).where(
+                product_product_block_association.c.product_id.in_(product_ids_sql),
+                product_product_block_association.c.product_block_id.in_(block_id_sql),
+            )
+        )
+
+    return [delete_block_relation(*item) for item in delete_block_relations.items()]

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -1,12 +1,18 @@
 from typing import Dict, List, Set, Type, Union
 
+from more_itertools import flatten
 from sqlalchemy.orm import Query
 from sqlalchemy.sql.expression import Delete, Insert
 
 from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_compile
 from orchestrator.cli.domain_gen_helpers.product_block_helpers import get_product_block_id
 from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges
-from orchestrator.db.models import ProductTable, product_product_block_association
+from orchestrator.db.models import (
+    ProductTable,
+    SubscriptionInstanceTable,
+    SubscriptionTable,
+    product_product_block_association,
+)
 from orchestrator.domain.base import SubscriptionModel, get_depends_on_product_block_type_list
 
 
@@ -23,6 +29,16 @@ def get_product_ids(product_names: Union[List[str], Set[str]]) -> Query:
 
 
 def map_product_additional_relations(changes: DomainModelChanges) -> DomainModelChanges:
+    """Map additional relations for created products.
+
+    Adds resource type and product block relations.
+
+    Args:
+        - changes: DomainModelChanges class with all changes.
+
+    Returns: Updated DomainModelChanges.
+    """
+
     for product_name, product_class in changes.create_products.items():
         for field_name in product_class._non_product_block_fields_.keys():
             if field_name not in changes.create_resource_types:
@@ -42,6 +58,21 @@ def map_product_additional_relations(changes: DomainModelChanges) -> DomainModel
 def generate_create_products_sql(
     create_products: Dict[str, Type[SubscriptionModel]], inputs: Dict[str, Dict[str, str]]
 ) -> List[str]:
+    """Generate SQL to create products.
+
+    Args:
+        - create_products: Dict of SubscriptionModels by product name.
+            - key: product name.
+            - value: SubscriptionModel
+        - inputs: Optional Dict to add prefilled values for 'description', 'product_type' and 'tag' per product.
+            - key: product name.
+            - value: Dict with 'description', 'product_type' and 'tag'.
+                - key: product property.
+                - value: value for the property.
+
+    Returns: List of SQL strings to create products.
+    """
+
     def create_product(name: str) -> str:
         values = inputs.get(name, {})
 
@@ -65,6 +96,14 @@ def generate_create_products_sql(
 
 
 def generate_delete_products_sql(delete_products: List[str]) -> List[str]:
+    """Generate SQL to delete products.
+
+    Args:
+        - delete_products: List of product names.
+
+    Returns: List of SQL strings to delete products.
+    """
+
     def delete_product_block(product_name: str) -> str:
         return sql_compile(Delete(ProductTable).where(ProductTable.name == product_name))
 
@@ -72,6 +111,16 @@ def generate_delete_products_sql(delete_products: List[str]) -> List[str]:
 
 
 def generate_create_product_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to create product relations to product blocks.
+
+    Args:
+        - create_block_relations: Dict with product names by product block
+            - key: product block name.
+            - value: Set of product names to relate with.
+
+    Returns: List of SQL strings to create subscription instances.
+    """
+
     def create_block_relation(block_name: str, product_names: Set[str]) -> str:
         block_id_sql = get_product_block_id(block_name)
 
@@ -87,7 +136,61 @@ def generate_create_product_relations_sql(create_block_relations: Dict[str, Set[
     return [create_block_relation(*item) for item in create_block_relations.items()]
 
 
+def generate_create_product_instance_relations_sql(product_to_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to create subscription instances for existing subscriptions.
+
+    Args:
+        - product_to_block_relations: Dict with product blocks by resource type
+            - key: product block name.
+            - value: Set of product names to relate with.
+
+    Returns: List of SQL strings to create subscription instances.
+    """
+
+    def create_subscription_instance_relations(block_name: str, product_names: Set[str]) -> str:
+        product_block_id = get_product_block_id(block_name)
+
+        def map_subscription_instance_relations(product_name: str) -> List[Dict[str, Union[str, Query]]]:
+            product_id_sql = get_product_id(product_name)
+            subscription_ids = (
+                SubscriptionTable.query.where(SubscriptionTable.product_id.in_(product_id_sql))
+                .with_entities(SubscriptionTable.subscription_id)
+                .all()
+            )
+            if not subscription_ids:
+                return []
+            return [
+                {"subscription_id": subscription_id[0], "product_block_id": product_block_id}
+                for subscription_id in subscription_ids
+            ]
+
+        subscription_relation_dicts = list(
+            flatten([map_subscription_instance_relations(block_name) for block_name in product_names])
+        )
+        subscription_block_relations = ""
+        if subscription_relation_dicts:
+            subscription_block_relations = sql_compile(
+                Insert(SubscriptionInstanceTable).values(subscription_relation_dicts)
+            )
+        return subscription_block_relations
+
+    create_subscription_instance_sqls = [
+        create_subscription_instance_relations(*item) for item in product_to_block_relations.items()
+    ]
+    return [sub_instance_sql for sub_instance_sql in create_subscription_instance_sqls if sub_instance_sql]
+
+
 def generate_delete_product_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to delete product to product blocks relations.
+
+    Args:
+        - delete_block_relations: Dict with product blocks by resource type
+            - key: product block name.
+            - value: Set of product names to relate with.
+
+    Returns: List of SQL strings to delete relations between product and product block.
+    """
+
     def delete_block_relation(delete_block_name: str, product_names: Set[str]) -> str:
         product_ids_sql = get_product_ids(product_names)
         block_id_sql = get_product_block_id(delete_block_name)

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -89,7 +89,7 @@ def generate_create_products_sql(
     return [create_product(name) for name in create_products.keys()]
 
 
-def generate_delete_products_sql(delete_products: List[str]) -> List[str]:
+def generate_delete_products_sql(delete_products: Set[str]) -> List[str]:
     """Generate SQL to delete products.
 
     Args:

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -75,7 +75,6 @@ def generate_create_products_sql(
 
     def create_product(name: str) -> str:
         values = inputs.get(name, {})
-
         print(f"--- PRODUCT ['{name}'] INPUTS ---")  # noqa: T001, T201
         description = values.get("description") or get_user_input("Product description: ")
         product_type = values.get("product_type") or get_user_input("Product type: ")

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -41,17 +41,12 @@ def map_product_additional_relations(changes: DomainModelChanges) -> DomainModel
 
     for product_name, product_class in changes.create_products.items():
         for field_name in product_class._non_product_block_fields_.keys():
-            if field_name not in changes.create_product_fixed_inputs:
-                changes.create_product_fixed_inputs[field_name] = set()
-            changes.create_product_fixed_inputs[field_name].add(product_name)
+            changes.create_product_fixed_inputs.setdefault(field_name, set()).add(product_name)
 
         product_blocks_in_model = product_class._get_depends_on_product_block_types()
         product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
         for product_block in product_blocks_types_in_model:
-            depends_on_block_name = product_block.name
-            if depends_on_block_name not in changes.create_product_to_block_relations:
-                changes.create_product_to_block_relations[depends_on_block_name] = set()
-            changes.create_product_to_block_relations[depends_on_block_name].add(product_name)
+            changes.create_product_to_block_relations.setdefault(product_block.name, set()).add(product_name)
     return changes
 
 

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -42,7 +42,7 @@ def map_create_resource_types(resource_types: Dict[str, Set[str]], updated_resou
         .with_entities(ResourceTypeTable.resource_type)
         .all()
     )
-    existing_resource_types = [*[r_type[0] for r_type in existing_resource_types], *updated_resource_types.values()]
+    existing_resource_types = {*[r_type[0] for r_type in existing_resource_types], *updated_resource_types.values()}
     return [rt for rt in resource_type_names if rt not in existing_resource_types]
 
 
@@ -142,10 +142,10 @@ def map_delete_resource_types(
         .all()
     )
     existing_names = [r_type[0] for r_type in existing_resource_types if r_type[0] in resource_type_names]
-    rt_with_existing_instances = [
+    rt_with_existing_instances = {
         *find_resource_within_blocks(existing_names, product_blocks),
         *updated_resource_types,
-    ]
+    }
     return [name for name in existing_names if name not in rt_with_existing_instances]
 
 

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Set, Type, Union
 
+import structlog
 from more_itertools import flatten
 from sqlalchemy.orm import Query
 from sqlalchemy.sql.expression import Delete, Insert, Update
@@ -13,6 +14,8 @@ from orchestrator.db.models import (
     product_block_resource_type_association,
 )
 from orchestrator.domain.base import ProductBlockModel
+
+logger = structlog.get_logger(__name__)
 
 
 def get_resource_type(resource_type: str) -> Query:
@@ -283,8 +286,9 @@ def generate_create_resource_type_instance_values_sql(
                     CROSS JOIN subscription_instance_ids
                     WHERE resource_types.resource_type = '{1}'
             """
-
-            return query.format(block_name, resource_type, value)
+            sql_string = query.format(block_name, resource_type, value)
+            logger.debug("generated SQL", sql_string=sql_string)
+            return sql_string
 
         return [map_subscription_instance_relations(block_name) for block_name in block_names]
 

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -28,6 +28,14 @@ def get_resource_types(resource_types: Union[List[str], Set[str]]) -> Query:
 
 
 def map_create_resource_types(resource_types: Dict[str, Set[str]], updated_resource_types: Dict[str, str]) -> List[str]:
+    """Map resource types to create.
+
+    Args:
+        - resource_types: List of resource type names.
+        - updated_resource_types: List of resource types that get renamed and don't need to be created.
+
+    Returns: List of resource type names that can be created.
+    """
     resource_type_names = resource_types.keys()
     existing_resource_types = (
         ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_type_names))
@@ -41,27 +49,16 @@ def map_create_resource_types(resource_types: Dict[str, Set[str]], updated_resou
 def find_resource_within_blocks(
     resource_type_names: List[str], product_blocks: Dict[str, Type[ProductBlockModel]]
 ) -> Set[str]:
+    """Find resource types within product blocks.
+
+    Args:
+        - resource_type_names: List of resource type names.
+        - product_blocks: Dict of product blocks mapped by product block name, used to check if the resource type still exists in a product block that hasn't changed.
+
+    Returns: List of the resource_type_names that are found within product blocks.
+    """
     keys = list(flatten([product_block._non_product_block_fields_.keys() for product_block in product_blocks.values()]))
     return {field_name for field_name in keys if field_name in resource_type_names}
-
-
-def map_delete_resource_types(
-    resource_types: Dict[str, Set[str]],
-    updated_resource_type_names: List[str],
-    product_blocks: Dict[str, Type[ProductBlockModel]],
-) -> List[str]:
-    resource_type_names = resource_types.keys()
-    existing_resource_types = (
-        ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_type_names))
-        .with_entities(ResourceTypeTable.resource_type)
-        .all()
-    )
-    existing_names = [r_type[0] for r_type in existing_resource_types if r_type[0] in resource_type_names]
-    rt_with_existing_instances = [
-        *find_resource_within_blocks(existing_names, product_blocks),
-        *updated_resource_type_names,
-    ]
-    return [name for name in existing_names if name not in rt_with_existing_instances]
 
 
 def map_update_resource_types(
@@ -69,6 +66,26 @@ def map_update_resource_types(
     product_blocks: Dict[str, Type[ProductBlockModel]],
     inputs: Dict[str, Dict[str, str]],
 ) -> Dict[str, str]:
+    """Map resource types to update.
+
+    Args:
+        - block_diffs: Dict with product block differences.
+            - key: product block name
+            - value: Dict with differences between model and database.
+                - key: difference name, 'missing_resource_types_in_model' and 'missing_resource_types_in_db' are used to check if a resource type can be renamed.
+                - value: Set of resource type names.
+        - product_blocks: Dict of product blocks mapped by product block name, used to check if the resource type still exists in a product block.
+        - inputs: Optional Dict to specify if resource type should update.
+            - key: Resource type name.
+            - value: Dict with update 'y/n'.
+                - key: 'update' key.
+                - value: 'y/n'.
+
+    Returns: Dict with resource types that can be updated.
+        - key: old resource type name.
+        - value: new resource type name.
+    """
+
     updates = {}
     print("--- UPDATE RESOURCE TYPE DECISIONS ---")  # noqa: T001, T201
     for diff in block_diffs.values():
@@ -104,9 +121,50 @@ def map_update_resource_types(
     return updates
 
 
+def map_delete_resource_types(
+    resource_types: Dict[str, Set[str]],
+    updated_resource_types: List[str],
+    product_blocks: Dict[str, Type[ProductBlockModel]],
+) -> List[str]:
+    """Map resource types to delete.
+
+    Args:
+        - resource_types: List of resource type names.
+        - updated_resource_types: List of resource types that get renamed and shouldn't be deleted.
+        - product_blocks: Dict of product blocks mapped by product block name, used to check if the resource type still exists in a product block.
+
+    Returns: List of resource type names that can be deleted.
+    """
+    resource_type_names = resource_types.keys()
+    existing_resource_types = (
+        ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_type_names))
+        .with_entities(ResourceTypeTable.resource_type)
+        .all()
+    )
+    existing_names = [r_type[0] for r_type in existing_resource_types if r_type[0] in resource_type_names]
+    rt_with_existing_instances = [
+        *find_resource_within_blocks(existing_names, product_blocks),
+        *updated_resource_types,
+    ]
+    return [name for name in existing_names if name not in rt_with_existing_instances]
+
+
 def generate_create_resource_types_sql(
     resource_types: List[str], inputs: Dict[str, Dict[str, str]], revert: bool = False
 ) -> List[str]:
+    """Generate SQL to create resource types.
+
+    Args:
+        - resource_types: List of resource type names.
+        - inputs: Optional Dict to add default value to the resource type for existing product block instances.
+            - key: Resource type name.
+            - value: Dict with product block by default value.
+                - key: Product block name.
+                - value: Default value for the resource type.
+
+    Returns: List of SQL strings to create resource type.
+    """
+
     def create_resource_type(resource_type: str) -> str:
         if revert:
             description = (
@@ -128,6 +186,16 @@ def generate_create_resource_types_sql(
 
 
 def generate_update_resource_types_sql(resource_types: Dict[str, str]) -> List[str]:
+    """Generate SQL to update resource types.
+
+    Args:
+        - resource_types: Dict with new resource type name by old resource type name.
+            - key: old resource type name.
+            - value: new resource type name.
+
+    Returns: List of SQL strings to update resource types.
+    """
+
     def update_resource_type(old_rt_name: str, new_rt_name: str) -> str:
         return sql_compile(
             Update(ResourceTypeTable)
@@ -139,6 +207,13 @@ def generate_update_resource_types_sql(resource_types: Dict[str, str]) -> List[s
 
 
 def generate_delete_resource_types_sql(resource_types: List[str]) -> List[str]:
+    """Generate SQL to delete resource types.
+
+    Args:
+        - resource_types: List of resource type names.
+
+    Returns: List of SQL strings to delete resource types.
+    """
     if not resource_types:
         return []
     return [
@@ -151,49 +226,95 @@ def generate_delete_resource_types_sql(resource_types: List[str]) -> List[str]:
     ]
 
 
-def generate_create_resource_type_relations_sql(
-    resource_types: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]]
-) -> List[str]:
-    def create_resource_type_relation(resource_type: str, block_names: Set[str]) -> List[str]:
+def generate_create_resource_type_relations_sql(resource_types: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to create resource type relations.
+
+    Args:
+        - resource_types: Dict with product blocks by resource type
+            - key: Resource type name.
+            - value: Set of product block names to relate with.
+
+    Returns: List of SQL strings to create relation between product blocks and resource type.
+    """
+
+    def create_resource_type_relation(resource_type: str, block_names: Set[str]) -> str:
         resource_type_id_sql = get_resource_type(resource_type)
 
         def create_block_relation_dict(block_name: str) -> Dict[str, Union[str, Query]]:
             block_id_sql = get_product_block_id(block_name)
             return {"resource_type_id": resource_type_id_sql, "product_block_id": block_id_sql}
 
-        def create_subscription_block_relations(block_name: str) -> List[Dict[str, Union[str, Query]]]:
+        block_relation_dicts = [create_block_relation_dict(block_name) for block_name in block_names]
+        return sql_compile(Insert(product_block_resource_type_association).values(block_relation_dicts))
+
+    return [create_resource_type_relation(*item) for item in resource_types.items()]
+
+
+def generate_create_resource_type_instance_relations_sql(
+    resource_types: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]]
+) -> List[str]:
+    """Generate SQL to create resource type instance values for existing instances.
+
+    Args:
+        - resource_types: Dict with product blocks by resource type
+            - key: Resource type name.
+            - value: Set of product block names to relate with.
+        - inputs: Optional Dict to add default value to the resource type for existing product block instances.
+            - key: Resource type name.
+            - value: Dict with product block by default value.
+                - key: Product block name.
+                - value: Default value for the resource type.
+
+    Returns: List of SQL strings to create subscription instance values for existing product block instances.
+    """
+
+    def create_resource_type_instance_relations(resource_type: str, block_names: Set[str]) -> List[str]:
+        def map_subscription_instance_relations(block_name: str) -> str:
             input_value = inputs.get(resource_type, {}).get(block_name) or inputs.get(resource_type, {}).get("value")
             value = input_value or get_user_input(
                 f"Resource type ['{resource_type}'] default value for block ['{block_name}']: "
             )
 
-            block_id_sql = get_product_block_id(block_name)
-            subscription_instance_ids = (
-                SubscriptionInstanceTable.query.where(SubscriptionInstanceTable.product_block_id.in_(block_id_sql))
-                .with_entities(SubscriptionInstanceTable.subscription_instance_id)
-                .all()
-            )
-            return [
-                {"resource_type_id": resource_type_id_sql, "subscription_instance_id": instance_id[0], "value": value}
-                for instance_id in subscription_instance_ids
-            ]
+            query = """
+                    WITH subscription_instance_ids AS (
+                        SELECT subscription_instances.subscription_instance_id
+                        FROM   subscription_instances
+                        WHERE  subscription_instances.product_block_id IN (
+                            SELECT product_blocks.product_block_id
+                            FROM   product_blocks
+                            WHERE  product_blocks.name = '{0}'
+                        )
+                    )
 
-        block_relation_dicts = [create_block_relation_dict(block_name) for block_name in block_names]
-        subscription_relation_dicts = list(
-            flatten([create_subscription_block_relations(block_name) for block_name in block_names])
-        )
-        block_relations = sql_compile(Insert(product_block_resource_type_association).values(block_relation_dicts))
-        if subscription_relation_dicts:
-            subscription_block_relations = sql_compile(
-                Insert(SubscriptionInstanceValueTable).values(subscription_relation_dicts)
-            )
-            return [block_relations, subscription_block_relations]
-        return [block_relations]
+                    INSERT INTO
+                        subscription_instance_values (subscription_instance_id, resource_type_id, value)
+                    SELECT
+                        subscription_instance_ids.subscription_instance_id,
+                        resource_types.resource_type_id,
+                        '{2}'
+                    FROM resource_types
+                    CROSS JOIN subscription_instance_ids
+                    WHERE resource_types.resource_type = '{1}'
+            """
 
-    return list(flatten([create_resource_type_relation(*item) for item in resource_types.items()]))
+            return query.format(block_name, resource_type, value)
+
+        return [map_subscription_instance_relations(block_name) for block_name in block_names]
+
+    return list(flatten([create_resource_type_instance_relations(*item) for item in resource_types.items()]))
 
 
 def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str, Set[str]]) -> List[str]:
+    """Generate SQL to delete resource type relations and its instance values.
+
+    Args:
+        - resource_types: Dict with product blocks by resource type
+            - key: Resource type name.
+            - value: Set of product block names to relate with.
+
+    Returns: List of SQL strings to delete relations between product blocks and resource type.
+    """
+
     def delete_resource_type_relation(resource_type: str, block_names: Set[str]) -> List[str]:
         block_ids_sql = get_product_block_ids(block_names)
         resource_type_id_sql = get_resource_type(resource_type)

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -87,7 +87,7 @@ def map_update_resource_types(
     """
 
     updates = {}
-    print("--- UPDATE RESOURCE TYPE DECISIONS ---")  # noqa: T001, T201
+    print("--- UPDATE RESOURCE TYPE DECISIONS ('No'= create and delete) ---")  # noqa: T001, T201
     for diff in block_diffs.values():
         db_props = list(diff.get("missing_resource_types_in_model", set()))
         model_props = list(diff.get("missing_resource_types_in_db", set()))

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -57,7 +57,7 @@ def find_resource_within_blocks(
 
     Returns: List of the resource_type_names that are found within product blocks.
     """
-    keys = list(flatten([product_block._non_product_block_fields_.keys() for product_block in product_blocks.values()]))
+    keys = flatten([product_block._non_product_block_fields_.keys() for product_block in product_blocks.values()])
     return {field_name for field_name in keys if field_name in resource_type_names}
 
 
@@ -108,16 +108,16 @@ def map_update_resource_types(
                     updates[db_props[0]] = model_props[0]
 
     for name, diff in block_diffs.items():
-        db_props = list(diff.get("missing_resource_types_in_model", set()))
-        model_props = list(diff.get("missing_resource_types_in_db", set()))
+        db_props_set = diff.get("missing_resource_types_in_model", set())
+        model_props_set = diff.get("missing_resource_types_in_db", set())
 
         for key, value in updates.items():
-            if key in db_props and value in model_props:
-                db_props.remove(key)
-                model_props.remove(value)
+            if key in db_props_set and value in model_props_set:
+                db_props_set.remove(key)
+                model_props_set.remove(value)
 
-        block_diffs[name]["missing_resource_types_in_model"] = set(db_props)
-        block_diffs[name]["missing_resource_types_in_db"] = set(model_props)
+        block_diffs[name]["missing_resource_types_in_model"] = db_props_set
+        block_diffs[name]["missing_resource_types_in_db"] = model_props_set
     return updates
 
 
@@ -250,7 +250,7 @@ def generate_create_resource_type_relations_sql(resource_types: Dict[str, Set[st
     return [create_resource_type_relation(*item) for item in resource_types.items()]
 
 
-def generate_create_resource_type_instance_relations_sql(
+def generate_create_resource_type_instance_values_sql(
     resource_types: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]]
 ) -> List[str]:
     """Generate SQL to create resource type instance values for existing instances.

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -190,7 +190,7 @@ def generate_create_resource_type_relations_sql(
             return [block_relations, subscription_block_relations]
         return [block_relations]
 
-    return flatten([create_resource_type_relation(*item) for item in resource_types.items()])
+    return list(flatten([create_resource_type_relation(*item) for item in resource_types.items()]))
 
 
 def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str, Set[str]]) -> List[str]:
@@ -217,4 +217,4 @@ def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str,
             ),
         ]
 
-    return flatten([delete_resource_type_relation(*item) for item in delete_resource_types.items()])
+    return list(flatten([delete_resource_type_relation(*item) for item in delete_resource_types.items()]))

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -1,0 +1,220 @@
+from typing import Dict, List, Set, Type, Union
+
+from more_itertools import flatten
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.expression import Delete, Insert, Update
+
+from orchestrator.cli.domain_gen_helpers.helpers import get_user_input, sql_compile
+from orchestrator.cli.domain_gen_helpers.product_block_helpers import get_product_block_id, get_product_block_ids
+from orchestrator.db.models import (
+    ResourceTypeTable,
+    SubscriptionInstanceTable,
+    SubscriptionInstanceValueTable,
+    product_block_resource_type_association,
+)
+from orchestrator.domain.base import ProductBlockModel
+
+
+def get_resource_type(resource_type: str) -> Query:
+    return get_resource_types([resource_type])
+
+
+def get_resource_types(resource_types: Union[List[str], Set[str]]) -> Query:
+    return (
+        ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_types))
+        .with_entities(ResourceTypeTable.resource_type_id)
+        .scalar_subquery()
+    )
+
+
+def map_create_resource_types(resource_types: Dict[str, Set[str]], updated_resource_types: Dict[str, str]) -> List[str]:
+    resource_type_names = resource_types.keys()
+    existing_resource_types = (
+        ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_type_names))
+        .with_entities(ResourceTypeTable.resource_type)
+        .all()
+    )
+    existing_resource_types = [*[r_type[0] for r_type in existing_resource_types], *updated_resource_types.values()]
+    return [rt for rt in resource_type_names if rt not in existing_resource_types]
+
+
+def find_resource_within_blocks(
+    resource_type_names: List[str], product_blocks: Dict[str, Type[ProductBlockModel]]
+) -> Set[str]:
+    keys = list(flatten([product_block._non_product_block_fields_.keys() for product_block in product_blocks.values()]))
+    return {field_name for field_name in keys if field_name in resource_type_names}
+
+
+def map_delete_resource_types(
+    resource_types: Dict[str, Set[str]],
+    updated_resource_type_names: List[str],
+    product_blocks: Dict[str, Type[ProductBlockModel]],
+) -> List[str]:
+    resource_type_names = resource_types.keys()
+    existing_resource_types = (
+        ResourceTypeTable.query.where(ResourceTypeTable.resource_type.in_(resource_type_names))
+        .with_entities(ResourceTypeTable.resource_type)
+        .all()
+    )
+    existing_names = [r_type[0] for r_type in existing_resource_types if r_type[0] in resource_type_names]
+    rt_with_existing_instances = [
+        *find_resource_within_blocks(existing_names, product_blocks),
+        *updated_resource_type_names,
+    ]
+    return [name for name in existing_names if name not in rt_with_existing_instances]
+
+
+def map_update_resource_types(
+    block_diffs: Dict[str, Dict[str, Set[str]]],
+    product_blocks: Dict[str, Type[ProductBlockModel]],
+    inputs: Dict[str, Dict[str, str]],
+) -> Dict[str, str]:
+    updates = {}
+    print("--- UPDATE RESOURCE TYPE DECISIONS ---")  # noqa: T001, T201
+    for diff in block_diffs.values():
+        db_props = list(diff.get("missing_resource_types_in_model", set()))
+        model_props = list(diff.get("missing_resource_types_in_db", set()))
+
+        if (len(db_props) == 1 and len(model_props) == 1) and db_props[0] not in updates:
+            existing_in_blocks = find_resource_within_blocks(db_props, product_blocks)
+            if not existing_in_blocks:
+                prefilled_val = inputs.get(db_props[0], {}).get("update")
+                should_update = (
+                    prefilled_val
+                    if prefilled_val
+                    else get_user_input(
+                        f"Change resource type {db_props} to {model_props} (y/N): ",
+                        "n",
+                    )
+                )
+                if should_update == "y":
+                    updates[db_props[0]] = model_props[0]
+
+    for name, diff in block_diffs.items():
+        db_props = list(diff.get("missing_resource_types_in_model", set()))
+        model_props = list(diff.get("missing_resource_types_in_db", set()))
+
+        for key, value in updates.items():
+            if key in db_props and value in model_props:
+                db_props.remove(key)
+                model_props.remove(value)
+
+        block_diffs[name]["missing_resource_types_in_model"] = set(db_props)
+        block_diffs[name]["missing_resource_types_in_db"] = set(model_props)
+    return updates
+
+
+def generate_create_resource_types_sql(
+    resource_types: List[str], inputs: Dict[str, Dict[str, str]], revert: bool = False
+) -> List[str]:
+    def create_resource_type(resource_type: str) -> str:
+        if revert:
+            description = (
+                ResourceTypeTable.query.where(ResourceTypeTable.resource_type == resource_type)
+                .with_entities(ResourceTypeTable.description)
+                .one()
+            )[0]
+        else:
+            print(f"--- RESOURCE TYPE ['{resource_type}'] ---")  # noqa: T001, T201
+            description = inputs.get(resource_type, {}).get("description") or get_user_input(
+                "Resource type description: "
+            )
+
+        return sql_compile(
+            Insert(ResourceTypeTable).values({"resource_type": resource_type, "description": description})
+        )
+
+    return [create_resource_type(resource_type) for resource_type in resource_types]
+
+
+def generate_update_resource_types_sql(resource_types: Dict[str, str]) -> List[str]:
+    def update_resource_type(old_rt_name: str, new_rt_name: str) -> str:
+        return sql_compile(
+            Update(ResourceTypeTable)
+            .where(ResourceTypeTable.resource_type == old_rt_name)
+            .values(resource_type=new_rt_name)
+        )
+
+    return [update_resource_type(*item) for item in resource_types.items()]
+
+
+def generate_delete_resource_types_sql(resource_types: List[str]) -> List[str]:
+    if not resource_types:
+        return []
+    return [
+        sql_compile(
+            Delete(SubscriptionInstanceValueTable).where(
+                SubscriptionInstanceValueTable.resource_type_id.in_(get_resource_types(resource_types))
+            )
+        ),
+        sql_compile(Delete(ResourceTypeTable).where(ResourceTypeTable.resource_type.in_(resource_types))),
+    ]
+
+
+def generate_create_resource_type_relations_sql(
+    resource_types: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]]
+) -> List[str]:
+    def create_resource_type_relation(resource_type: str, block_names: Set[str]) -> List[str]:
+        resource_type_id_sql = get_resource_type(resource_type)
+
+        def create_block_relation_dict(block_name: str) -> Dict[str, Union[str, Query]]:
+            block_id_sql = get_product_block_id(block_name)
+            return {"resource_type_id": resource_type_id_sql, "product_block_id": block_id_sql}
+
+        def create_subscription_block_relations(block_name: str) -> List[Dict[str, Union[str, Query]]]:
+            input_value = inputs.get(resource_type, {}).get(block_name) or inputs.get(resource_type, {}).get("value")
+            value = input_value or get_user_input(
+                f"Resource type ['{resource_type}'] default value for block ['{block_name}']: "
+            )
+
+            block_id_sql = get_product_block_id(block_name)
+            subscription_instance_ids = (
+                SubscriptionInstanceTable.query.where(SubscriptionInstanceTable.product_block_id.in_(block_id_sql))
+                .with_entities(SubscriptionInstanceTable.subscription_instance_id)
+                .all()
+            )
+            return [
+                {"resource_type_id": resource_type_id_sql, "subscription_instance_id": instance_id[0], "value": value}
+                for instance_id in subscription_instance_ids
+            ]
+
+        block_relation_dicts = [create_block_relation_dict(block_name) for block_name in block_names]
+        subscription_relation_dicts = list(
+            flatten([create_subscription_block_relations(block_name) for block_name in block_names])
+        )
+        block_relations = sql_compile(Insert(product_block_resource_type_association).values(block_relation_dicts))
+        if subscription_relation_dicts:
+            subscription_block_relations = sql_compile(
+                Insert(SubscriptionInstanceValueTable).values(subscription_relation_dicts)
+            )
+            return [block_relations, subscription_block_relations]
+        return [block_relations]
+
+    return flatten([create_resource_type_relation(*item) for item in resource_types.items()])
+
+
+def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str, Set[str]]) -> List[str]:
+    def delete_resource_type_relation(resource_type: str, block_names: Set[str]) -> List[str]:
+        block_ids_sql = get_product_block_ids(block_names)
+        resource_type_id_sql = get_resource_type(resource_type)
+        subscription_instance_id_sql = (
+            SubscriptionInstanceTable.query.where(SubscriptionInstanceTable.subscription_instance_id.in_(block_ids_sql))
+            .with_entities(SubscriptionInstanceTable.subscription_instance_id)
+            .scalar_subquery()
+        )
+        return [
+            sql_compile(
+                Delete(product_block_resource_type_association).where(
+                    product_block_resource_type_association.c.product_block_id.in_(block_ids_sql),
+                    product_block_resource_type_association.c.resource_type_id == resource_type_id_sql,
+                )
+            ),
+            sql_compile(
+                Delete(SubscriptionInstanceValueTable).where(
+                    SubscriptionInstanceValueTable.subscription_instance_id.in_(subscription_instance_id_sql),
+                    product_block_resource_type_association.c.resource_type_id == resource_type_id_sql,
+                )
+            ),
+        ]
+
+    return flatten([delete_resource_type_relation(*item) for item in delete_resource_types.items()])

--- a/orchestrator/cli/domain_gen_helpers/types.py
+++ b/orchestrator/cli/domain_gen_helpers/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Type
+from typing import Dict, Set, Type
 
 from pydantic import BaseModel
 
@@ -7,22 +7,27 @@ from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
 
 class DomainModelChanges(BaseModel):
     create_products: Dict[str, Type[SubscriptionModel]] = {}
-    delete_products: List[str] = []
+    delete_products: Set[str] = set()
     create_product_to_block_relations: Dict[str, Set[str]] = {}
     delete_product_to_block_relations: Dict[str, Set[str]] = {}
     create_product_blocks: Dict[str, Type[ProductBlockModel]] = {}
-    delete_product_blocks: List[str] = []
+    delete_product_blocks: Set[str] = set()
     create_product_block_relations: Dict[str, Set[str]] = {}
     delete_product_block_relations: Dict[str, Set[str]] = {}
     create_product_fixed_inputs: Dict[str, Set[str]] = {}
     update_product_fixed_inputs: Dict[str, Dict[str, str]] = {}
     delete_product_fixed_inputs: Dict[str, Set[str]] = {}
-    create_resource_types: List[str] = []
-    update_resource_types: Dict[str, str] = {}
-    delete_resource_types: List[str] = []
+    create_resource_types: Set[str] = set()
+    rename_resource_types: Dict[str, str] = {}
+    delete_resource_types: Set[str] = set()
     create_resource_type_relations: Dict[str, Set[str]] = {}
     delete_resource_type_relations: Dict[str, Set[str]] = {}
 
 
 class DuplicateException(Exception):
     pass
+
+
+class ModelUpdates(BaseModel):
+    fixed_inputs: Dict[str, Dict[str, str]] = {}
+    resource_types: Dict[str, str] = {}

--- a/orchestrator/cli/domain_gen_helpers/types.py
+++ b/orchestrator/cli/domain_gen_helpers/types.py
@@ -1,0 +1,28 @@
+from typing import Dict, List, Set, Type
+
+from pydantic import BaseModel
+
+from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
+
+
+class DomainModelChanges(BaseModel):
+    create_products: Dict[str, Type[SubscriptionModel]] = {}
+    delete_products: List[str] = []
+    create_product_to_block_relations: Dict[str, Set[str]] = {}
+    delete_product_to_block_relations: Dict[str, Set[str]] = {}
+    create_product_blocks: Dict[str, Type[ProductBlockModel]] = {}
+    delete_product_blocks: List[str] = []
+    create_product_block_relations: Dict[str, Set[str]] = {}
+    delete_product_block_relations: Dict[str, Set[str]] = {}
+    create_product_fixed_inputs: Dict[str, Set[str]] = {}
+    update_product_fixed_inputs: Dict[str, Dict[str, str]] = {}
+    delete_product_fixed_inputs: Dict[str, Set[str]] = {}
+    create_resource_types: List[str] = []
+    update_resource_types: Dict[str, str] = {}
+    delete_resource_types: List[str] = []
+    create_resource_type_relations: Dict[str, Set[str]] = {}
+    delete_resource_type_relations: Dict[str, Set[str]] = {}
+
+
+class DuplicateException(Exception):
+    pass

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+
+"""Create migration for models based on diff_product_in_database.
+
+$ PYTHONPATH=. python bin/list_workflows
+
+"""
+from typing import Dict, List, Set, Tuple, Type, Union
+from uuid import UUID
+
+import structlog
+
+from orchestrator.cli.domain_gen_helpers.fixed_input_helpers import (
+    generate_create_fixed_inputs_sql,
+    generate_delete_fixed_inputs_sql,
+    generate_update_fixed_inputs_sql,
+    map_update_fixed_inputs,
+)
+from orchestrator.cli.domain_gen_helpers.helpers import (
+    map_create_fixed_inputs,
+    map_create_product_block_relations,
+    map_create_resource_type_relations,
+    map_delete_fixed_inputs,
+    map_delete_product_block_relations,
+    map_delete_resource_type_relations,
+)
+from orchestrator.cli.domain_gen_helpers.product_block_helpers import (
+    generate_create_product_block_relations_sql,
+    generate_create_product_blocks_sql,
+    generate_delete_product_block_relations_sql,
+    generate_delete_product_blocks_sql,
+    map_create_product_blocks,
+    map_delete_product_blocks,
+    map_product_block_additional_relations,
+)
+from orchestrator.cli.domain_gen_helpers.product_helpers import (
+    generate_create_product_relations_sql,
+    generate_create_products_sql,
+    generate_delete_product_relations_sql,
+    generate_delete_products_sql,
+    map_product_additional_relations,
+)
+from orchestrator.cli.domain_gen_helpers.resource_type_helpers import (
+    generate_create_resource_type_relations_sql,
+    generate_create_resource_types_sql,
+    generate_delete_resource_type_relations_sql,
+    generate_delete_resource_types_sql,
+    generate_update_resource_types_sql,
+    map_create_resource_types,
+    map_delete_resource_types,
+    map_update_resource_types,
+)
+from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges
+from orchestrator.db import init_database
+from orchestrator.db.models import ProductTable
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.domain.base import ProductBlockModel, SubscriptionModel, get_depends_on_product_block_type_list
+from orchestrator.settings import app_settings
+
+logger = structlog.get_logger(__name__)
+
+
+def should_skip(product_name: str) -> bool:
+    return any(name in product_name.lower() for name in app_settings.SKIP_MODEL_FOR_MIGRATION_DB_DIFF)
+
+
+def map_product_blocks_in_class(
+    model_class: Union[Type[SubscriptionModel], Type[ProductBlockModel]],
+    product_blocks: Dict[str, Type[ProductBlockModel]],
+) -> Dict[str, Type[ProductBlockModel]]:
+    """Create mapping of all existing product block models related to a model.
+
+    Args:
+        - model_class: a product class (SubscriptionModel) or product block class (ProductBlockModel).
+
+    Returns a Dict with product block models by product block name.
+    """
+    product_blocks_types_in_model = get_depends_on_product_block_type_list(
+        model_class._get_depends_on_product_block_types()
+    )
+
+    new_blocks = {
+        block.name: block for block in product_blocks_types_in_model if block.name not in product_blocks.keys()
+    }
+    product_blocks = {**product_blocks, **new_blocks}
+
+    blocks_map = {
+        name: block_cls
+        for block in new_blocks.values()
+        for name, block_cls in map_product_blocks_in_class(block, product_blocks).items()
+        if block_cls.name not in product_blocks.keys()
+    }
+    return {**product_blocks, **blocks_map}
+
+
+def map_product_blocks(product_classes: List[Type[SubscriptionModel]]) -> Dict[str, Type[ProductBlockModel]]:
+    """Create mapping of all existing product block models related to products.
+
+    Args:
+        - product_classes: List of product classes.
+
+    Returns a Dict with product block models by product block name.
+    """
+
+    product_blocks: Dict[str, Type[ProductBlockModel]] = {}
+    for product_class in product_classes:
+        product_blocks = {**product_blocks, **map_product_blocks_in_class(product_class, product_blocks)}
+    return product_blocks
+
+
+def map_differences_unique(
+    registered_products: Dict[str, Type[SubscriptionModel]], existing_products: List[Tuple[str, UUID]]
+) -> Dict[str, Dict[str, Dict[str, Set[str]]]]:
+    """Create a unique map for products and product block differences from the database.
+
+    Args:
+        - existing_products: List with tuples of product name and its uuid that exist in the database.
+
+    Returns a dict with product and product block differences from the database without duplicates.
+    """
+    model_diffs: Dict[str, Dict[str, Dict[str, Set[str]]]] = {"products": {}, "blocks": {}}
+
+    for product_name, product_id in existing_products:
+        if should_skip(product_name) or product_name not in registered_products.keys():
+            continue
+
+        product_class = registered_products[product_name]
+        if diff := product_class.diff_product_in_database(product_id):
+            model_diffs["products"][product_name] = {**diff[product_name], "missing_in_depends_on_blocks": []}  # type: ignore
+
+            if missing_in_depends_on_blocks := diff[product_name].get("missing_in_depends_on_blocks"):
+                model_diff_keys = model_diffs["blocks"].keys()
+                # since missing_in_depends_on_blocks is always a dict the type is ignored.
+                new_model_diffs = {
+                    name: diff for name, diff in missing_in_depends_on_blocks.items() if name not in model_diff_keys  # type: ignore
+                }
+                model_diffs["blocks"] = {**model_diffs["blocks"], **new_model_diffs}  # type: ignore
+    return model_diffs
+
+
+def map_changes(
+    model_diffs: Dict[str, Dict[str, Dict[str, Set[str]]]],
+    products: Dict[str, Type[SubscriptionModel]],
+    product_blocks: Dict[str, Type[ProductBlockModel]],
+    db_product_names: List[str],
+    inputs: Dict[str, Dict[str, str]],
+) -> DomainModelChanges:
+    create_products = {name: model for name, model in products.items() if name not in db_product_names}
+    delete_products = [name for name in db_product_names if name not in SUBSCRIPTION_MODEL_REGISTRY.keys()]
+
+    # updates need to go before create or deletes.
+    update_product_fixed_inputs = map_update_fixed_inputs(model_diffs["products"])
+    update_resource_types = map_update_resource_types(model_diffs["blocks"], product_blocks, inputs)
+
+    create_resource_type_relations = map_create_resource_type_relations(model_diffs["blocks"])
+    delete_resource_type_relations = map_delete_resource_type_relations(model_diffs["blocks"])
+
+    changes = DomainModelChanges(
+        create_products=create_products,
+        delete_products=delete_products,
+        create_product_fixed_inputs=map_create_fixed_inputs(model_diffs["products"]),
+        update_product_fixed_inputs=update_product_fixed_inputs,
+        delete_product_fixed_inputs=map_delete_fixed_inputs(model_diffs["products"]),
+        create_product_to_block_relations=map_create_product_block_relations(model_diffs["products"]),
+        delete_product_to_block_relations=map_delete_product_block_relations(model_diffs["products"]),
+        update_resource_types=update_resource_types,
+        delete_resource_types=map_delete_resource_types(
+            delete_resource_type_relations, list(update_resource_types.keys()), product_blocks
+        ),
+        create_resource_type_relations=create_resource_type_relations,
+        delete_resource_type_relations=delete_resource_type_relations,
+        create_product_blocks=map_create_product_blocks(product_blocks),
+        delete_product_blocks=map_delete_product_blocks(product_blocks),
+        create_product_block_relations=map_create_product_block_relations(model_diffs["blocks"]),
+        delete_product_block_relations=map_delete_product_block_relations(model_diffs["blocks"]),
+    )
+
+    changes = map_product_additional_relations(changes)
+    changes = map_product_block_additional_relations(changes)
+    changes.create_resource_types = map_create_resource_types(
+        changes.create_resource_type_relations, update_resource_types
+    )
+    return changes
+
+
+def generate_upgrade_sql(changes: DomainModelChanges, inputs: Dict[str, Dict[str, str]]) -> List[str]:
+    return [
+        *generate_update_fixed_inputs_sql(changes.update_product_fixed_inputs),
+        *generate_update_resource_types_sql(changes.update_resource_types),
+        *generate_delete_resource_type_relations_sql(changes.delete_resource_type_relations),
+        *generate_delete_product_block_relations_sql(changes.delete_product_block_relations),
+        *generate_delete_product_relations_sql(changes.delete_product_to_block_relations),
+        *generate_delete_resource_types_sql(changes.delete_resource_types),
+        *generate_delete_product_blocks_sql(changes.delete_product_blocks),
+        *generate_delete_fixed_inputs_sql(changes.delete_product_fixed_inputs),
+        *generate_delete_products_sql(changes.delete_products),
+        *generate_create_products_sql(changes.create_products, inputs),
+        *generate_create_fixed_inputs_sql(changes.create_product_fixed_inputs, inputs),
+        *generate_create_product_blocks_sql(changes.create_product_blocks, inputs),
+        *generate_create_resource_types_sql(changes.create_resource_types, inputs),
+        *generate_create_product_relations_sql(changes.create_product_to_block_relations),
+        *generate_create_resource_type_relations_sql(changes.create_resource_type_relations, inputs),
+        *generate_create_product_block_relations_sql(changes.create_product_block_relations),
+    ]
+
+
+def generate_downgrade_sql(changes: DomainModelChanges) -> List[str]:
+    sql_revert_create_fixed_inputs = generate_delete_fixed_inputs_sql(changes.create_product_fixed_inputs)
+
+    update_revert_map = {
+        name: {new: old for old, new in updates.items()}
+        for name, updates in changes.update_product_fixed_inputs.items()
+    }
+    sql_revert_update_fixed_inputs = generate_update_fixed_inputs_sql(update_revert_map)
+    sql_revert_delete_fixed_inputs = generate_create_fixed_inputs_sql(
+        changes.delete_product_fixed_inputs, {}, revert=True
+    )
+
+    sql_revert_create_resource_type_relations = generate_delete_resource_type_relations_sql(
+        changes.create_resource_type_relations
+    )
+    sql_revert_create_resource_types = generate_delete_resource_types_sql(changes.create_resource_types)
+    sql_revert_update_resource_types = generate_update_resource_types_sql(
+        {new: old for old, new in changes.update_resource_types.items()}
+    )
+
+    sql_revert_create_product_product_block_relations = generate_delete_product_relations_sql(
+        changes.create_product_to_block_relations,
+    )
+    sql_revert_create_product_block_depends_blocks = generate_delete_product_block_relations_sql(
+        changes.create_product_block_relations
+    )
+
+    sql_revert_create_product_blocks = generate_delete_product_blocks_sql(list(changes.create_product_blocks.keys()))
+    sql_revert_create_products = generate_delete_products_sql(list(changes.create_products.keys()))
+
+    return [
+        *sql_revert_create_resource_type_relations,
+        *sql_revert_create_resource_types,
+        *sql_revert_create_product_product_block_relations,
+        *sql_revert_create_product_block_depends_blocks,
+        *sql_revert_create_fixed_inputs,
+        *sql_revert_create_product_blocks,
+        *sql_revert_create_products,
+        *sql_revert_delete_fixed_inputs,
+        *sql_revert_update_resource_types,
+        *sql_revert_update_fixed_inputs,
+    ]
+
+
+def create_domain_models_migration_sql(inputs: Dict[str, Dict[str, str]]) -> Tuple[List[str], List[str]]:
+    """Create tuple with list for upgrade and downgrade sql statements based on SubscriptionModel.diff_product_in_database.
+
+    You will be prompted with inputs for new models and resource type updates.
+
+    Args:
+        - inputs: dict with pre-defined input values
+
+    Returns tuple:
+        - list of upgrade sql statements in string format.
+        - list of downgrade sql statements in string format.
+    """
+
+    if not app_settings.TESTING:
+        init_database(app_settings)
+
+    existing_products: List[Tuple[str, UUID]] = list(
+        ProductTable.query.with_entities(ProductTable.name, ProductTable.product_id)
+    )
+    db_product_names: List[str] = [product_name for product_name, _ in existing_products]
+
+    products = SUBSCRIPTION_MODEL_REGISTRY
+    product_blocks = map_product_blocks(list(SUBSCRIPTION_MODEL_REGISTRY.values()))
+    model_diffs = map_differences_unique(products, existing_products)
+
+    changes = map_changes(model_diffs, products, product_blocks, db_product_names, inputs)
+
+    logger.debug("create_products", create_products=changes.create_products)
+    logger.debug("create_product_fixed_inputs", create_product_fixed_inputs=changes.create_product_fixed_inputs)
+    logger.debug("update_product_fixed_inputs", update_product_fixed_inputs=changes.update_product_fixed_inputs)
+    logger.debug("delete_product_fixed_inputs", delete_product_fixed_inputs=changes.delete_product_fixed_inputs)
+    logger.debug(
+        "create_product_to_block_relations", create_product_to_block_relations=changes.create_product_to_block_relations
+    )
+    logger.debug(
+        "delete_product_to_block_relations", delete_product_to_block_relations=changes.delete_product_to_block_relations
+    )
+    logger.debug("create_resource_types", create_resource_types=changes.create_resource_types)
+    logger.debug("update_resource_types", update_resource_types=changes.update_resource_types)
+    logger.debug("delete_resource_types", delete_resource_types=changes.delete_resource_types)
+    logger.debug(
+        "create_resource_type_relations", create_resource_type_relations=changes.create_resource_type_relations
+    )
+    logger.debug(
+        "delete_resource_type_relations", delete_resource_type_relations=changes.delete_resource_type_relations
+    )
+    logger.debug("create_product_blocks", create_blocks=changes.create_product_blocks)
+    logger.debug("delete_product_blocks", delete_blocks=changes.delete_product_blocks)
+    logger.debug(
+        "create_product_block_relations", create_product_block_relations=changes.create_product_block_relations
+    )
+    logger.debug(
+        "delete_product_block_relations", delete_product_block_relations=changes.delete_product_block_relations
+    )
+
+    sql_upgrade_stmts = generate_upgrade_sql(changes, inputs)
+    sql_downgrade_stmts = generate_downgrade_sql(changes)
+
+    return sql_upgrade_stmts, sql_downgrade_stmts

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -206,27 +206,27 @@ def generate_upgrade_sql(changes: DomainModelChanges, inputs: Dict[str, Dict[str
 
     Returns: List of SQL strings to upgrade the database.
     """
-    return [
-        *generate_update_fixed_inputs_sql(changes.update_product_fixed_inputs),
-        *generate_update_resource_types_sql(changes.update_resource_types),
-        *generate_delete_resource_type_relations_sql(changes.delete_resource_type_relations),
-        *generate_delete_product_block_relations_sql(changes.delete_product_block_relations),
-        *generate_delete_product_relations_sql(changes.delete_product_to_block_relations),
-        *generate_delete_resource_types_sql(changes.delete_resource_types),
-        *generate_delete_product_blocks_sql(changes.delete_product_blocks),
-        *generate_delete_fixed_inputs_sql(changes.delete_product_fixed_inputs),
-        *generate_delete_products_sql(changes.delete_products),
-        *generate_create_products_sql(changes.create_products, inputs),
-        *generate_create_fixed_inputs_sql(changes.create_product_fixed_inputs, inputs),
-        *generate_create_product_blocks_sql(changes.create_product_blocks, inputs),
-        *generate_create_resource_types_sql(changes.create_resource_types, inputs),
-        *generate_create_product_relations_sql(changes.create_product_to_block_relations),
-        *generate_create_product_block_relations_sql(changes.create_product_block_relations),
-        *generate_create_resource_type_relations_sql(changes.create_resource_type_relations),
-        *generate_create_product_instance_relations_sql(changes.create_product_to_block_relations),
-        *generate_create_product_block_instance_relations_sql(changes.create_product_block_relations),
-        *generate_create_resource_type_instance_values_sql(changes.create_resource_type_relations, inputs),
-    ]
+    return (
+        generate_update_fixed_inputs_sql(changes.update_product_fixed_inputs)
+        + generate_update_resource_types_sql(changes.update_resource_types)
+        + generate_delete_resource_type_relations_sql(changes.delete_resource_type_relations)
+        + generate_delete_product_block_relations_sql(changes.delete_product_block_relations)
+        + generate_delete_product_relations_sql(changes.delete_product_to_block_relations)
+        + generate_delete_resource_types_sql(changes.delete_resource_types)
+        + generate_delete_product_blocks_sql(changes.delete_product_blocks)
+        + generate_delete_fixed_inputs_sql(changes.delete_product_fixed_inputs)
+        + generate_delete_products_sql(changes.delete_products)
+        + generate_create_products_sql(changes.create_products, inputs)
+        + generate_create_fixed_inputs_sql(changes.create_product_fixed_inputs, inputs)
+        + generate_create_product_blocks_sql(changes.create_product_blocks, inputs)
+        + generate_create_resource_types_sql(changes.create_resource_types, inputs)
+        + generate_create_product_relations_sql(changes.create_product_to_block_relations)
+        + generate_create_product_block_relations_sql(changes.create_product_block_relations)
+        + generate_create_resource_type_relations_sql(changes.create_resource_type_relations)
+        + generate_create_product_instance_relations_sql(changes.create_product_to_block_relations)
+        + generate_create_product_block_instance_relations_sql(changes.create_product_block_relations)
+        + generate_create_resource_type_instance_values_sql(changes.create_resource_type_relations, inputs)
+    )
 
 
 def generate_downgrade_sql(changes: DomainModelChanges) -> List[str]:
@@ -268,18 +268,18 @@ def generate_downgrade_sql(changes: DomainModelChanges) -> List[str]:
     sql_revert_create_product_blocks = generate_delete_product_blocks_sql(list(changes.create_product_blocks.keys()))
     sql_revert_create_products = generate_delete_products_sql(list(changes.create_products.keys()))
 
-    return [
-        *sql_revert_create_resource_type_relations,
-        *sql_revert_create_resource_types,
-        *sql_revert_create_product_product_block_relations,
-        *sql_revert_create_product_block_depends_blocks,
-        *sql_revert_create_fixed_inputs,
-        *sql_revert_create_product_blocks,
-        *sql_revert_create_products,
-        *sql_revert_delete_fixed_inputs,
-        *sql_revert_update_resource_types,
-        *sql_revert_update_fixed_inputs,
-    ]
+    return (
+        sql_revert_create_resource_type_relations
+        + sql_revert_create_resource_types
+        + sql_revert_create_product_product_block_relations
+        + sql_revert_create_product_block_depends_blocks
+        + sql_revert_create_fixed_inputs
+        + sql_revert_create_product_blocks
+        + sql_revert_create_products
+        + sql_revert_delete_fixed_inputs
+        + sql_revert_update_resource_types
+        + sql_revert_update_fixed_inputs
+    )
 
 
 def create_domain_models_migration_sql(inputs: Dict[str, Dict[str, str]]) -> Tuple[List[str], List[str]]:

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -117,6 +117,7 @@ def map_differences_unique(
     """Create a unique map for products and product block differences from the database.
 
     Args:
+        - registered_products: Dict with product models by product name.
         - existing_products: List with tuples of product name and its uuid that exist in the database.
 
     Returns a dict with product and product block differences from the database without duplicates.

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -133,7 +133,9 @@ def map_differences_unique(
             if missing_in_depends_on_blocks := diff[product_name].get("missing_in_depends_on_blocks"):
                 # since missing_in_depends_on_blocks is always a dict the type is ignored.
                 new_model_diffs: Dict[str, Dict[str, Set[str]]] = {
-                    name: diff for name, diff in missing_in_depends_on_blocks.items() if name not in model_diffs["blocks"]  # type: ignore
+                    name: diff  # type: ignore
+                    for name, diff in missing_in_depends_on_blocks.items()  # type: ignore
+                    if name not in model_diffs["blocks"]
                 }
                 model_diffs["blocks"] = {**model_diffs["blocks"], **new_model_diffs}
     return model_diffs

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -309,34 +309,26 @@ def create_domain_models_migration_sql(inputs: Dict[str, Dict[str, str]]) -> Tup
 
     changes = map_changes(model_diffs, products, product_blocks, db_product_names, inputs)
 
-    logger.debug("create_products", create_products=changes.create_products)
-    logger.debug("delete_products", delete_products=changes.delete_products)
-    logger.debug("create_product_fixed_inputs", create_product_fixed_inputs=changes.create_product_fixed_inputs)
-    logger.debug("update_product_fixed_inputs", update_product_fixed_inputs=changes.update_product_fixed_inputs)
-    logger.debug("delete_product_fixed_inputs", delete_product_fixed_inputs=changes.delete_product_fixed_inputs)
-    logger.debug(
+    logger.info("create_products", create_products=changes.create_products)
+    logger.info("delete_products", delete_products=changes.delete_products)
+    logger.info("create_product_fixed_inputs", create_product_fixed_inputs=changes.create_product_fixed_inputs)
+    logger.info("update_product_fixed_inputs", update_product_fixed_inputs=changes.update_product_fixed_inputs)
+    logger.info("delete_product_fixed_inputs", delete_product_fixed_inputs=changes.delete_product_fixed_inputs)
+    logger.info(
         "create_product_to_block_relations", create_product_to_block_relations=changes.create_product_to_block_relations
     )
-    logger.debug(
+    logger.info(
         "delete_product_to_block_relations", delete_product_to_block_relations=changes.delete_product_to_block_relations
     )
-    logger.debug("create_resource_types", create_resource_types=changes.create_resource_types)
-    logger.debug("update_resource_types", update_resource_types=changes.update_resource_types)
-    logger.debug("delete_resource_types", delete_resource_types=changes.delete_resource_types)
-    logger.debug(
-        "create_resource_type_relations", create_resource_type_relations=changes.create_resource_type_relations
-    )
-    logger.debug(
-        "delete_resource_type_relations", delete_resource_type_relations=changes.delete_resource_type_relations
-    )
-    logger.debug("create_product_blocks", create_blocks=changes.create_product_blocks)
-    logger.debug("delete_product_blocks", delete_blocks=changes.delete_product_blocks)
-    logger.debug(
-        "create_product_block_relations", create_product_block_relations=changes.create_product_block_relations
-    )
-    logger.debug(
-        "delete_product_block_relations", delete_product_block_relations=changes.delete_product_block_relations
-    )
+    logger.info("create_resource_types", create_resource_types=changes.create_resource_types)
+    logger.info("rename_resource_types", rename_resource_types=changes.update_resource_types)
+    logger.info("delete_resource_types", delete_resource_types=changes.delete_resource_types)
+    logger.info("create_resource_type_relations", create_resource_type_relations=changes.create_resource_type_relations)
+    logger.info("delete_resource_type_relations", delete_resource_type_relations=changes.delete_resource_type_relations)
+    logger.info("create_product_blocks", create_blocks=changes.create_product_blocks)
+    logger.info("delete_product_blocks", delete_blocks=changes.delete_product_blocks)
+    logger.info("create_product_block_relations", create_product_block_relations=changes.create_product_block_relations)
+    logger.info("delete_product_block_relations", delete_product_block_relations=changes.delete_product_block_relations)
 
     sql_upgrade_stmts = generate_upgrade_sql(changes, inputs)
     sql_downgrade_stmts = generate_downgrade_sql(changes)

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -479,6 +479,23 @@ class ProductBlockModelMeta(ModelMetaclass):
         return super().__call__(*args, **kwargs)
 
 
+def get_depends_on_product_block_type_list(
+    product_block_types: Dict[str, Union[Type["ProductBlockModel"], Tuple[Type["ProductBlockModel"]]]]
+) -> List[Type["ProductBlockModel"]]:
+    product_blocks_types_in_model = []
+    for product_block_type in product_block_types.values():
+        if is_union_type(product_block_type):
+            for union_product_block_type in get_args(product_block_type):  # type: ignore
+                if not isinstance(None, union_product_block_type):
+                    product_blocks_types_in_model.append(union_product_block_type)
+        else:
+            product_blocks_types_in_model.append(product_block_type)
+
+    if product_blocks_types_in_model and isinstance(first(product_blocks_types_in_model), tuple):
+        return one(product_blocks_types_in_model)
+    return product_blocks_types_in_model
+
+
 class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
     r"""Base class for all product block models.
 
@@ -562,7 +579,7 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
         cls.__doc__ = make_product_block_docstring(cls, lifecycle)
 
     @classmethod
-    def diff_product_block_in_database(cls) -> Dict[str, Any]:
+    def diff_product_block_in_database(cls) -> Dict[str, Set[str]]:
         """Return any differences between the attrs defined on the domain model and those on product blocks in the database.
 
         This is only needed to check if the domain model and database models match which would be done during testing...
@@ -577,21 +594,9 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
         product_blocks_in_db = {pb.name for pb in product_block_db.depends_on} if product_block_db else set()
 
         product_blocks_in_model = cls._get_depends_on_product_block_types()
-        product_blocks_types_in_model = []
+        product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
 
-        # expand Union types for comparison to the DB
-        for product_block_type in product_blocks_in_model.values():
-            if is_union_type(product_block_type):
-                for union_product_block_type in get_args(product_block_type):  # type: ignore
-                    product_blocks_types_in_model.append(union_product_block_type)
-            else:
-                product_blocks_types_in_model.append(product_block_type)
-
-        if product_blocks_types_in_model and isinstance(first(product_blocks_types_in_model), tuple):
-            # There may only be one in the type if it is a Tuple
-            product_blocks_in_model = set(flatten(map(attrgetter("__names__"), one(product_blocks_types_in_model))))  # type: ignore
-        else:
-            product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
+        product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
 
         missing_product_blocks_in_db = product_blocks_in_model - product_blocks_in_db  # type: ignore
         missing_product_blocks_in_model = product_blocks_in_db - product_blocks_in_model  # type: ignore
@@ -627,7 +632,7 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
                     continue
                 missing_data.update(product_block_model.diff_product_block_in_database())
 
-        diff = {
+        diff: Dict[str, Set[str]] = {
             k: v
             for k, v in {
                 "missing_product_blocks_in_db": missing_product_blocks_in_db,
@@ -1025,7 +1030,7 @@ class SubscriptionModel(DomainModel):
         cls.__doc__ = make_subscription_model_docstring(cls, lifecycle)
 
     @classmethod
-    def diff_product_in_database(cls, product_id: UUID) -> Dict[str, Any]:
+    def diff_product_in_database(cls, product_id: UUID) -> Dict[str, Dict[str, Union[Set[str], Dict[str, Set[str]]]]]:
         """Return any differences between the attrs defined on the domain model and those on product blocks in the database.
 
         This is only needed to check if the domain model and database models match which would be done during testing...
@@ -1034,20 +1039,9 @@ class SubscriptionModel(DomainModel):
         product_blocks_in_db = {pb.name for pb in product_db.product_blocks} if product_db else set()
 
         product_blocks_in_model = cls._get_depends_on_product_block_types()
-        product_blocks_types_in_model = []
-        # expand Union types for comparison to the DB
-        for product_block_type in product_blocks_in_model.values():
-            if is_union_type(product_block_type):
-                for union_product_block_type in get_args(product_block_type):  # type: ignore
-                    if not isinstance(None, union_product_block_type):
-                        product_blocks_types_in_model.append(union_product_block_type)
-            else:
-                product_blocks_types_in_model.append(product_block_type)
+        product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
 
-        if product_blocks_types_in_model and isinstance(first(product_blocks_types_in_model), tuple):
-            product_blocks_in_model = set(flatten(map(attrgetter("__names__"), one(product_blocks_types_in_model))))  # type: ignore
-        else:
-            product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
+        product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
 
         missing_product_blocks_in_db = product_blocks_in_model - product_blocks_in_db  # type: ignore
         missing_product_blocks_in_model = product_blocks_in_db - product_blocks_in_model  # type: ignore
@@ -1071,11 +1065,11 @@ class SubscriptionModel(DomainModel):
             missing_fixed_inputs_in_model=missing_fixed_inputs_in_model,
         )
 
-        missing_data_depends_on_blocks: Dict[str, Any] = {}
+        missing_data_depends_on_blocks: Dict[str, Set[str]] = {}
         for product_block_in_model in product_blocks_types_in_model:
             missing_data_depends_on_blocks.update(product_block_in_model.diff_product_block_in_database())
 
-        diff = {
+        diff: Dict[str, Union[Set[str], Dict[str, Set[str]]]] = {
             k: v
             for k, v in {
                 "missing_product_blocks_in_db": missing_product_blocks_in_db,
@@ -1087,7 +1081,7 @@ class SubscriptionModel(DomainModel):
             if v
         }
 
-        missing_data = {}
+        missing_data: Dict[str, Dict[str, Union[Set[str], Dict[str, Set[str]]]]] = {}
         if diff:
             missing_data[product_db.name] = diff
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -621,16 +621,10 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
         )
 
         missing_data: Dict[str, Any] = {}
-        if product_blocks_types_in_model and isinstance(first(product_blocks_types_in_model), tuple):
-            for product_block_model in one(product_blocks_types_in_model):
-                if product_block_model.name == cls.name or product_block_model.name in missing_data:
-                    continue
-                missing_data.update(product_block_model.diff_product_block_in_database())
-        else:
-            for product_block_model in product_blocks_types_in_model:
-                if product_block_model.name == cls.name or product_block_model.name in missing_data:
-                    continue
-                missing_data.update(product_block_model.diff_product_block_in_database())
+        for product_block_model in product_blocks_types_in_model:
+            if product_block_model.name == cls.name or product_block_model.name in missing_data:
+                continue
+            missing_data.update(product_block_model.diff_product_block_in_database())
 
         diff: Dict[str, Set[str]] = {
             k: v

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -64,6 +64,7 @@ class AppSettings(BaseSettings):
     ENABLE_WEBSOCKETS: bool = True
     DISABLE_INSYNC_CHECK: bool = False
     DEFAULT_PRODUCT_WORKFLOWS: List[str] = ["modify_note"]
+    SKIP_MODEL_FOR_MIGRATION_DB_DIFF: List[str] = []
 
 
 class Oauth2Settings(BaseSettings):

--- a/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
@@ -1,0 +1,387 @@
+import json
+from typing import List, Union
+
+from sqlalchemy.exc import IntegrityError
+
+from orchestrator.cli.database import migrate_domain_models
+from orchestrator.db import db
+from orchestrator.db.models import ResourceTypeTable
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
+from orchestrator.types import SubscriptionLifecycle
+
+
+def test_migrate_domain_models_new_resource_type(
+    test_product_type_one, test_product_sub_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTestUpdated(
+        ProductBlockModel, product_block_name="ProductBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        int_field: int
+        str_field: str
+        list_field: List[int]
+        new_int_field: int
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps({"new_int_field": {"ProductBlockOneForTest": "1", "description": "test new int field type"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    assert len(upgrade_sql) == 3
+    assert len(downgrade_sql) == 4
+
+    def test_expected_before_upgrade():
+        subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+        assert "new_int_field" not in subscription.block.dict()
+
+        new_int_field_resource = ResourceTypeTable.query.where(ResourceTypeTable.resource_type == "new_int_field").all()
+        assert not new_int_field_resource
+
+    test_expected_before_upgrade()
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    updated_subscription = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert updated_subscription.block
+    assert updated_subscription.block.new_int_field == 1
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    test_expected_before_upgrade()
+
+
+def test_migrate_domain_models_update_resource_type(
+    test_product_type_one, test_product_sub_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTestUpdated(
+        ProductBlockModel, product_block_name="ProductBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        str_field: str
+        int_field: int
+        new_list_field: List[int]
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps({"list_field": {"update": "y"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    assert len(upgrade_sql) == 1
+    assert "UPDATE" in upgrade_sql[0]
+    assert len(downgrade_sql) == 1
+    assert "UPDATE" in downgrade_sql[0]
+
+    def test_expected_before_upgrade():
+        subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+        assert subscription.block.list_field == [10, 20, 30]
+        assert "new_int_field" not in subscription.block.dict()
+
+        new_int_field_resource = ResourceTypeTable.query.where(ResourceTypeTable.resource_type == "new_int_field").all()
+        assert not new_int_field_resource
+
+    test_expected_before_upgrade()
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    updated_subscription = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert updated_subscription.block.new_list_field == [10, 20, 30]
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    test_expected_before_upgrade()
+
+
+def test_migrate_domain_models_create_and_update_resource_type(test_product_type_one, product_one_subscription_1):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    class SubBlockOneForTestNewResource(
+        ProductBlockModel, product_block_name="SubBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        int_field: int
+        str_field: str
+        new_list_field: List[int]
+
+    class ProductBlockOneForTestUpdated(
+        ProductBlockModel, product_block_name="ProductBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        sub_block: SubBlockOneForTestNewResource
+        sub_block_2: SubBlockOneForTestNewResource
+        sub_block_list: List[SubBlockOneForTestNewResource]
+        str_field: str
+        int_field: int
+        new_list_field: List[int]
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps(
+        {
+            "new_list_field": {"SubBlockOneForTest": "5"},
+            "list_field": {"update": "y"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    assert len(upgrade_sql) == 3
+    assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
+    assert len(downgrade_sql) == 3
+    assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]
+
+    def test_expected_before_upgrade():
+        subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+        assert subscription.block.list_field == [10, 20, 30]
+        assert "new_int_field" not in subscription.block.dict()
+        assert "new_int_field" not in subscription.block.sub_block.dict()
+
+        new_int_field_resource = ResourceTypeTable.query.where(ResourceTypeTable.resource_type == "new_int_field").all()
+        assert not new_int_field_resource
+
+    test_expected_before_upgrade()
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    updated_instance = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert updated_instance.block.new_list_field == [10, 20, 30]
+    assert updated_instance.block.sub_block.new_list_field == [5]
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    test_expected_before_upgrade()
+
+
+def test_migrate_domain_models_create_and_update_and_delete_resource_type(
+    test_product_type_sub_list_union,
+    product_sub_list_union_subscription_1,
+):
+    _, _, ProductSubListUnion = test_product_type_sub_list_union
+
+    class SubBlockOneForTestChanged(
+        ProductBlockModel, product_block_name="SubBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        changed_int_field: int
+
+    class SubBlockTwoForTestChanged(
+        ProductBlockModel, product_block_name="SubBlockTwoForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        int_field_2: int
+        changed_int_field: int
+
+    class ProductBlockWithListUnionForTestNew(
+        ProductBlockModel,
+        product_block_name="ProductBlockWithListUnionForTest",
+        lifecycle=[SubscriptionLifecycle.ACTIVE],
+    ):
+        list_union_blocks: List[Union[SubBlockTwoForTestChanged, SubBlockOneForTestChanged]]
+        changed_int_field: int
+        str_field: str
+        list_field: List[int]
+
+    class ProductSubListUnionTest(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_block: ProductBlockWithListUnionForTestNew
+
+    SUBSCRIPTION_MODEL_REGISTRY["ProductSubListUnion"] = ProductSubListUnionTest
+
+    inputs = json.dumps(
+        {
+            "changed_int_field": {"SubBlockOneForTest": "5", "SubBlockTwoForTest": "2"},
+            "int_field": {"update": "y"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    assert len(upgrade_sql) == 5
+    assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
+    assert len(downgrade_sql) == 3
+    assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]
+
+    def test_expected_before_upgrade():
+        subscription = ProductSubListUnion.from_subscription(product_sub_list_union_subscription_1)
+        assert subscription.test_block.int_field == 1
+        assert subscription.test_block.list_union_blocks[1].int_field == 1
+        assert "int_field" not in subscription.test_block.list_union_blocks[0].dict()
+        assert "changed_int_field" not in subscription.test_block.dict()
+        assert "changed_int_field" not in subscription.test_block.list_union_blocks[0].dict()
+        assert "changed_int_field" not in subscription.test_block.list_union_blocks[1].dict()
+
+        new_int_field_resource = ResourceTypeTable.query.where(ResourceTypeTable.resource_type == "new_int_field").all()
+        assert not new_int_field_resource
+
+    test_expected_before_upgrade()
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    updated_subscription = ProductSubListUnionTest.from_subscription(product_sub_list_union_subscription_1)
+    assert updated_subscription.test_block.changed_int_field == 1
+    assert updated_subscription.test_block.list_union_blocks[0].changed_int_field == 2
+    assert updated_subscription.test_block.list_union_blocks[1].changed_int_field == 1
+    assert "int_field" not in updated_subscription.test_block.dict()
+    assert "int_field" not in updated_subscription.test_block.list_union_blocks[0].dict()
+    assert "int_field" not in updated_subscription.test_block.list_union_blocks[1].dict()
+
+    int_field_resource = ResourceTypeTable.query.where(ResourceTypeTable.resource_type == "int_field").all()
+    assert not int_field_resource
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    test_expected_before_upgrade()
+
+
+def test_migrate_domain_models_remove_product(test_product_type_one, product_one_subscription_1):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    del SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"]
+
+    upgrade_sql, _ = migrate_domain_models("example", True)
+
+    try:
+        for stmt in upgrade_sql:
+            db.session.execute(stmt)
+        db.session.commit()
+        assert 1 == 0
+    except IntegrityError:
+        assert 1 == 1
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTest
+
+
+def test_migrate_domain_models_remove_fixed_input(
+    test_product_type_one, test_product_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 1
+    assert len(downgrade_sql) == 1
+
+    def test_expected_before_upgrade():
+        subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+        assert not subscription.test_fixed_input
+
+    test_expected_before_upgrade()
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    subscription = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert "test_fixed_input" not in subscription.dict()
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    test_expected_before_upgrade()
+
+
+def test_migrate_domain_models_remove_product_block(test_product_type_one, product_one_subscription_1):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 3
+    assert len(downgrade_sql) == 0
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    assert subscription.block
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    subscription = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert "block" not in subscription.dict()
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+
+def test_migrate_domain_models_remove_resource_type(
+    test_product_type_one, test_product_sub_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTest(
+        ProductBlockModel, product_block_name="ProductBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        int_field: int
+        str_field: str
+
+    class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 4
+    assert len(downgrade_sql) == 0
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    assert subscription.block.list_field
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    subscription = ProductTypeOneForTestNew.from_subscription(product_one_subscription_1)
+    assert "list_field" not in subscription.block.dict()
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -12,8 +12,12 @@ from orchestrator.types import SubscriptionLifecycle
 def test_migrate_domain_models_new_product(test_product_type_one, test_product_sub_block_one_db):
     _, _, ProductTypeOneForTest = test_product_type_one
     inputs = {
-        "TestProductOne": {"description": "test description", "tag": "test_tag", "product_type": "test_type"},
-        "test_fixed_input": {"value": "test value"},
+        "TestProductOne": {
+            "description": "test description",
+            "tag": "test_tag",
+            "product_type": "test_type",
+            "test_fixed_input": "test value",
+        },
         "ProductBlockOneForTest": {"description": "product block description", "tag": "test_block_tag"},
         "int_field": {"ProductBlockOneForTest": "1"},
         "str_field": {"ProductBlockOneForTest": "test"},
@@ -90,7 +94,7 @@ def test_migrate_domain_models_new_fixed_input(test_product_one, test_product_ty
 
     SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
 
-    inputs = json.dumps({"new_fixed_input": {"value": "test"}})
+    inputs = json.dumps({"TestProductOne": {"new_fixed_input": "test"}})
     upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
 
     expected_old_diff = {"TestProductOne": {"missing_fixed_inputs_in_db": {"new_fixed_input"}}}

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -23,7 +23,7 @@ def test_migrate_domain_models_new_product(test_product_type_one, test_product_s
     )
     upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs=inputs)
 
-    assert len(upgrade_sql) == 9
+    assert len(upgrade_sql) == 12
     assert len(downgrade_sql) == 14
 
     product_id = (
@@ -118,7 +118,7 @@ def test_migrate_domain_models_new_product_block(test_product_one, test_product_
         }
     }
 
-    assert len(upgrade_sql) == 3
+    assert len(upgrade_sql) == 4
     assert len(downgrade_sql) == 5
 
     before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
@@ -172,7 +172,7 @@ def test_migrate_domain_models_new_resource_type(
         }
     }
 
-    assert len(upgrade_sql) == 2
+    assert len(upgrade_sql) == 3
     assert len(downgrade_sql) == 4
 
     before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
@@ -297,7 +297,7 @@ def test_migrate_domain_models_create_and_update_resource_type(
         }
     }
 
-    assert len(upgrade_sql) == 2
+    assert len(upgrade_sql) == 3
     assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
     assert len(downgrade_sql) == 3
     assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]
@@ -376,7 +376,7 @@ def test_migrate_domain_models_create_and_delete_and_update_resource_type(
         }
     }
 
-    assert len(upgrade_sql) == 4
+    assert len(upgrade_sql) == 5
     assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
     assert len(downgrade_sql) == 3
     assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -1,0 +1,582 @@
+import json
+from typing import List, Union
+
+from orchestrator.cli.database import migrate_domain_models
+from orchestrator.db import db
+from orchestrator.db.models import ProductTable
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.domain.base import ProductBlockModel
+from orchestrator.types import SubscriptionLifecycle
+
+
+def test_migrate_domain_models_new_product(test_product_type_one, test_product_sub_block_one_db):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    inputs = json.dumps(
+        {
+            "TestProductOne": {"description": "test description", "tag": "test_tag", "product_type": "test_type"},
+            "test_fixed_input": {"value": "test value"},
+            "ProductBlockOneForTest": {"description": "product block description", "tag": "test_block_tag"},
+            "int_field": {"ProductBlockOneForTest": "1"},
+            "str_field": {"ProductBlockOneForTest": "test"},
+            "list_field": {"description": "list field desc", "ProductBlockOneForTest": "list test"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs=inputs)
+
+    assert len(upgrade_sql) == 9
+    assert len(downgrade_sql) == 14
+
+    product_id = (
+        ProductTable.query.where(ProductTable.name == "TestProductOne").with_entities(ProductTable.product_id).all()
+    )
+    assert not product_id
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    product_id = (
+        ProductTable.query.where(ProductTable.name == "TestProductOne").with_entities(ProductTable.product_id).all()
+    )
+    assert product_id[0][0]
+    diff = ProductTypeOneForTest.diff_product_in_database(product_id[0][0])
+    assert diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    product_id = (
+        ProductTable.query.where(ProductTable.name == "TestProductOne").with_entities(ProductTable.product_id).all()
+    )
+    assert not product_id
+
+
+def test_migrate_domain_models_new_fixed_input(test_product_one, test_product_type_one, test_product_block_one):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        new_fixed_input: bool
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps({"new_fixed_input": {"value": "test"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {"TestProductOne": {"missing_fixed_inputs_in_db": {"new_fixed_input"}}}
+
+    assert len(upgrade_sql) == 1
+    assert len(downgrade_sql) == 1
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    downgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert downgrade_diff == expected_old_diff
+
+
+def test_migrate_domain_models_new_product_block(test_product_one, test_product_type_one, test_product_block_one):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+
+    class TestBlock(ProductBlockModel, product_block_name="test block", lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        str_field: str
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        new_block: TestBlock
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps(
+        {
+            "test block": {"description": "test block description", "tag": "test_block_tag"},
+            "str_field": {"test block": "test"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {
+        "TestProductOne": {
+            "missing_in_depends_on_blocks": {"test block": {"missing_resource_types_in_db": {"str_field"}}},
+            "missing_product_blocks_in_db": {"test block"},
+        }
+    }
+
+    assert len(upgrade_sql) == 3
+    assert len(downgrade_sql) == 5
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    downgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert downgrade_diff == expected_old_diff
+
+
+def test_migrate_domain_models_new_resource_type(
+    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
+):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        int_field: int
+        str_field: str
+        list_field: List[int]
+        new_int_field: int
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps({"new_int_field": {"ProductBlockOneForTest": 1, "description": "test new int field type"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {
+        "TestProductOne": {
+            "missing_in_depends_on_blocks": {
+                "ProductBlockOneForTest": {"missing_resource_types_in_db": {"new_int_field"}}
+            }
+        }
+    }
+
+    assert len(upgrade_sql) == 2
+    assert len(downgrade_sql) == 4
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    downgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert downgrade_diff == expected_old_diff
+
+
+def test_migrate_domain_models_update_resource_type(
+    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
+):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        str_field: str
+        int_field: int
+        new_list_field: List[int]
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps({"list_field": {"update": "y"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {
+        "TestProductOne": {
+            "missing_in_depends_on_blocks": {
+                "ProductBlockOneForTest": {
+                    "missing_resource_types_in_db": {"new_list_field"},
+                    "missing_resource_types_in_model": {"list_field"},
+                }
+            }
+        }
+    }
+
+    assert len(upgrade_sql) == 1
+    assert "UPDATE" in upgrade_sql[0]
+    assert len(downgrade_sql) == 1
+    assert "UPDATE" in downgrade_sql[0]
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    downgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert downgrade_diff == expected_old_diff
+
+
+def test_migrate_domain_models_create_and_update_resource_type(
+    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
+):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class SubBlockOneForTestNewResource(SubBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        int_field: int
+        str_field: str
+        new_list_field: List[int]
+
+    class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        sub_block: SubBlockOneForTestNewResource
+        sub_block_2: SubBlockOneForTestNewResource
+        sub_block_list: List[SubBlockOneForTestNewResource]
+        str_field: str
+        int_field: int
+        new_list_field: List[int]
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTestUpdated
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    inputs = json.dumps(
+        {
+            "new_list_field": {"SubBlockOneForTest": "test"},
+            "list_field": {"update": "y"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {
+        "TestProductOne": {
+            "missing_in_depends_on_blocks": {
+                "ProductBlockOneForTest": {
+                    "missing_resource_types_in_db": {"new_list_field"},
+                    "missing_resource_types_in_model": {"list_field"},
+                },
+                "SubBlockOneForTest": {"missing_resource_types_in_db": {"new_list_field"}},
+            }
+        }
+    }
+
+    assert len(upgrade_sql) == 2
+    assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
+    assert len(downgrade_sql) == 3
+    assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    downgrade_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert downgrade_diff == expected_old_diff
+
+
+def test_migrate_domain_models_create_and_delete_and_update_resource_type(
+    test_product_sub_list_union,
+    test_product_type_sub_list_union,
+    test_product_block_with_list_union,
+    test_product_sub_block_one,
+    test_product_sub_block_two,
+):
+    _, ProductSubListUnionProvisioning, _ = test_product_type_sub_list_union
+    _, _, ProductBlockWithListUnionForTest = test_product_block_with_list_union
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+    _, _, SubBlockTwoForTest = test_product_sub_block_two
+
+    class SubBlockOneForTestChanged(SubBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        changed_int_field: int
+
+    class SubBlockTwoForTestChanged(SubBlockTwoForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        int_field_2: int
+        changed_int_field: int
+
+    class ProductBlockWithListUnionForTestNew(
+        ProductBlockWithListUnionForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]
+    ):
+        list_union_blocks: List[Union[SubBlockTwoForTestChanged, SubBlockOneForTestChanged]]
+        changed_int_field: int
+        str_field: str
+        list_field: List[int]
+
+    class ProductSubListUnionTest(ProductSubListUnionProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_block: ProductBlockWithListUnionForTestNew
+
+    SUBSCRIPTION_MODEL_REGISTRY["ProductSubListUnion"] = ProductSubListUnionTest
+
+    inputs = json.dumps(
+        {
+            "changed_int_field": {"SubBlockOneForTest": "test", "SubBlockTwoForTest": "test"},
+            "int_field": {"update": "y"},
+        }
+    )
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+
+    expected_old_diff = {
+        "ProductSubListUnion": {
+            "missing_in_depends_on_blocks": {
+                "ProductBlockWithListUnionForTest": {
+                    "missing_resource_types_in_db": {"changed_int_field"},
+                    "missing_resource_types_in_model": {"int_field"},
+                },
+                "SubBlockOneForTest": {
+                    "missing_resource_types_in_db": {"changed_int_field"},
+                    "missing_resource_types_in_model": {"int_field", "str_field"},
+                },
+                "SubBlockTwoForTest": {"missing_resource_types_in_db": {"changed_int_field"}},
+            }
+        }
+    }
+
+    assert len(upgrade_sql) == 4
+    assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
+    assert len(downgrade_sql) == 3
+    assert [sql_stmt for sql_stmt in downgrade_sql if "UPDATE" in sql_stmt]
+
+    before_diff = ProductSubListUnionTest.diff_product_in_database(test_product_sub_list_union)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    upgrade_diff = ProductSubListUnionTest.diff_product_in_database(test_product_sub_list_union)
+    assert upgrade_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+
+def test_migrate_domain_models_remove_product(test_product_one, test_product_type_one):
+    _, _, ProductTypeOneForTest = test_product_type_one
+    del SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"]
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 3
+    assert len(downgrade_sql) == 0
+
+    before_diff = ProductTypeOneForTest.diff_product_in_database(test_product_one)
+    assert before_diff == {}
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    product_id = (
+        ProductTable.query.where(ProductTable.name == "TestProductOne").with_entities(ProductTable.product_id).all()
+    )
+    assert not product_id
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTest
+
+
+def test_migrate_domain_models_remove_fixed_input(test_product_one, test_product_type_one, test_product_block_one):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, _, ProductBlockOneForTest = test_product_block_one
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    expected_old_diff = {"TestProductOne": {"missing_fixed_inputs_in_model": {"test_fixed_input"}}}
+
+    assert len(upgrade_sql) == 1
+    assert len(downgrade_sql) == 1
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == expected_old_diff
+
+
+def test_migrate_domain_models_remove_product_block(test_product_one, test_product_type_one):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 3
+    assert len(downgrade_sql) == 0
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {"TestProductOne": {"missing_product_blocks_in_model": {"ProductBlockOneForTest"}}}
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+
+def test_migrate_domain_models_remove_resource_type(
+    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
+):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, ProductBlockOneForTestProvisioning, _ = test_product_block_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        int_field: int
+        str_field: str
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 4
+    assert len(downgrade_sql) == 0
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert (
+        before_diff
+        == {
+            "TestProductOne": {
+                "missing_in_depends_on_blocks": {
+                    "ProductBlockOneForTest": {"missing_resource_types_in_model": {"list_field"}}
+                }
+            }
+        }
+        != {"TestProductOne": {"missing_product_blocks_in_model": {"ProductBlockOneForTest"}}}
+    )
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+
+def test_migrate_domain_models_remove_resource_type_from_block(
+    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
+):
+    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
+    _, ProductBlockOneForTestProvisioning, _ = test_product_block_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        sub_block: SubBlockOneForTest
+        sub_block_2: SubBlockOneForTest
+        sub_block_list: List[SubBlockOneForTest]
+        int_field: int
+        list_field: List[int]
+
+    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+        test_fixed_input: bool
+        block: ProductBlockOneForTest
+
+    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
+
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
+
+    assert len(upgrade_sql) == 2
+    assert len(downgrade_sql) == 0
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {
+        "TestProductOne": {
+            "missing_in_depends_on_blocks": {
+                "ProductBlockOneForTest": {"missing_resource_types_in_model": {"str_field"}}
+            }
+        }
+    }
+
+    for stmt in upgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()
+
+    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
+    assert before_diff == {}
+
+    for stmt in downgrade_sql:
+        db.session.execute(stmt)
+    db.session.commit()

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -512,60 +512,10 @@ def test_migrate_domain_models_remove_resource_type(
     assert len(downgrade_sql) == 0
 
     before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
-    assert (
-        before_diff
-        == {
-            "TestProductOne": {
-                "missing_in_depends_on_blocks": {
-                    "ProductBlockOneForTest": {"missing_resource_types_in_model": {"list_field"}}
-                }
-            }
-        }
-        != {"TestProductOne": {"missing_product_blocks_in_model": {"ProductBlockOneForTest"}}}
-    )
-
-    for stmt in upgrade_sql:
-        db.session.execute(stmt)
-    db.session.commit()
-
-    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
-    assert before_diff == {}
-
-    for stmt in downgrade_sql:
-        db.session.execute(stmt)
-    db.session.commit()
-
-
-def test_migrate_domain_models_remove_resource_type_from_block(
-    test_product_one, test_product_type_one, test_product_block_one, test_product_sub_block_one
-):
-    _, ProductTypeOneForTestProvisioning, _ = test_product_type_one
-    _, ProductBlockOneForTestProvisioning, _ = test_product_block_one
-    _, _, SubBlockOneForTest = test_product_sub_block_one
-
-    class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
-        sub_block: SubBlockOneForTest
-        sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
-        int_field: int
-        list_field: List[int]
-
-    class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
-        test_fixed_input: bool
-        block: ProductBlockOneForTest
-
-    SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
-
-    upgrade_sql, downgrade_sql = migrate_domain_models("example", True)
-
-    assert len(upgrade_sql) == 2
-    assert len(downgrade_sql) == 0
-
-    before_diff = ProductTypeOneForTestNew.diff_product_in_database(test_product_one)
     assert before_diff == {
         "TestProductOne": {
             "missing_in_depends_on_blocks": {
-                "ProductBlockOneForTest": {"missing_resource_types_in_model": {"str_field"}}
+                "ProductBlockOneForTest": {"missing_resource_types_in_model": {"list_field"}}
             }
         }
     }

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -75,6 +75,7 @@ from test.unit_tests.fixtures.products.product_types.product_type_list_union_ove
     test_product_type_list_union_overlap,
 )
 from test.unit_tests.fixtures.products.product_types.product_type_one import (  # noqa: F401
+    product_one_subscription_1,
     test_product_model,
     test_product_one,
     test_product_type_one,
@@ -85,6 +86,7 @@ from test.unit_tests.fixtures.products.product_types.product_type_one_nested imp
     test_product_type_one_nested,
 )
 from test.unit_tests.fixtures.products.product_types.product_type_sub_list_union import (  # noqa: F401
+    product_sub_list_union_subscription_1,
     test_product_sub_list_union,
     test_product_type_sub_list_union,
 )

--- a/test/unit_tests/fixtures/products/product_types/product_type_one.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_one.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 
 from orchestrator.db import FixedInputTable, ProductTable, db
@@ -61,3 +63,30 @@ def test_product_model(test_product_one):
         status=ProductLifecycle.ACTIVE,
         created_at=product.created_at,
     )
+
+
+@pytest.fixture
+def product_one_subscription_1(test_product_one, test_product_type_one, test_product_sub_block_one):
+    ProductTypeOneForTestInactive, _, ProductTypeOneForTest = test_product_type_one
+    _, _, SubBlockOneForTest = test_product_sub_block_one
+
+    model = ProductTypeOneForTestInactive.from_product_id(
+        product_id=test_product_one,
+        customer_id=uuid4(),
+        status=SubscriptionLifecycle.INITIAL,
+        insync=True,
+        description="product one sub description",
+    )
+    model.block.str_field = "A"
+    model.block.int_field = 1
+    model.block.list_field = [10, 20, 30]
+    model.block.sub_block.str_field = "B"
+    model.block.sub_block.int_field = 2
+    model.block.sub_block_2 = SubBlockOneForTest.new(
+        subscription_id=model.subscription_id, int_field=3, str_field="test"
+    )
+
+    model = ProductTypeOneForTest.from_other_lifecycle(model, SubscriptionLifecycle.ACTIVE)
+    model.save()
+    db.session.commit()
+    return model.subscription_id

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_one.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_one.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 
 from orchestrator.db import ProductTable, db
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import SubscriptionLifecycle
 
@@ -21,7 +22,9 @@ def test_product_type_sub_one(test_product_sub_block_one):
     class ProductSubOne(ProductSubOneProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: SubBlockOneForTest
 
-    return ProductSubOneInactive, ProductSubOneProvisioning, ProductSubOne
+    SUBSCRIPTION_MODEL_REGISTRY["ProductSubOne"] = ProductSubOne
+    yield ProductSubOneInactive, ProductSubOneProvisioning, ProductSubOne
+    del SUBSCRIPTION_MODEL_REGISTRY["ProductSubOne"]
 
 
 @pytest.fixture

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_two.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_two.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 
 from orchestrator.db import ProductTable, db
+from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import SubscriptionLifecycle
 
@@ -21,7 +22,9 @@ def test_product_type_sub_two(test_product_sub_block_two):
     class ProductSubTwo(ProductSubTwoProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: SubBlockTwoForTest
 
-    return ProductSubTwoInactive, ProductSubTwoProvisioning, ProductSubTwo
+    SUBSCRIPTION_MODEL_REGISTRY["ProductSubTwo"] = ProductSubTwo
+    yield ProductSubTwoInactive, ProductSubTwoProvisioning, ProductSubTwo
+    del SUBSCRIPTION_MODEL_REGISTRY["ProductSubTwo"]
 
 
 @pytest.fixture


### PR DESCRIPTION
creates migration based on difference of SUBSCRIPTION_MODEL_REGISTRY and database products using SubscriptionModel.diff_product_in_database.

usage: `python main.py db migrate_domain_models`
- add message and migration file name with: `--message="migration_name"`
- to test without generating the migration file use: `--test"`
- if you want to prefill the input prompts you get when running the command, use: `--inputs="{}"`. more info in docstring of the command

created cases:
- [x] create new products.
- [x] create new fixed inputs.
- [x] update fixed input.
- [x] delete removed fixed inputs.

- [x] create new product blocks.
- [x] create new product block relations. 
- [x] delete removed product block relations.

- [x] create new resource types.
- [x] create new resource type relations.
- [x] update resource type when the old resource type doesn't remain within any product block.
- [x] delete removed resource type relations.

TODO:
- [x] add unit tests without existing subscription instances.
- [x] add tests with existing subscription instances to make sure there are no side-effects.

Out of scope:
- Updated product block Property within a product block, this is not seen as a difference with `diff_product_in_database`.
