### PR TITLE
#271: Fix workflows getting stuck in resume state after forms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 1.1.0rc1
+current_version = 1.1.0rc2
 commit = False
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?
 serialize =
-	{major}.{minor}.{patch}-rc{build}
+	{major}.{minor}.{patch}rc{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:file:orchestrator/__init__.py]

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "1.1.0rc1"
+__version__ = "1.1.0rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -486,6 +486,13 @@ def resume_process(
         process id
 
     """
+    pstat = load_process(process)
+    try:
+        post_process(pstat.log[0].form, pstat.state.unwrap(), user_inputs=user_inputs or [])
+    except FormValidationError:
+        logger.exception("Validation errors", user_inputs=user_inputs)
+        raise
+
     resume_func = get_execution_context()["resume"]
     return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
 


### PR DESCRIPTION
Adds form validation check in the orchestrator api resume endpoint before the workers.

Closes: #271 