### PR TITLE
Revert "Let publish-package.yml trigger build-push-container.yml"

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -1,12 +1,8 @@
 name: Build and push container image
 
 on:
-  # Run when publish-package.yml has completed (this could mean it failed..)
-  workflow_run:
-    workflows:
-      - "Upload Python Package"
-    types:
-      - completed
+  release:
+    types: [prereleased, released]
 
 env:
   REGISTRY: ghcr.io
@@ -15,10 +11,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-
-    # Run when publish-package.yml has completed with success
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This reverts commit 006c98690e32ab0e391ba27e891d03f731bd80ab.

For some reason the triggered event has the main branch as `ref` instead of the tag name. And we need the tag name.

There's an explanation here https://github.com/orgs/community/discussions/27124 but the fix doesn't apply for us as we depend on external actions to read the `ref`. So, reverting.