### PR TITLE
Docker build changes

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -31,6 +31,15 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Override latest tag to make it so that:
+          # 'latest' -> last release
+          # 'edge'   -> last release or pre-release
+          flavor: |
+            latest=false
+          tags: |
+            type=match,pattern=\d+.\d+.\d+-rc\d+,value=edge
+            type=match,pattern=\d+.\d+.\d+,value=edge
+            type=match,pattern=\d+.\d+.\d+,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -39,3 +39,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.9-slim
 
+ARG VERSION
+
 ENV PIP_ROOT_USER_ACTION=ignore
 
 RUN apt-get update && apt-get install --yes git
 
 RUN pip install pip --upgrade
-RUN pip install orchestrator-core
+RUN pip install orchestrator-core==${VERSION}
 
 RUN useradd orchestrator
 USER orchestrator


### PR DESCRIPTION
* Add Dockerfile build-arg `VERSION` to guarantee the image is built with a specific orchestrator-core version
* Give docker images for normal core releases the tags: `latest` and `edge`
* Give docker images for core pre-releases the tag: `edge`

These changes are to facilitate automatic tests of the example-orchestrator-beginner app.