### PR TITLE
Added a "slash" to the product endpoint

### DIFF
--- a/orchestrator/devtools/populator.py
+++ b/orchestrator/devtools/populator.py
@@ -152,7 +152,7 @@ class Populator:
         Returns: product dict
 
         """
-        response = self.session.get(BASE_API_URL / "products")
+        response = self.session.get(BASE_API_URL / "products/")
         if response.status_code == HTTPStatus.OK:
             for product in response.json():
                 if product["name"] == product_name:


### PR DESCRIPTION
I needed this get pass the product selection in the populator.

```
  File "/Users/acidjunk/surfnet/orchestrator/venv/lib/python3.10/site-packages/requests/sessions.py", line 191, in resolve_redirects
    raise TooManyRedirects(
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```

Not sure why this is suddenly a problem