### PR TITLE
1552 fix extended domain model caching

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.2-rc3
+current_version = 0.5.2-rc4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: v5.11.3
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3.9
@@ -14,7 +14,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==21.9b0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -25,8 +25,8 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: detect-private-key
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -66,10 +66,10 @@ repos:
       - id: python-check-mock-methods
       - id: rst-backticks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
-#  - repo: https://github.com/andreoliwa/nitpick
-#    rev: v0.31.0
-#    hooks:
-#      - id: nitpick-check
+  - repo: https://github.com/andreoliwa/nitpick
+    rev: v0.32.0
+    hooks:
+      - id: nitpick-check

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "0.5.2-rc3"
+__version__ = "0.5.2-rc4"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -42,7 +42,8 @@ from orchestrator.schemas import SubscriptionDomainModelSchema, SubscriptionSche
 from orchestrator.security import oidc_user
 from orchestrator.services.subscriptions import (
     _generate_etag,
-    build_extendend_domain_model,
+    build_extended_domain_model,
+    format_extended_domain_model,
     get_subscription,
     query_depends_on_subscriptions,
     query_in_use_by_subscriptions,
@@ -113,14 +114,14 @@ def subscription_details_by_id_with_domain_model(
             response.status_code = HTTPStatus.NOT_MODIFIED
             return None
         response.headers["ETag"] = etag
-        return model
+        return format_extended_domain_model(model, filter_owner_relations=filter_owner_relations)
 
     if cache_response := from_redis(subscription_id):
         return _build_response(*cache_response)
 
     try:
         subscription_model = SubscriptionModel.from_subscription(subscription_id)
-        extended_model = build_extendend_domain_model(subscription_model, filter_owner_relations)
+        extended_model = build_extended_domain_model(subscription_model)
         etag = _generate_etag(extended_model)
         return _build_response(extended_model, etag)
     except ValueError as e:

--- a/orchestrator/api/helpers.py
+++ b/orchestrator/api/helpers.py
@@ -238,19 +238,24 @@ def get_in(dct: Union[dict, list], path: str, sep: str = ".") -> Any:
     return prev[x]  # type: ignore
 
 
-def getattr_in(obj: Any, attr: str, *args: List[Any]) -> Any:
+def getattr_in(obj: Any, attr: str) -> Any:
     """Get an instance attribute value by path."""
 
     def _getattr(obj: object, attr: str) -> Any:
         if isinstance(obj, list):
             return obj[int(attr)]
 
-        return getattr(obj, attr, None, *args)
+        if isinstance(obj, dict):
+            return obj.get(attr)
+
+        return getattr(obj, attr, None)
 
     return functools.reduce(_getattr, [obj] + attr.split("."))
 
 
-def product_block_paths(subscription: SubscriptionModel) -> List[Optional[str]]:
+def product_block_paths(subscription: Union[SubscriptionModel, dict]) -> List[str]:
+    _subscription = subscription.dict() if isinstance(subscription, SubscriptionModel) else subscription
+
     def get_dict_items(d: dict) -> Generator:
         for k, v in d.items():
             if isinstance(v, dict):
@@ -264,4 +269,4 @@ def product_block_paths(subscription: SubscriptionModel) -> List[Optional[str]]:
                             yield (f"{k}.{index}.{list_item_key}", list_item_value)
                         yield (f"{k}.{index}", list_item)
 
-    return [c[0] for c in get_dict_items(subscription.dict())]
+    return [path for path, value in get_dict_items(_subscription)]

--- a/orchestrator/types.py
+++ b/orchestrator/types.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 try:
     # python3.10 introduces types.UnionType for the new union and optional type defs.
-    from types import UnionType
+    from types import UnionType  # type: ignore[attr-defined]
 
     union_types = [Union, UnionType]
 except ImportError:

--- a/orchestrator/types.py
+++ b/orchestrator/types.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 try:
     # python3.10 introduces types.UnionType for the new union and optional type defs.
-    from types import UnionType  # type: ignore[attr-defined]
+    from types import UnionType
 
     union_types = [Union, UnionType]
 except ImportError:

--- a/orchestrator/workflows/steps.py
+++ b/orchestrator/workflows/steps.py
@@ -20,7 +20,7 @@ from pydantic import ValidationError
 from orchestrator.db import db
 from orchestrator.db.models import ProcessSubscriptionTable
 from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
-from orchestrator.services.subscriptions import build_extendend_domain_model, get_subscription
+from orchestrator.services.subscriptions import build_extended_domain_model, get_subscription
 from orchestrator.targets import Target
 from orchestrator.types import State, SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.json import to_serializable
@@ -207,10 +207,10 @@ def cache_domain_models(workflow_name: str, subscription: Optional[SubscriptionM
     # Cache all the sub subscriptions
     for subscription_id in cached_subscription_ids:
         subscription_model = SubscriptionModel.from_subscription(subscription_id)
-        to_redis(build_extendend_domain_model(subscription_model))
+        to_redis(build_extended_domain_model(subscription_model))
 
     # Cache the main subscription
-    to_redis(build_extendend_domain_model(subscription))
+    to_redis(build_extended_domain_model(subscription))
     cached_subscription_ids.add(subscription.subscription_id)
 
     return {"cached_subscription_ids": cached_subscription_ids}

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,9 @@ show_column_numbers = True
 ;lineprecision_report = mypy-coverage
 plugins = pydantic.mypy
 
+;Suppress "note: By default the bodies of untyped functions are not checked"
+disable_error_code = annotation-unchecked
+
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True

--- a/test/unit_tests/api/test_caching.py
+++ b/test/unit_tests/api/test_caching.py
@@ -8,7 +8,7 @@ from nwastdlib.url import URL
 from redis import Redis
 
 from orchestrator.domain.base import SubscriptionModel
-from orchestrator.services.subscriptions import build_extendend_domain_model
+from orchestrator.services.subscriptions import build_extended_domain_model
 from orchestrator.settings import app_settings
 from orchestrator.utils.redis import to_redis
 
@@ -42,7 +42,7 @@ def test_cache_update_customer_description(
         customer_id=subscription.customer_id,
         description="Original description",
     )
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
 
     # Add domainmodel to cache
     to_redis(extended_model)
@@ -80,7 +80,7 @@ def test_cache_delete_customer_description(
         customer_id=subscription.customer_id,
         description="Original description",
     )
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
 
     # Add domainmodel to cache
     to_redis(extended_model)
@@ -107,7 +107,7 @@ def test_cache_create_customer_description(
 ):
     """Check that creating subscription customer description is reflected in the cache."""
     subscription = SubscriptionModel.from_subscription(generic_subscription_1)
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
 
     # Add domainmodel to cache
     to_redis(extended_model)

--- a/test/unit_tests/api/test_helpers.py
+++ b/test/unit_tests/api/test_helpers.py
@@ -1,4 +1,6 @@
-from orchestrator.api.helpers import product_block_paths
+import pytest
+
+from orchestrator.api.helpers import getattr_in, product_block_paths, update_in
 
 
 def test_product_block_paths(sub_list_union_overlap_subscription_1):
@@ -12,3 +14,72 @@ def test_product_block_paths(sub_list_union_overlap_subscription_1):
         "list_union_blocks.0",
         "list_union_blocks.1",
     ]
+
+    # Check that SubscriptionModel and subscription dict work the same
+    assert product_block_paths(sub_list_union_overlap_subscription_1) == product_block_paths(
+        sub_list_union_overlap_subscription_1.dict()
+    )
+
+
+class BasicObject:
+    def __init__(self, **kwargs) -> None:
+        self.__dict__.update(kwargs)
+
+
+SAMPLE_OBJECT = BasicObject(foo=BasicObject(bar="a", baz=[BasicObject(fooo=123)]))
+
+
+@pytest.mark.parametrize(
+    "input_object,path,expected_result",
+    [
+        ({"foo": "bar"}, "fizz", None),
+        ({"foo": "bar"}, "foo", "bar"),
+        ({"foo": {"bar": {"fizz": "buzz"}}}, "foo.bar.fizz", "buzz"),
+        ({"foo": {"barbar": {"fizz": "buzz"}}}, "foo.bar.fizz", None),
+        ({"foo": {"bar": {"fizz": ["a", "b", "c"]}}}, "foo.bar.fizz.1", "b"),
+        ({"foo": {"bar": {"fizz": ["a", "b", "c"]}}}, "foo.bar.fizz.4", IndexError),
+        ({"foo": {"bar": {"fizz": ["a", "b", "c"]}}}, "foo.bar", {"fizz": ["a", "b", "c"]}),
+        (BasicObject(), "foo.bar", None),
+        (SAMPLE_OBJECT, "foo.bar", "a"),
+        (SAMPLE_OBJECT, "foo.barbar", None),
+        (SAMPLE_OBJECT, "foo.baz.0.fooo", 123),
+        (SAMPLE_OBJECT, "foo.baz.10.fooo", IndexError),
+    ],
+)
+def test_getattr_in(input_object, path, expected_result):
+    if isinstance(expected_result, type) and issubclass(expected_result, Exception):
+        with pytest.raises(expected_result):
+            getattr_in(input_object, path)
+    else:
+        assert getattr_in(input_object, path) == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_dict,path,value,expected_result",
+    [
+        pytest.param({}, "foo", "bar", {"foo": "bar"}),
+        pytest.param(
+            {},
+            "foo.x",
+            "bar",
+            {"foo": {"x": "bar"}},
+            marks=[pytest.mark.xfail(reason="Intermediate dicts not created")],
+        ),
+        pytest.param({"foo": {}}, "foo.x", "bar", {"foo": {"x": "bar"}}),
+        pytest.param(
+            {},
+            "foo.x.y",
+            "bar",
+            {"foo": {"x": {"y": "bar"}}},
+            marks=[pytest.mark.xfail(reason="Intermediate dicts not created")],
+        ),
+        pytest.param({"foo": "bar"}, "fizz", "buzz", {"foo": "bar", "fizz": "buzz"}),
+        pytest.param(
+            {"foo": ["bar"]}, "foo.0", "buzz", {"foo": ["buzz"]}, marks=[pytest.mark.xfail(reason="Raises TypeError")]
+        ),
+    ],
+)
+def test_update_in(input_dict, path, value, expected_result):
+    # TODO fix the failing scenarios
+    assert update_in(input_dict, path, value) is None
+    assert input_dict == expected_result

--- a/test/unit_tests/api/test_subscriptions.py
+++ b/test/unit_tests/api/test_subscriptions.py
@@ -24,7 +24,7 @@ from orchestrator.domain.base import SubscriptionModel
 from orchestrator.services.subscriptions import (
     RELATION_RESOURCE_TYPES,
     _generate_etag,
-    build_extendend_domain_model,
+    build_extended_domain_model,
     unsync,
 )
 from orchestrator.settings import app_settings
@@ -887,7 +887,7 @@ def test_subscription_detail_with_domain_model_etag(test_client, generic_subscri
     response = test_client.get(URL("api/subscriptions/domain-model") / generic_subscription_1)
     assert response.status_code == HTTPStatus.OK
     subscription = SubscriptionModel.from_subscription(generic_subscription_1)
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
     etag = _generate_etag(extended_model)
     assert etag == response.headers["ETag"]
     # Check hierarchy
@@ -897,7 +897,7 @@ def test_subscription_detail_with_domain_model_etag(test_client, generic_subscri
 def test_subscription_detail_with_domain_model_if_none_match(test_client, generic_subscription_1):
     # test with a subscription that has domain model and without
     subscription = SubscriptionModel.from_subscription(generic_subscription_1)
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
     etag = _generate_etag(extended_model)
     response = test_client.get(
         URL("api/subscriptions/domain-model") / generic_subscription_1, headers={"If-None-Match": etag}
@@ -911,7 +911,7 @@ def test_subscription_detail_with_domain_model_if_none_match(test_client, generi
 def test_subscription_detail_with_domain_model_cache(test_client, generic_subscription_1):
     # test with a subscription that has domain model and without
     subscription = SubscriptionModel.from_subscription(generic_subscription_1)
-    extended_model = build_extendend_domain_model(subscription)
+    extended_model = build_extended_domain_model(subscription)
     etag = _generate_etag(extended_model)
 
     app_settings.CACHE_DOMAIN_MODELS = True

--- a/test/unit_tests/services/test_subscriptions.py
+++ b/test/unit_tests/services/test_subscriptions.py
@@ -1,10 +1,19 @@
+import datetime
+from copy import deepcopy
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm.exc import MultipleResultsFound
 
 from orchestrator.db import ProductTable
-from orchestrator.services.subscriptions import get_subscription, retrieve_subscription_by_subscription_instance_value
+from orchestrator.domain import SubscriptionModel
+from orchestrator.services.subscriptions import (
+    build_extended_domain_model,
+    format_extended_domain_model,
+    get_subscription,
+    retrieve_subscription_by_subscription_instance_value,
+)
+from orchestrator.utils.json import json_dumps, json_loads
 from test.unit_tests import fixtures
 
 CORRECT_SUBSCRIPTION = str(uuid4())
@@ -62,3 +71,69 @@ def test_retrieve_subscription_by_subscription_instance_value_err(generic_produc
 
     with pytest.raises(MultipleResultsFound):
         retrieve_subscription_by_subscription_instance_value("rt_3", "0")
+
+
+def test_build_extended_domain_model(generic_subscription_1, generic_product_1):
+    subscription = SubscriptionModel.from_subscription(generic_subscription_1)
+    extended_model = build_extended_domain_model(subscription)
+    actual = json_loads(json_dumps(extended_model))
+
+    # Remove dates from the result and just verify their type
+    assert isinstance(actual.pop("start_date"), datetime.datetime)
+    datetime.datetime.fromisoformat(actual["product"].pop("created_at"))
+
+    assert actual == {
+        "customer_descriptions": [],
+        "customer_id": "2f47f65a-0911-e511-80d0-005056956c1a",
+        "description": "Generic Subscription One",
+        "end_date": None,
+        "insync": True,
+        "note": None,
+        "pb_1": {
+            "label": None,
+            "name": "PB_1",
+            "owner_subscription_id": generic_subscription_1,
+            "rt_1": "Value1",
+            "subscription_instance_id": str(subscription.pb_1.subscription_instance_id),
+        },
+        "pb_2": {
+            "label": None,
+            "name": "PB_2",
+            "owner_subscription_id": generic_subscription_1,
+            "rt_2": 42,
+            "rt_3": "Value2",
+            "subscription_instance_id": str(subscription.pb_2.subscription_instance_id),
+        },
+        "product": {
+            # "created_at": "2022-12-20T10:36:36+00:00",
+            "description": "Generic Product One",
+            "end_date": None,
+            "name": "Product 1",
+            "product_id": str(generic_product_1.product_id),
+            "product_type": "Generic",
+            "status": "active",
+            "tag": "GEN1",
+        },
+        # "start_date": datetime.datetime(2022, 12, 20, 10, 36, 36, tzinfo=datetime.timezone.utc),
+        "status": "active",
+        "subscription_id": generic_subscription_1,
+    }
+
+
+def test_format_extended_domain_model(generic_subscription_1, generic_product_1):
+    subscription = SubscriptionModel.from_subscription(generic_subscription_1)
+    extended_model = build_extended_domain_model(subscription)
+
+    # For the sake of testing, inject 2 in_use_by_ids on the subscription dict; 1 of which belongs
+    # to the owner
+    other_instance_id = uuid4()
+    in_use_by_ids = [subscription.pb_1.subscription_instance_id, other_instance_id]
+    extended_model["pb_1"]["in_use_by_ids"] = in_use_by_ids
+
+    # Without filtering we should see the instance_id from the owner subscription
+    formatted_no_filter = format_extended_domain_model(deepcopy(extended_model), filter_owner_relations=False)
+    assert sorted(formatted_no_filter["pb_1"]["in_use_by_ids"]) == sorted(in_use_by_ids)
+
+    # With filtering we should not see the instance_id from the owner subscription
+    formatted_with_filter = format_extended_domain_model(deepcopy(extended_model), filter_owner_relations=True)
+    assert sorted(formatted_with_filter["pb_1"]["in_use_by_ids"]) == [other_instance_id]


### PR DESCRIPTION
We use `build_extendend_domain_model()` to populate the domain model cache. Currently this function also has a parameter `filter_owner_relations` to change the representation. The problem here is that this representation is cached and cannot be changed when retrieving from cache, i.e. when retrieving it through the API.

This PR solves this by splitting `build_extendend_domain_model()` into 2 functions, keeping the old function with a DeprecatedWarning.

1) `build_extended_domain_model()` (note the subtle name change) now only creates an extended subscription dict with all of the data
2) `format_extended_domain_model()` represents the subscription dict as instructed by the given filters, taking input from either `build_extended_domain_model()` or from cache
