### PR TITLE
No need to use a threadpool when not necessary.

### DIFF
--- a/orchestrator/services/tasks.py
+++ b/orchestrator/services/tasks.py
@@ -79,7 +79,7 @@ def initialise_celery(celery: Celery) -> None:
             pstat = ProcessStat(pid, workflow=workflow, state=Success(state), log=workflow.steps, current_user=user)
 
             safe_logstep_with_func = partial(safe_logstep, broadcast_func=None)
-            pid, _ = _run_process_async(pstat.pid, lambda: runwf(pstat, safe_logstep_with_func))
+            pid = _run_process_async(pstat.pid, lambda: runwf(pstat, safe_logstep_with_func))
 
         except Exception as exc:
             local_logger.error("Worker failed to execute workflow", pid=pid, details=str(exc))
@@ -90,7 +90,7 @@ def initialise_celery(celery: Celery) -> None:
     def resume_process(pid: UUID, user_inputs: Optional[List[State]], user: str) -> Optional[UUID]:
         try:
             process = _get_process(pid)
-            pid, _ = thread_resume_process(process, user_inputs=user_inputs, user=user)
+            pid = thread_resume_process(process, user_inputs=user_inputs, user=user)
         except Exception as exc:
             local_logger.error("Worker failed to resume workflow", pid=pid, details=str(exc))
             return None

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -1,5 +1,4 @@
 import asyncio
-from concurrent.futures import Future
 from http import HTTPStatus
 from threading import Event
 from time import sleep
@@ -710,7 +709,7 @@ def test_run_process_async_exception(mock_db_log_process_ex):
     app_settings.TESTING = True
 
 
-@mock.patch("orchestrator.services.processes._run_process_async", return_value=(mock.sentinel.pid, Future()))
+@mock.patch("orchestrator.services.processes._run_process_async", return_value=(mock.sentinel.pid))
 @mock.patch("orchestrator.services.processes._db_create_process")
 @mock.patch("orchestrator.services.processes.post_process")
 @mock.patch("orchestrator.services.processes.get_workflow")


### PR DESCRIPTION
Small modifications to the celery implementation. This change is along the lines of this change: 2631de4fc3faac6be0f8d4ed8e322cbbea7bc197. Making sure we aren't sync when we don't need to, and not using a threadpool when not necessary.