### PR TITLE
Fix #242: ensure a workflow cannot be resumed twice

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -118,6 +118,9 @@ def resume_process_endpoint(
     if process.last_status == ProcessStatus.RUNNING:
         raise_status(HTTPStatus.CONFLICT, "Resuming a running workflow is not possible")
 
+    if process.last_status == ProcessStatus.RESUMED:
+        raise_status(HTTPStatus.CONFLICT, "Resuming a resumed workflow is not possible")
+
     user_name = user.user_name if user else SYSTEM_USER
 
     broadcast_func = api_broadcast_process_data(request)

--- a/orchestrator/services/celery.py
+++ b/orchestrator/services/celery.py
@@ -80,7 +80,7 @@ def _celery_resume_process(
     return pstat.pid
 
 
-def _celery_set_process_status_resumed(process: ProcessTable):
+def _celery_set_process_status_resumed(process: ProcessTable) -> None:
     """Set the process status to RESUMED to prevent re-adding to task queue.
 
     Args:

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -464,21 +464,8 @@ def resume_process(
         process id
 
     """
-    set_process_status_resumed(process)
     resume_func = get_execution_context()["resume"]
     return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
-
-
-def set_process_status_resumed(process: ProcessTable):
-    """Set the process status to RESUMED.
-
-    Args:
-        process: Process from database
-    """
-    # update to the process status to prevent re-adding to task queue
-    process.last_status = ProcessStatus.RESUMED
-    db.session.add(process)
-    db.session.commit()
 
 
 async def _async_resume_processes(

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -464,6 +464,7 @@ def resume_process(
         process id
 
     """
+    # CS-TODO: Update process status here
     resume_func = get_execution_context()["resume"]
     return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
 
@@ -494,6 +495,10 @@ async def _async_resume_processes(
                     if process.last_status == ProcessStatus.RUNNING:
                         # Process has been started by something else in the meantime
                         logger.info("Cannot resume a running process", pid=_proc.pid)
+                        continue
+                    elif process.last_status == ProcessStatus.RESUMED:
+                        # Process has been resumed by something else in the meantime
+                        logger.info("Cannot resume a resumed process", pid=_proc.pid)
                         continue
                     resume_process(process, user=user_name, broadcast_func=broadcast_func)
                 except Exception:

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -464,9 +464,21 @@ def resume_process(
         process id
 
     """
-    # CS-TODO: Update process status here
+    set_process_status_resumed(process)
     resume_func = get_execution_context()["resume"]
     return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
+
+
+def set_process_status_resumed(process: ProcessTable):
+    """Set the process status to RESUMED.
+
+    Args:
+        process: Process from database
+    """
+    # update to the process status to prevent re-adding to task queue
+    process.last_status = ProcessStatus.RESUMED
+    db.session.add(process)
+    db.session.commit()
 
 
 async def _async_resume_processes(

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -413,6 +413,7 @@ class ProcessStatus(strEnum):
     API_UNAVAILABLE = "api_unavailable"
     INCONSISTENT_DATA = "inconsistent_data"
     COMPLETED = "completed"
+    RESUMED = "resumed"
 
 
 class StepStatus(strEnum):

--- a/test/unit_tests/api/conftest.py
+++ b/test/unit_tests/api/conftest.py
@@ -106,9 +106,11 @@ def mocked_processes(test_workflow, generic_subscription_1, generic_subscription
         mock_process(generic_subscription_1, "suspended", first_datetime + timedelta(days=1), assignee="NOC"),
         mock_process(generic_subscription_2, "completed", first_datetime + timedelta(days=2)),
         mock_process(generic_subscription_2, "failed", first_datetime + timedelta(days=3)),
+        mock_process(generic_subscription_1, "resumed", first_datetime + timedelta(days=5)),
         mock_process(generic_subscription_1, "suspended", first_datetime + timedelta(days=1), is_task=True),
         mock_process(generic_subscription_2, "completed", first_datetime + timedelta(days=2), is_task=True),
         mock_process(None, "running", first_datetime + timedelta(days=4), is_task=True),
+        mock_process(None, "resumed", first_datetime + timedelta(days=5), is_task=True),
     ]
 
 
@@ -165,7 +167,9 @@ def mocked_processes_resumeall(test_workflow, generic_subscription_1, generic_su
         mock_process(generic_subscription_2, "completed", first_datetime + timedelta(days=2), is_task=True),
         mock_process(generic_subscription_2, "running", first_datetime + timedelta(days=2), is_task=True),
         mock_process(generic_subscription_2, "failed", first_datetime + timedelta(days=3), is_task=True),
+        mock_process(generic_subscription_1, "resumed", first_datetime + timedelta(days=5), is_task=True),
         mock_process(generic_subscription_1, "inconsistent_data", first_datetime + timedelta(days=1), is_task=True),
         mock_process(generic_subscription_2, "failed", first_datetime + timedelta(days=2), is_task=False),
         mock_process(None, "running", first_datetime + timedelta(days=4), is_task=True),
+        mock_process(None, "resumed", first_datetime + timedelta(days=5), is_task=True),
     ]

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -370,6 +370,7 @@ def test_try_resume_resumed_workflow(test_client, started_process):
     # setup DB so it looks like this workflow has already been resumed
     process.last_status = ProcessStatus.RESUMED
     process.failed_reason = ""
+    db.session.add(process)
     db.session.commit()
 
     response = test_client.put(f"/api/processes/{started_process}/resume", json=[{}])

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -19,7 +19,6 @@ from orchestrator.services.processes import (
     _run_process_async,
     safe_logstep,
     start_process,
-    resume_process,
 )
 from orchestrator.settings import app_settings
 from orchestrator.targets import Target

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -622,25 +622,6 @@ def test_safe_logstep_critical_failure():
         assert f"Failed to write failure step to process: process with PID {pid} not found" in str(e.value)
 
 
-@mock.patch("orchestrator.services.processes.set_process_status_resumed")
-@mock.patch("orchestrator.services.processes.get_execution_context")
-def test_resume_process(mock_get_execution_context, mock_set_process_status_resumed):
-    """Test that resume_process() sets the process status to RESUMED."""
-    process = mock.Mock(spec=ProcessTable())
-    mock_resume_func = mock.Mock()
-
-    context = {"resume": mock_resume_func}
-
-    # Cannot just do .side_effect, otherwise returns the contexts's
-    #   key "resume" instead of the `context` dictionary.
-    mock_get_execution_context.__getitem__.side_effect = context
-
-    process.pid, process.last_status = 123, ProcessStatus.FAILED
-
-    _ = resume_process(process)
-    assert len(mock_set_process_status_resumed.mock_calls) == 1
-
-
 @mock.patch("orchestrator.services.processes._get_process")
 @mock.patch("orchestrator.services.processes.resume_process")
 def test_async_resume_processes(mock_resume_process, mock_get_process, caplog):


### PR DESCRIPTION
OCD internal tracking issue: ORC-1443
GH issue: #242 

This PR adds a new `ProcessStatus` state of `RESUMED`, and checks for that value when a user accesses the API. If a process is in the `RESUMED` state, it cannot be re-resumed. This applies for both the individual process `/api/processes/{pid}/resume` endpoint as well as the `_async_resume_processes` call (linked to the `/api/processes/resume-all` endpoint).

This PR also sets the `RESUMED` state in the Celery methods, when a process is resumed in that code flow. I manually tested this -- hopefully I re-created the Celery environment correctly. I created a process for a workflow and then issued a `PUT` to the `/api/processes/{pid}/resume` endpoint. In the database, the `last_status` column value correctly changed from `created` -> `resumed` when it was put onto the Celery queue. I then tried to re-resume a process with `last_status == resumed`, and received the expected 409 error as a response. Processes that are in `failed` / `waiting` statuses also are set to `resumed` when issuing a `PUT` to `/api/processes/resume-all`. `resumed` processes are not attempted to be re-resumed by issuing a `PUT` to the `/api/processes/resume-all` endpoint.

Are there corresponding UI changes that are required, to show the user that a process might be in the `RESUMED` state, or to catch the 409 from trying to restart a resumed workflow?

Also, please provide feedback if I'm heading in the wrong direction, mis-understood the linked issue, or your team has other preferences with regards to code style / linting / etc.
