### PR TITLE
allow optional enum fields in populator

### DIFF
--- a/orchestrator/devtools/populator.py
+++ b/orchestrator/devtools/populator.py
@@ -254,8 +254,8 @@ class Populator:
                     log.warning("Unable to resolve custom function based on type.")
                     value = None
 
-            # If enum just pick the first
-            if value is None and "enum" in input_field:
+            # If enum just pick the first or leave empty if there are no options to select
+            if value is None and "enum" in input_field and input_field["enum"]:
                 value = input_field["enum"][0]
 
             if value is None and input_field.get("format") == "divider":


### PR DESCRIPTION
Currently in the populator, when we see an enum field in the form, then we always select the first option. However, sometimes enum fields are optional and the list of options can be empty. In this case the populator fails.

This PR changes the logic such that if there are no options to select from then we simply leave the field empty.