### PR TITLE
Create worker-status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Allow user to extend the default translation set, instead of overwriting everything
-- Return worker status information in the `/api/settings/status` endpoint
+- Return worker status information in the `/api/settings/worker-status` endpoint
 
 ## [0.4.0-rc1](https://github.com/workfloworchestrator/orchestrator-core/tree/0.4.0-rc1) (2022-03-08)
 

--- a/orchestrator/api/api_v1/endpoints/settings.py
+++ b/orchestrator/api/api_v1/endpoints/settings.py
@@ -92,9 +92,10 @@ async def set_global_status(
     return status_response
 
 
+@router.get("/worker-status", response_model=WorkerStatus)
 def get_worker_status() -> WorkerStatus:
     """
-    Return information job workers and queues.
+    Return data on job workers and queues.
 
     Returns:
     - The number of queued jobs
@@ -121,9 +122,7 @@ def get_global_status() -> EngineSettingsSchema:
 
     """
     engine_settings = EngineSettingsTable.query.one()
-    response = generate_engine_status_response(engine_settings)
-    response.worker_status = get_worker_status()
-    return response
+    return generate_engine_status_response(engine_settings)
 
 
 if app_settings.ENABLE_WEBSOCKETS:

--- a/orchestrator/schemas/engine_settings.py
+++ b/orchestrator/schemas/engine_settings.py
@@ -37,7 +37,6 @@ class WorkerStatus(OrchestratorBaseModel):
 class EngineSettingsSchema(EngineSettingsBaseSchema):
     global_status: Optional[GlobalStatusEnum]
     running_processes: int
-    worker_status: Optional[WorkerStatus]
 
     class Config:
         orm_mode = True

--- a/orchestrator/services/tasks.py
+++ b/orchestrator/services/tasks.py
@@ -136,7 +136,7 @@ class CeleryJobWorkerStatus(WorkerStatus):
         self.number_of_workers_online = len(stats)
 
         def sum_items(d: dict) -> int:
-            return sum(len(l) for _, l in d.items())
+            return sum(len(l) for _, l in d.items()) if d else 0
 
         self.number_of_queued_jobs = sum_items(inspection.scheduled()) + sum_items(inspection.reserved())
         self.number_of_running_jobs = sum(len(tasks) for w, tasks in inspection.active().items())


### PR DESCRIPTION
Instead returning the worker status in the EngineSettings, there is a separate `api/settings/worker-status` endpoint.
The reason is to maintain compatibility with the current engine-settings sync-method via websockets.
