### PR TITLE
Add check for websocket 'disconnected' state to WebSocketMemoryManager

### DIFF
--- a/orchestrator/websocket/managers/memory_websocket_manager.py
+++ b/orchestrator/websocket/managers/memory_websocket_manager.py
@@ -14,6 +14,7 @@
 from typing import Dict, List, Union
 
 from fastapi import WebSocket, WebSocketDisconnect, status
+from starlette.websockets import WebSocketState
 from structlog import get_logger
 
 from orchestrator.utils.json import json_dumps
@@ -65,7 +66,8 @@ class MemoryWebsocketManager:
             pass
 
     async def remove_ws(self, websocket: WebSocket, channel: str) -> None:
-        await self.disconnect(websocket)
+        if websocket.client_state != WebSocketState.DISCONNECTED:
+            await self.disconnect(websocket)
         if channel in self.connections_by_pid:
             self.connections_by_pid[channel].remove(websocket)
             if len(self.connections_by_pid[channel]):


### PR DESCRIPTION
When using the default `memory://` websocket broadcaster implementation, hot-reloading consumer application code (in our case, ESnet-specific code via a docker volume mount) results in watchfiles failing to reload the app.

### Expected log output:
```
WARNING:  WatchFiles detected changes in 'main.py'. Reloading...
INFO:     Shutting down
INFO:     Waiting for application shutdown.
2023-05-22 19:48:18 [debug    ] Sending shutdown signal to ProcessDataBroadcastThread [orchestrator.services.processes]
2023-05-22 19:48:19 [info     ] Shutdown ProcessDataBroadcastThread [orchestrator.services.processes]
INFO:     Application shutdown complete.
INFO:     Finished server process [47]
2023-05-22 19:48.19 [warning  ] WebSocketManager object configured, all methods referencing `websocket_manager` should work.
2023-05-22 19:48.19 [warning  ] DistLockManager object configured, all methods referencing `distlock_manager` should work.
2023-05-22 19:48:20 [warning  ] Database object configured, all methods referencing `db` should work. [orchestrator.db]
2023-05-22 19:48:20 [debug    ] [context] creating context initial (None) [pyesnet]
2023-05-22 19:48:20 [debug    ] [context] creating new configuration for initial [pyesnet]
INFO:     Started server process [3582]
INFO:     Waiting for application startup.
2023-05-22 19:48:22 [info     ] Starting ProcessDataBroadcastThread [orchestrator.services.processes]
INFO:     Application startup complete.
```

### Actual:
```
  File "/usr/src/git_dependencies/orchestrator-core/orchestrator/websocket/websocket_manager.py", line 70, in disconnect_all
    await self._backend.disconnect_all()
  File "/usr/src/git_dependencies/orchestrator-core/orchestrator/websocket/managers/memory_websocket_manager.py", line 54, in disconnect_all
    await self.remove_ws(websocket, channel)
  File "/usr/src/git_dependencies/orchestrator-core/orchestrator/websocket/managers/memory_websocket_manager.py", line 68, in remove_ws
    await self.disconnect(websocket)
  File "/usr/src/git_dependencies/orchestrator-core/orchestrator/websocket/managers/memory_websocket_manager.py", line 49, in disconnect
    await websocket.close(code=code)
  File "/usr/local/lib/python3.10/site-packages/starlette/websockets.py", line 180, in close
    await self.send(
  File "/usr/local/lib/python3.10/site-packages/starlette/websockets.py", line 87, in send
    raise RuntimeError('Cannot call "send" once a close message has been sent.')
RuntimeError: Cannot call "send" once a close message has been sent.

ERROR:    Application shutdown failed. Exiting.
INFO:     Finished server process [1492]
```