### PR TITLE
implement setting endpoint in graphql

### DIFF
--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -24,16 +24,17 @@ from oauth2_lib.graphql_authentication import authenticated_field
 from starlette.requests import Request
 from strawberry.fastapi import GraphQLRouter
 from strawberry.http import GraphQLHTTPResponse
+from strawberry.tools import merge_types
 from strawberry.types import ExecutionContext, ExecutionResult
 from strawberry.utils.logging import StrawberryLogger
 
 from orchestrator.graphql.extensions.deprecation_checker_extension import make_deprecation_checker_extension
 from orchestrator.graphql.extensions.ErrorCollectorExtension import ErrorCollectorExtension
 from orchestrator.graphql.pagination import Connection
-from orchestrator.graphql.resolvers.process import resolve_processes
-from orchestrator.graphql.resolvers.product import resolve_products
+from orchestrator.graphql.resolvers import SettingsMutation, resolve_processes, resolve_products, resolve_settings
 from orchestrator.graphql.schemas.process import ProcessType
 from orchestrator.graphql.schemas.product import ProductType
+from orchestrator.graphql.schemas.settings import StatusType
 from orchestrator.graphql.types import CustomContext
 from orchestrator.security import get_oidc_user, get_opa_security_graphql
 from orchestrator.settings import app_settings
@@ -51,6 +52,13 @@ class Query:
     products: Connection[ProductType] = authenticated_field(
         resolver=resolve_products, description="Returns list of products"
     )
+    settings: StatusType = authenticated_field(
+        resolver=resolve_settings,
+        description="Returns information about cache, workers, and global engine settings",
+    )
+
+
+Mutation = merge_types("Mutation", (SettingsMutation,))
 
 
 class OrchestratorGraphqlRouter(GraphQLRouter):
@@ -97,6 +105,7 @@ class OrchestratorSchema(strawberry.federation.Schema):
 
 schema = OrchestratorSchema(
     query=Query,
+    mutation=Mutation,
     enable_federation_2=app_settings.FEDEREATION_ENABLED,
     extensions=[ErrorCollectorExtension, make_deprecation_checker_extension(query=Query)],
 )

--- a/orchestrator/graphql/resolvers/__init__.py
+++ b/orchestrator/graphql/resolvers/__init__.py
@@ -1,0 +1,5 @@
+from orchestrator.graphql.resolvers.process import resolve_processes
+from orchestrator.graphql.resolvers.product import resolve_products
+from orchestrator.graphql.resolvers.settings import SettingsMutation, resolve_settings
+
+__all__ = ["resolve_processes", "resolve_products", "resolve_settings", "SettingsMutation"]

--- a/orchestrator/graphql/resolvers/settings.py
+++ b/orchestrator/graphql/resolvers/settings.py
@@ -10,9 +10,11 @@ from orchestrator.db import EngineSettingsTable
 from orchestrator.graphql.schemas.errors import Error
 from orchestrator.graphql.schemas.settings import (
     CACHE_FLUSH_OPTIONS,
+    CacheClearResponse,
     CacheClearSuccess,
     EngineSettingsType,
     StatusType,
+    StatusUpdateResponse,
     WorkerStatusType,
 )
 from orchestrator.graphql.types import CustomInfo
