### PR TITLE
Improve interactive resource type rename in migrate-domain-models

### DIFF
--- a/orchestrator/cli/helpers/input_helpers.py
+++ b/orchestrator/cli/helpers/input_helpers.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Tuple, TypeVar
+from typing import Iterable, List, Optional, Set, Tuple, TypeVar, Union
 
 import structlog
 
@@ -15,10 +15,10 @@ def get_user_input(text: str, default: str = "", optional: bool = False) -> str:
         if answer or default:
             return answer.strip() if answer else default
         if optional:
-            return ""
+            return default
 
 
-def _enumerate_menu_keys(items: List) -> List[str]:
+def _enumerate_menu_keys(items: Union[List, Set]) -> List[str]:
     return [str(i + 1) for i in range(len(items))]
 
 

--- a/orchestrator/cli/migrate_domain_models.py
+++ b/orchestrator/cli/migrate_domain_models.py
@@ -55,8 +55,8 @@ from orchestrator.cli.domain_gen_helpers.resource_type_helpers import (
     map_create_resource_type_instances,
     map_create_resource_types,
     map_delete_resource_types,
+    map_rename_resource_types,
     map_update_product_block_resource_types,
-    map_update_resource_types,
 )
 from orchestrator.cli.domain_gen_helpers.types import DomainModelChanges, ModelUpdates
 from orchestrator.cli.helpers.input_helpers import get_user_input
@@ -204,7 +204,7 @@ def map_changes(
 
     # updates need to go before create or deletes.
     if not updates:
-        renamed_resource_types = map_update_resource_types(model_diffs["blocks"], product_blocks, inputs)
+        renamed_resource_types = map_rename_resource_types(model_diffs["blocks"], product_blocks)
         update_block_resource_types = map_update_product_block_resource_types(
             model_diffs["blocks"], renamed_resource_types
         )

--- a/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
@@ -244,8 +244,8 @@ def test_migrate_domain_models_update_resource_type(
 
     SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
 
-    inputs = json.dumps({"list_field": {"update": "y"}})
-    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+    updates = json.dumps({"resource_types": {"list_field": "new_list_field"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, updates=updates)
 
     assert len(upgrade_sql) == 1
     assert "UPDATE" in upgrade_sql[0]
@@ -302,13 +302,9 @@ def test_migrate_domain_models_create_and_rename_resource_type(test_product_type
 
     SUBSCRIPTION_MODEL_REGISTRY["TestProductOne"] = ProductTypeOneForTestNew
 
-    inputs = json.dumps(
-        {
-            "new_list_field": {"SubBlockOneForTest": "5"},
-            "list_field": {"update": "y"},
-        }
-    )
-    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+    inputs = json.dumps({"new_list_field": {"SubBlockOneForTest": "5"}})
+    updates = json.dumps({"resource_types": {"list_field": "new_list_field"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs=inputs, updates=updates)
 
     assert len(upgrade_sql) == 3
     assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]
@@ -373,13 +369,9 @@ def test_migrate_domain_models_create_and_rename_and_delete_resource_type(
 
     SUBSCRIPTION_MODEL_REGISTRY["ProductSubListUnion"] = ProductSubListUnionTest
 
-    inputs = json.dumps(
-        {
-            "changed_int_field": {"SubBlockOneForTest": "5", "SubBlockTwoForTest": "2"},
-            "int_field": {"update": "y"},
-        }
-    )
-    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs)
+    inputs = json.dumps({"changed_int_field": {"SubBlockOneForTest": "5", "SubBlockTwoForTest": "2"}})
+    updates = json.dumps({"resource_types": {"int_field": "changed_int_field"}})
+    upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs=inputs, updates=updates)
 
     assert len(upgrade_sql) == 5
     assert [sql_stmt for sql_stmt in upgrade_sql if "UPDATE" in sql_stmt]


### PR DESCRIPTION
- changed map_rename_resource_types to first find all old resource types that aren't in any blocks and the possible resource types it can be renamed to, choices can't already be in the database.
- ^ after finding all possibilities, it will prompt user menu to choose resource type to rename and then prompt a menu with possible choices it can be renamed to.
- update unit tests.

Closes: #180