### PR TITLE
Available caches to flush endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
           - flake8-rst-docstrings
           - flake8-tidy-imports
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -630,6 +630,8 @@ def format_extended_domain_model(subscription: dict, filter_owner_relations: boo
 
 
 def build_extendend_domain_model(subscription_model: SubscriptionModel, filter_owner_relations: bool = False) -> dict:
-    warnings.warn("Use build_extended_domain_model() and format_extended_domain_model() instead", DeprecationWarning)
+    warnings.warn(
+        "Use build_extended_domain_model() and format_extended_domain_model() instead", DeprecationWarning, stacklevel=2
+    )
     subscription = build_extended_domain_model(subscription_model)
     return format_extended_domain_model(subscription, filter_owner_relations=filter_owner_relations)


### PR DESCRIPTION
* Add redis util `delete_keys_matching_pattern` to delete keys using `"SCAN"`
* Add endpoint `get_cache_names` for gui to retrieve the possible cache flush options
* Dict `CACHE_FLUSH_OPTIONS` can be extended by orchestrator-implementer