@@ -86,9 +88,9 @@ def set_status(info: CustomInfo, global_lock: bool) -> Union[Error, EngineSettin
 
 @strawberry.type(description="Settings endpoint mutations")
 class SettingsMutation:
-    clear_cache: Union[CacheClearSuccess, Error] = authenticated_mutation_field(
+    clear_cache: CacheClearResponse = authenticated_mutation_field(
         resolver=clear_cache, description="Clear a redis cache by name"
     )
-    update_status: Union[EngineSettingsType, Error] = authenticated_mutation_field(
+    update_status: StatusUpdateResponse = authenticated_mutation_field(
         resolver=set_status, description="Update global status of the engine"
     )

--- a/orchestrator/graphql/resolvers/settings.py
+++ b/orchestrator/graphql/resolvers/settings.py
@@ -1,0 +1,99 @@
+import os
+
+import strawberry
+import structlog
+from oauth2_lib.graphql_authentication import authenticated_mutation_field
+from redis.asyncio import Redis as AIORedis
+
+from orchestrator.api.api_v1.endpoints.settings import generate_engine_status_response
+from orchestrator.db import EngineSettingsTable
+from orchestrator.graphql.schemas.errors import Error
+from orchestrator.graphql.schemas.settings import (
+    CACHE_FLUSH_OPTIONS,
+    CacheClearResponse,
+    CacheClearSuccess,
+    EngineSettingsType,
+    StatusType,
+    StatusUpdateResponse,
+    WorkerStatusType,
+)
+from orchestrator.graphql.types import CustomInfo
+from orchestrator.graphql.utils import get_selected_fields
+from orchestrator.schemas.engine_settings import EngineSettingsSchema, WorkerStatus
+from orchestrator.services.processes import SYSTEM_USER, ThreadPoolWorkerStatus
+from orchestrator.services.settings import marshall_processes, post_update_to_slack
+from orchestrator.settings import ExecutorType, app_settings
+from orchestrator.utils.redis import delete_keys_matching_pattern
+
+logger = structlog.get_logger(__name__)
+
+
+# Queries
+def resolve_settings(info: CustomInfo) -> StatusType:
+    selected_fields = get_selected_fields(info)
+    logger.debug(OAUTH2_ENABLED=os.getenv("OATH2_ENABLED"), MUTATIONS_ENABLED=os.getenv("MUTATIONS_ENABLED"))
+    logger.debug("resolve_settings() called...", selected_fields=selected_fields)
+
+    db_engine_settings = EngineSettingsTable.query.one()
+    pydantic_orm_resp = generate_engine_status_response(db_engine_settings)
+    engine_settings = EngineSettingsType.from_pydantic(pydantic_orm_resp)
+
+    settings_resp_obj = StatusType(
+        engine_settings=engine_settings,
+        cache_names=None,
+        worker_status=None,
+    )
+
+    if "workerStatus" in selected_fields:
+        worker_status: WorkerStatus
+        if app_settings.EXECUTOR == ExecutorType.WORKER:
+            from orchestrator.services.tasks import CeleryJobWorkerStatus
+
+            worker_status = CeleryJobWorkerStatus()
+        else:
+            worker_status = ThreadPoolWorkerStatus()
+        settings_resp_obj.worker_status = WorkerStatusType.from_pydantic(worker_status)
+
+    if "cacheNames" in selected_fields:
+        settings_resp_obj.cache_names = CACHE_FLUSH_OPTIONS
+
+    return settings_resp_obj
+
+
+# Mutations
+async def clear_cache(info: CustomInfo, name: str) -> CacheClearResponse:  # type: ignore
+    cache: AIORedis = AIORedis(host=app_settings.CACHE_HOST, port=app_settings.CACHE_PORT)
+    if name not in CACHE_FLUSH_OPTIONS:
+        return Error(message="Invalid cache name")
+
+    key_name = "orchestrator:*" if name == "all" else f"orchestrator:{name}:*"
+    deleted = await delete_keys_matching_pattern(cache, key_name)
+    return CacheClearSuccess(deleted=deleted)
+
+
+# TODO(alex): Why is mypy complaining here? I thought the strawberry plugin handled this...
+def set_status(info: CustomInfo, global_lock: bool) -> StatusUpdateResponse:  # type: ignore
+    engine_settings = EngineSettingsTable.query.with_for_update().one()
+
+    result = marshall_processes(engine_settings, global_lock)
+    if not result:
+        return Error(
+            message="Something went wrong while updating the database aborting, possible manual intervention required",
+        )
+    if app_settings.SLACK_ENGINE_SETTINGS_HOOK_ENABLED:
+        oidc_user = info.context.get_current_user()
+        user_name = oidc_user.name if oidc_user else SYSTEM_USER
+        post_update_to_slack(EngineSettingsSchema.from_orm(result), user_name)
+
+    status_response = generate_engine_status_response(result)
+    return EngineSettingsType.from_pydantic(status_response)
+
+
+@strawberry.type(description="Settings endpoint mutations")
+class SettingsMutation:
+    clear_cache: CacheClearResponse = authenticated_mutation_field(  # type: ignore
+        resolver=clear_cache, description="Clear a redis cache by name"
+    )
+    update_status: StatusUpdateResponse = authenticated_mutation_field(  # type: ignore
+        resolver=set_status, description="Update global status of the engine"
+    )

--- a/orchestrator/graphql/schemas/errors.py
+++ b/orchestrator/graphql/schemas/errors.py
@@ -1,0 +1,16 @@
+import strawberry
+
+
+@strawberry.interface
+class BaseError:
+    message: str
+
+
+@strawberry.type
+class Error(BaseError):
+    message: str
+
+
+@strawberry.type
+class DebugError(BaseError):
+    traceback: str

--- a/orchestrator/graphql/schemas/settings.py
+++ b/orchestrator/graphql/schemas/settings.py
@@ -35,4 +35,3 @@ class CacheClearSuccess:
 
 CacheClearResponse = strawberry.union("CacheClearResponse", [CacheClearSuccess, Error])
 StatusUpdateResponse = strawberry.union("StatusUpdateResponse", [EngineSettingsType, Error])
-StatusUpdateResponse = strawberry.union("StatusUpdateResponse", [EngineSettingsType, Error])

--- a/orchestrator/graphql/schemas/settings.py
+++ b/orchestrator/graphql/schemas/settings.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+import strawberry
+from strawberry.scalars import JSON
+
+from orchestrator.graphql.schemas.errors import Error
+from orchestrator.schemas import WorkerStatus
+from orchestrator.schemas.engine_settings import EngineSettingsSchema
+
+CACHE_FLUSH_OPTIONS: dict[str, str] = {"all": "All caches"}
+
+
+@strawberry.experimental.pydantic.type(model=WorkerStatus, all_fields=True)
+class WorkerStatusType:
+    pass
+
+
+@strawberry.experimental.pydantic.type(model=EngineSettingsSchema, all_fields=True)
+class EngineSettingsType:
+    pass
+
+
+@strawberry.type
+class StatusType:
+    engine_settings: Optional[EngineSettingsType]
+    worker_status: Optional[WorkerStatusType]
+    cache_names: Optional[JSON]
+
+
+# Responses
+@strawberry.type
+class CacheClearSuccess:
+    deleted: int
+
+
+CacheClearResponse = strawberry.union("CacheClearResponse", [CacheClearSuccess, Error])
+StatusUpdateResponse = strawberry.union("StatusUpdateResponse", [EngineSettingsType, Error])
+StatusUpdateResponse = strawberry.union("StatusUpdateResponse", [EngineSettingsType, Error])

--- a/orchestrator/graphql/schemas/settings.py
+++ b/orchestrator/graphql/schemas/settings.py
@@ -33,5 +33,5 @@ class CacheClearSuccess:
     deleted: int
 
 
-CacheClearResponse = strawberry.union("CacheClearResponse", [CacheClearSuccess, Error])
-StatusUpdateResponse = strawberry.union("StatusUpdateResponse", [EngineSettingsType, Error])
+CacheClearResponse = strawberry.union("CacheClearResponse", types=(CacheClearSuccess, Error))
+StatusUpdateResponse = strawberry.union("StatusUpdateResponse", types=(EngineSettingsType, Error))

--- a/orchestrator/graphql/utils/__init__.py
+++ b/orchestrator/graphql/utils/__init__.py
@@ -1,0 +1,3 @@
+from orchestrator.graphql.utils.get_selected_fields import get_selected_fields
+
+__all__ = ["get_selected_fields"]

--- a/orchestrator/schemas/engine_settings.py
+++ b/orchestrator/schemas/engine_settings.py
@@ -13,10 +13,13 @@
 
 from typing import Optional
 
+import strawberry
+
 from orchestrator.schemas.base import OrchestratorBaseModel
 from orchestrator.types import strEnum
 
 
+@strawberry.enum
 class GlobalStatusEnum(strEnum):
     RUNNING = "RUNNING"
     PAUSED = "PAUSED"
@@ -39,4 +42,5 @@ class EngineSettingsSchema(EngineSettingsBaseSchema):
     running_processes: int
 
     class Config:
+        orm_mode = True
         orm_mode = True

--- a/test/unit_tests/api/test_caching.py
+++ b/test/unit_tests/api/test_caching.py
@@ -1,32 +1,13 @@
 """(regression)tests in relation to domain model caching."""
 from http import HTTPStatus
 from os import getenv
-from unittest.mock import patch
 
 import pytest
 from nwastdlib.url import URL
-from redis import Redis
 
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.services.subscriptions import build_extended_domain_model
-from orchestrator.settings import app_settings
 from orchestrator.utils.redis import to_redis
-
-
-@pytest.fixture
-def cache_fixture():
-    # Fixture to enable domain model caching and cleanup keys added to the list
-    with patch.object(app_settings, "CACHE_DOMAIN_MODELS", True):
-        cache = Redis(host=app_settings.CACHE_HOST, port=app_settings.CACHE_PORT)
-        to_cleanup = []
-
-        yield to_cleanup
-
-        for key in to_cleanup:
-            try:
-                cache.delete(key)
-            except Exception as exc:
-                print("failed to delete cache key", key, str(exc))  # noqa: T001, T201
 
 
 @pytest.mark.skipif(

--- a/test/unit_tests/config.py
+++ b/test/unit_tests/config.py
@@ -8,3 +8,5 @@ IPAM_PREFIX_ID = "ipam_prefix_id"
 PARENT_IP_PREFIX_SUBSCRIPTION_ID = "parent_ip_prefix_subscription_id"
 INTERNETPINNEN_PREFIX_SUBSCRIPTION_ID = "internetpinnen_prefix_subscription_id"
 PEER_GROUP_SUBSCRIPTION_ID = "peer_group_subscription_id"
+GRAPHQL_ENDPOINT = "/api/graphql"
+GRAPHQL_HEADERS = {"Content-Type": "application/json"}

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -8,6 +8,7 @@ import requests
 import structlog
 from alembic import command
 from alembic.config import Config
+from redis import Redis
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm.scoping import scoped_session
@@ -243,6 +244,9 @@ def db_session(database):
 
 @pytest.fixture(scope="session", autouse=True)
 def fastapi_app(database, db_uri):
+    from oauth2_lib.settings import oauth2lib_settings
+
+    oauth2lib_settings.ENVIRONMENT_IGNORE_MUTATION_DISABLED = ["local", "TESTING"]
     app_settings.DATABASE_URI = db_uri
     app = OrchestratorCore(base_settings=app_settings)
     # Start ProcessDataBroadcastThread to test websocket_manager with memory backend
@@ -584,3 +588,23 @@ def make_customer_description():
         return model
 
     return customer_description
+
+
+@pytest.fixture
+def cache_fixture(monkeypatch):
+    """Fixture to enable domain model caching and cleanup keys added to the list."""
+    with monkeypatch.context() as m:
+        m.setattr(app_settings, "CACHE_DOMAIN_MODELS", True)
+        cache = Redis(host=app_settings.CACHE_HOST, port=app_settings.CACHE_PORT)
+        # Clear cache before using this fixture
+        cache.flushdb()
+
+        to_cleanup = []
+
+        yield to_cleanup
+
+        for key in to_cleanup:
+            try:
+                cache.delete(key)
+            except Exception as exc:
+                print("failed to delete cache key", key, str(exc))  # noqa: T001, T201

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -37,7 +37,7 @@ def get_processes_query(
     after: int = 0,
     filter_by: Union[list[str], None] = None,
     sort_by: Union[list[dict[str, str]], None] = None,
-) -> str:
+) -> bytes:
     query = """
 query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!]) {
   processes(first: $first, after: $after, sortBy: $sortBy, filterBy: $filterBy) {
@@ -78,14 +78,14 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
                 "filterBy": filter_by if filter_by else [],
             },
         }
-    )
+    ).encode("utf-8")
 
 
 def test_processes_has_next_page(
     test_client, mocked_processes, mocked_processes_resumeall, generic_subscription_2, generic_subscription_1
 ):
     data = get_processes_query()
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     processes_data = result["data"]["processes"]
@@ -111,7 +111,7 @@ def test_process_has_previous_page(
     test_client, mocked_processes, mocked_processes_resumeall, generic_subscription_2, generic_subscription_1
 ):
     data = get_processes_query(after=1)
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -136,7 +136,7 @@ def test_processes_sorting_asc(
     # when
 
     data = get_processes_query(sort_by=[{"field": "started", "order": "ASC"}])
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -165,7 +165,7 @@ def test_processes_sorting_desc(
     # when
 
     data = get_processes_query(sort_by=[{"field": "started", "order": "DESC"}])
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -196,7 +196,7 @@ def test_processes_has_filtering(
     # when
 
     data = get_processes_query(filter_by=[{"field": "status", "value": "completed"}])
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -230,7 +230,7 @@ def test_processes_filtering_with_invalid_filter(
     data = get_processes_query(
         filter_by=[{"field": "status", "value": "completed"}, {"field": "test", "value": "invalid"}]
     )
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -286,7 +286,7 @@ def test_processes_filtering_with_invalid_organisation(
             {"field": "organisation", "value": "54321447"},
         ]
     )
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -326,7 +326,7 @@ def test_single_subscription(
     # when
 
     data = get_processes_query(filter_by=[{"field": "pid", "value": process_pid}])
-    response = test_client.post("/api/graphql", data=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -145,7 +145,7 @@ def test_products_filter_by_product_block(test_client, generic_product_1, generi
 
 def test_products_sort_by_tag(test_client, generic_product_1, generic_product_2, generic_product_3):
     data = get_product_query(sort_by=[{"field": "tag", "order": "DESC"}])
-    response: Response = test_client.post("/api/graphql", json=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -114,7 +114,7 @@ def test_clear_cache_success(test_client, cache_fixture):
     cache.set(f"orchestrator:{key}", json.dumps(test_data), ex=ONE_WEEK)
     cache.set(
         f"orchestrator:etag:{key}",
-        md5(json.dumps(test_data).encode("utf-8"), usedforsecurity=False).hexdigest(),
+        md5(json.dumps(test_data).encode("utf-8"), usedforsecurity=False).hexdigest(),  # noqa: S303
         ex=ONE_WEEK,
     )
     cache_fixture.extend([f"orchestrator:{key}", f"orchestrator:etag:{key}"])

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -1,0 +1,77 @@
+import json
+from http import HTTPStatus
+
+
+def get_settings_query() -> bytes:
+    query = """
+query SettingsQuery {
+  settings {
+    cacheNames
+    engineSettings {
+      globalLock
+      globalStatus
+      runningProcesses
+    }
+    workerStatus {
+      executorType
+      numberOfQueuedJobs
+      numberOfWorkersOnline
+      numberOfRunningJobs
+    }
+  }
+}
+    """
+    return bytes(json.dumps({"operationName": "SettingsQuery", "query": query}), "utf-8")
+
+
+def get_clear_cache_mutation(name: str = "all"):
+    query = """
+mutation ClearCacheMutation($name: String!) {
+  clearCache(name: $name) {
+    __typename
+    ... on CacheClearSuccess {
+      deleted
+    }
+    ... on Error {
+      message
+    }
+  }
+}
+    """
+    return json.dumps({"operationName": "ClearCacheMutation", "query": query, "variables": {"name": name}}).encode(
+        "utf-8"
+    )
+
+
+def test_settings_query(test_client):
+    response = test_client.post(
+        "/api/graphql",
+        content=get_settings_query(),
+        headers={"Content-Type": "application/json"},
+    )
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    settings_data = result["data"]["settings"]
+
+    assert settings_data == {
+        "cacheNames": {"all": "All caches"},
+        "engineSettings": {"globalLock": False, "globalStatus": "RUNNING", "runningProcesses": 0},
+        "workerStatus": {
+            "executorType": "threadpool",
+            "numberOfQueuedJobs": 0,
+            "numberOfWorkersOnline": 5,
+            "numberOfRunningJobs": 1,
+        },
+    }
+
+
+def test_clear_cache_mutation_fails_auth(test_client):
+    data = get_clear_cache_mutation()
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    assert response.status_code == HTTPStatus.OK
+    result = response.json()
+
+    # TODO: Fix oauth2_lib or override default MUTATIONS_ENABLED & OAUTH2_ACTIVE
+    # and create fake OIDC user for requests...
+    assert result["data"] is None
+    assert result["errors"][0]["message"] == "User is not authenticated"

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -1,5 +1,12 @@
 import json
+from hashlib import md5
 from http import HTTPStatus
+
+from redis import Redis
+
+from orchestrator import app_settings
+from orchestrator.utils.redis import ONE_WEEK
+from test.unit_tests.config import GRAPHQL_ENDPOINT, GRAPHQL_HEADERS
 
 
 def get_settings_query() -> bytes:
@@ -43,11 +50,32 @@ mutation ClearCacheMutation($name: String!) {
     )
 
 
+def get_test_set_global_lock_mutation(global_lock: bool = False):
+    query = """
+mutation UpdateStatusMutation($globalLock: Boolean = false) {
+  updateStatus(globalLock: $globalLock) {
+    __typename
+    ... on EngineSettingsType {
+      globalStatus
+      globalLock
+      runningProcesses
+    }
+    ... on Error {
+      message
+    }
+  }
+}
+    """
+    return json.dumps(
+        {"operationName": "UpdateStatusMutation", "query": query, "variables": {"globalLock": global_lock}}
+    ).encode("utf-8")
+
+
 def test_settings_query(test_client):
     response = test_client.post(
         "/api/graphql",
         content=get_settings_query(),
-        headers={"Content-Type": "application/json"},
+        headers=GRAPHQL_HEADERS,
     )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -62,13 +90,70 @@ def test_settings_query(test_client):
     # numberOfRunningJobs is different depending if you run the whole suite vs just the graphql tests
 
 
-def test_clear_cache_mutation_fails_auth(test_client):
+def test_clear_cache_mutation_fails_auth(test_client, monkeypatch):
+    from oauth2_lib.settings import oauth2lib_settings
+
+    monkeypatch.setattr(oauth2lib_settings, "ENVIRONMENT_IGNORE_MUTATION_DISABLED", [])
+
+    # oauth2lib_settings.ENVIRONMENT_IGNORE_MUTATION_DISABLED = []
     data = get_clear_cache_mutation()
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client.post("/api/graphql", content=data, headers=GRAPHQL_HEADERS)
     assert response.status_code == HTTPStatus.OK
     result = response.json()
 
-    # TODO: Fix oauth2_lib or override default MUTATIONS_ENABLED & OAUTH2_ACTIVE
-    # and create fake OIDC user for requests...
     assert result["data"] is None
     assert result["errors"][0]["message"] == "User is not authenticated"
+
+
+def test_clear_cache_success(test_client, cache_fixture):
+    cache = Redis(host=app_settings.CACHE_HOST, port=app_settings.CACHE_PORT)
+    key = "some_model_uuid"
+    test_data = {key: {"data": [1, 2, 3]}}
+
+    # Add test data to cache
+    cache.set(f"orchestrator:{key}", json.dumps(test_data), ex=ONE_WEEK)
+    cache.set(
+        f"orchestrator:etag:{key}",
+        md5(json.dumps(test_data).encode("utf-8"), usedforsecurity=False).hexdigest(),
+        ex=ONE_WEEK,
+    )
+    cache_fixture.extend([f"orchestrator:{key}", f"orchestrator:etag:{key}"])
+
+    assert len(cache.keys()) == 2
+
+    response = test_client.post("/api/graphql", content=get_clear_cache_mutation(), headers=GRAPHQL_HEADERS)
+    assert HTTPStatus.OK == response.status_code
+
+    result = response.json()
+    data = result["data"]["clearCache"]
+    assert data["__typename"] == "CacheClearSuccess"
+    assert len(cache.keys()) == 0
+    assert data["deleted"] == 2
+
+
+def test_mutate_engine_global_settings(test_client):
+    # Turn it off
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_test_set_global_lock_mutation(True), headers=GRAPHQL_HEADERS
+    )
+    assert HTTPStatus.OK == response.status_code
+
+    result = response.json()
+
+    status_data = result["data"]["updateStatus"]
+    assert status_data["__typename"] == "EngineSettingsType"
+    assert status_data["globalStatus"] == "PAUSED"
+    assert status_data["globalLock"] is True
+
+    # Turn it back on
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_test_set_global_lock_mutation(False), headers=GRAPHQL_HEADERS
+    )
+    assert HTTPStatus.OK == response.status_code
+
+    result = response.json()
+
+    status_data = result["data"]["updateStatus"]
+    assert status_data["__typename"] == "EngineSettingsType"
+    assert status_data["globalStatus"] == "RUNNING"
+    assert status_data["globalLock"] is False

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -132,7 +132,7 @@ def test_success_clear_cache(test_client, cache_fixture):
 
 
 def test_failure_clear_cache(test_client):
-    response = test_client.post(GRAPHQL_ENDPOINT, data=get_clear_cache_mutation("invalid"), headers=GRAPHQL_HEADERS)
+    response = test_client.post(GRAPHQL_ENDPOINT, content=get_clear_cache_mutation("invalid"), headers=GRAPHQL_HEADERS)
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -52,17 +52,14 @@ def test_settings_query(test_client):
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     settings_data = result["data"]["settings"]
+    worker_status = settings_data["workerStatus"]
 
-    assert settings_data == {
-        "cacheNames": {"all": "All caches"},
-        "engineSettings": {"globalLock": False, "globalStatus": "RUNNING", "runningProcesses": 0},
-        "workerStatus": {
-            "executorType": "threadpool",
-            "numberOfQueuedJobs": 0,
-            "numberOfWorkersOnline": 5,
-            "numberOfRunningJobs": 1,
-        },
-    }
+    assert settings_data["cacheNames"] == {"all": "All caches"}
+    assert settings_data["engineSettings"] == {"globalLock": False, "globalStatus": "RUNNING", "runningProcesses": 0}
+    assert worker_status["executorType"] == "threadpool"
+    assert worker_status["numberOfQueuedJobs"] == 0
+    assert worker_status["numberOfWorkersOnline"] == 5
+    # numberOfRunningJobs is different depending if you run the whole suite vs just the graphql tests
 
 
 def test_clear_cache_mutation_fails_auth(test_client):


### PR DESCRIPTION
Cut this from the `feat/issue-237-product-endpoint-strawberry` branch with the expectation that that branch will be merged first. I will rebase this one

Looking for any input on the approach to mutations -- also think we may need to add a code path for `OATH2_ACTIVE=False` for mutations similar to query fields... something like

```python
class IsAuthenticatedForMutation(BasePermission):
    message = "User is not authenticated"

    async def has_permission(self, source: Any, info: OauthInfo, **kwargs) -> bool:  # type: ignore
        if not oath2lib_settings.OAUTH2_ACTIVE:
           return True
        mutations_active = oauth2lib_settings.OAUTH2_ACTIVE and oauth2lib_settings.MUTATIONS_ENABLED
```

**\*EDIT:** Circumvented this for local/testing by using `oauth2_lib.settings.oauth2lib_settings.ENVIRONMENT_IGNORE_MUTATION_DISABLED` attribute set to `["local", "TESTING"]`.