### PR TITLE
Add subscriptions graphql schema

### DIFF
--- a/orchestrator/db/filters/filters.py
+++ b/orchestrator/db/filters/filters.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2023 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -53,13 +53,19 @@ def generic_apply_filters(
         query: QueryType, filter_by: Iterator[Filter], handle_filter_error: CallableErrorHander
     ) -> QueryType:
         for item in filter_by:
-            field = item.field.lower()
+            field = item.field
             filter_fn = valid_filter_functions_by_column[field]
             try:
                 query = filter_fn(query, item.value)
             except ProblemDetailException as exception:
                 handle_filter_error(
                     exception.detail,
+                    field=field,
+                    value=item.value,
+                )
+            except ValueError as exception:
+                handle_filter_error(
+                    str(exception),
                     field=field,
                     value=item.value,
                 )

--- a/orchestrator/db/filters/generic_filters/__init__.py
+++ b/orchestrator/db/filters/generic_filters/__init__.py
@@ -1,0 +1,25 @@
+from orchestrator.db.filters.generic_filters.bool_filter import generic_bool_filter
+from orchestrator.db.filters.generic_filters.is_like_filter import generic_is_like_filter
+from orchestrator.db.filters.generic_filters.range_filter import (
+    convert_to_date,
+    convert_to_int,
+    generic_range_filter,
+    generic_range_filters,
+    get_filter_value_convert_function,
+    get_range_filter,
+    range_operator_list,
+)
+from orchestrator.db.filters.generic_filters.values_in_column_filter import generic_values_in_column_filter
+
+__all__ = [
+    "range_operator_list",
+    "convert_to_date",
+    "convert_to_int",
+    "get_filter_value_convert_function",
+    "get_range_filter",
+    "generic_range_filter",
+    "generic_range_filters",
+    "generic_is_like_filter",
+    "generic_values_in_column_filter",
+    "generic_bool_filter",
+]

--- a/orchestrator/db/filters/generic_filters/__init__.py
+++ b/orchestrator/db/filters/generic_filters/__init__.py
@@ -1,22 +1,20 @@
 from orchestrator.db.filters.generic_filters.bool_filter import generic_bool_filter
 from orchestrator.db.filters.generic_filters.is_like_filter import generic_is_like_filter
 from orchestrator.db.filters.generic_filters.range_filter import (
+    RANGE_TYPES,
     convert_to_date,
     convert_to_int,
     generic_range_filter,
     generic_range_filters,
     get_filter_value_convert_function,
-    get_range_filter,
-    range_operator_list,
 )
 from orchestrator.db.filters.generic_filters.values_in_column_filter import generic_values_in_column_filter
 
 __all__ = [
-    "range_operator_list",
+    "RANGE_TYPES",
     "convert_to_date",
     "convert_to_int",
     "get_filter_value_convert_function",
-    "get_range_filter",
     "generic_range_filter",
     "generic_range_filters",
     "generic_is_like_filter",

--- a/orchestrator/db/filters/generic_filters/bool_filter.py
+++ b/orchestrator/db/filters/generic_filters/bool_filter.py
@@ -1,0 +1,26 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+from sqlalchemy import Column
+
+from orchestrator.db.database import SearchQuery
+
+
+def generic_bool_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
+    def bool_filter(query: SearchQuery, value: str) -> SearchQuery:
+        value_as_bool = value.lower() in ("yes", "y", "ye", "true", "1", "ja", "insync")
+        return query.filter(field.is_(value_as_bool))
+
+    return bool_filter

--- a/orchestrator/db/filters/generic_filters/bool_filter.py
+++ b/orchestrator/db/filters/generic_filters/bool_filter.py
@@ -20,7 +20,7 @@ from orchestrator.db.database import SearchQuery
 
 def generic_bool_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
     def bool_filter(query: SearchQuery, value: str) -> SearchQuery:
-        value_as_bool = value.lower() in ("yes", "y", "ye", "true", "1", "ja", "insync")
+        value_as_bool = value.lower() in ("yes", "y", "true", "1", "ja", "j")
         return query.filter(field.is_(value_as_bool))
 
     return bool_filter

--- a/orchestrator/db/filters/generic_filters/is_like_filter.py
+++ b/orchestrator/db/filters/generic_filters/is_like_filter.py
@@ -1,0 +1,26 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Callable
+
+from sqlalchemy import Column, String, cast
+
+from orchestrator.db.database import SearchQuery
+
+
+def generic_is_like_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
+    def like_filter(query: SearchQuery, value: str) -> SearchQuery:
+        return query.filter(cast(field, String).ilike("%" + value + "%"))
+
+    return like_filter

--- a/orchestrator/db/filters/generic_filters/range_filter.py
+++ b/orchestrator/db/filters/generic_filters/range_filter.py
@@ -13,6 +13,8 @@
 from datetime import datetime
 from typing import Callable, Optional
 
+import pytz
+from dateutil.parser import parse
 from sqlalchemy import Column
 
 from orchestrator.db.database import SearchQuery
@@ -29,7 +31,7 @@ def convert_to_date(value: str) -> datetime:
     Example date: "2022-07-21T03:40:48+00:00"
     """
     try:
-        return datetime.fromisoformat(value)
+        return parse(value).replace(tzinfo=pytz.UTC)
     except ValueError:
         raise ValueError(f"{value} is not a valid date")
 

--- a/orchestrator/db/filters/generic_filters/range_filter.py
+++ b/orchestrator/db/filters/generic_filters/range_filter.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+from typing import Callable, Optional
+
+from sqlalchemy import Column
+
+from orchestrator.db.database import SearchQuery
+
+# from sqlalchemy.sql.expression import ColumnOperators
+from orchestrator.utils.helpers import to_camel
+
+range_operator_list = ["gt", "gte", "lt", "lte", "ne"]
+
+
+def convert_to_date(value: str) -> datetime:
+    """Parse iso 8601 date from string to datetime.
+
+    Example date: "2022-07-21T03:40:48+00:00"
+    """
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        raise ValueError(f"{value} is not a valid date")
+
+
+def convert_to_int(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"{value} is not a valid integer")
+
+
+def get_filter_value_convert_function(field: Column) -> Callable:
+    if field.type.python_type == datetime:
+        return convert_to_date
+    if field.type.python_type == int:
+        return convert_to_int
+    return lambda x: x
+
+
+def get_range_filter(range_type: str, field: Column) -> Callable:
+    if range_type == "gt":
+        return field.__gt__
+    if range_type == "gte":
+        return field.__ge__
+    if range_type == "lt":
+        return field.__lt__
+    if range_type == "lte":
+        return field.__le__
+    if range_type == "ne":
+        return field.__ne__
+    raise ValueError(f"{range_type} not a valid range type ({range_operator_list})")
+
+
+def generic_range_filter(range_type: str, field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
+    filter_operator = get_range_filter(range_type, field)
+    convert_filter_value = get_filter_value_convert_function(field)
+
+    def use_filter(query: SearchQuery, value: str) -> SearchQuery:
+        if val := convert_filter_value(value):
+            value = val
+        return query.filter(filter_operator(value))
+
+    return use_filter
+
+
+def generic_range_filters(
+    column: Column, column_alias: Optional[str] = None
+) -> dict[str, Callable[[SearchQuery, str], SearchQuery]]:
+    dict_filters = {}
+    for operator in range_operator_list:
+        dict_filters[f"{to_camel(column_alias or column.name)}{operator.capitalize()}"] = generic_range_filter(
+            operator, column
+        )
+
+    return dict_filters

--- a/orchestrator/db/filters/generic_filters/values_in_column_filter.py
+++ b/orchestrator/db/filters/generic_filters/values_in_column_filter.py
@@ -1,0 +1,27 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Callable
+
+from sqlalchemy import Column
+
+from orchestrator.db.database import SearchQuery
+
+
+def generic_values_in_column_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
+    def list_filter(query: SearchQuery, value: str) -> SearchQuery:
+        values = [s.lower() for s in value.split("-")]
+        return query.filter(field.in_(values))
+
+    return list_filter

--- a/orchestrator/db/filters/generic_filters/values_in_column_filter.py
+++ b/orchestrator/db/filters/generic_filters/values_in_column_filter.py
@@ -14,7 +14,7 @@
 
 from typing import Callable
 
-from sqlalchemy import Column
+from sqlalchemy import Column, func
 
 from orchestrator.db.database import SearchQuery
 
@@ -22,6 +22,6 @@ from orchestrator.db.database import SearchQuery
 def generic_values_in_column_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
     def list_filter(query: SearchQuery, value: str) -> SearchQuery:
         values = [s.lower() for s in value.split("-")]
-        return query.filter(field.in_(values))
+        return query.filter(func.lower(field).in_(values))
 
     return list_filter

--- a/orchestrator/db/filters/process.py
+++ b/orchestrator/db/filters/process.py
@@ -30,11 +30,11 @@ from orchestrator.db.filters.generic_filters import (
 logger = structlog.get_logger(__name__)
 
 
-def organisation_filter(query: SearchQuery, value: str) -> SearchQuery:
+def customer_id_filter(query: SearchQuery, value: str) -> SearchQuery:
     try:
         value_as_uuid = UUID(value)
     except (ValueError, AttributeError):
-        msg = f"Not a valid organisation, must be a UUID: '{value}'"
+        msg = f"Not a valid customer_id, must be a UUID: '{value}'"
         logger.debug(msg)
         raise_status(HTTPStatus.BAD_REQUEST, msg)
 
@@ -102,7 +102,7 @@ VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQ
     "status": generic_values_in_column_filter(ProcessTable.last_status),
     "workflow": generic_is_like_filter(ProcessTable.workflow),
     "creator": generic_is_like_filter(ProcessTable.created_by),
-    "organisation": organisation_filter,
+    "customerId": customer_id_filter,
     "product": product_filter,
     "tag": tag_filter,
     "subscription": subscriptions_filter,

--- a/orchestrator/db/filters/process.py
+++ b/orchestrator/db/filters/process.py
@@ -95,7 +95,7 @@ def target_filter(query: SearchQuery, value: str) -> SearchQuery:
     return query.filter(ProcessTable.pid == process_subscriptions.c.pid)
 
 
-VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
+PROCESS_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
     "pid": generic_is_like_filter(ProcessTable.pid),
     "istask": generic_bool_filter(ProcessTable.is_task),
     "assignee": generic_values_in_column_filter(ProcessTable.assignee),
@@ -111,4 +111,4 @@ VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQ
 }
 
 
-filter_processes = generic_filter(VALID_FILTER_FUNCTIONS_BY_COLUMN)
+filter_processes = generic_filter(PROCESS_FILTER_FUNCTIONS_BY_COLUMN)

--- a/orchestrator/db/filters/product.py
+++ b/orchestrator/db/filters/product.py
@@ -16,7 +16,7 @@ def product_block_filter(query: SearchQuery, value: str) -> SearchQuery:
     return query.filter(ProductTable.product_blocks.any(ProductBlockTable.name.in_(blocks)))
 
 
-VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
+PRODUCT_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
     "product_id": generic_is_like_filter(ProductTable.product_id),
     "name": generic_is_like_filter(ProductTable.name),
     "description": generic_is_like_filter(ProductTable.description),
@@ -26,4 +26,4 @@ VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQ
     "product_blocks": product_block_filter,
 }
 
-filter_products = generic_filter(VALID_FILTER_FUNCTIONS_BY_COLUMN)
+filter_products = generic_filter(PRODUCT_FILTER_FUNCTIONS_BY_COLUMN)

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -68,7 +68,7 @@ start_date_range_filters = generic_range_filters(SubscriptionTable.start_date)
 end_date_range_filters = generic_range_filters(SubscriptionTable.end_date)
 
 
-VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
     {
         "subscriptionId": generic_is_like_filter(SubscriptionTable.subscription_id),
         "subscriptionIds": subscription_list_filter,
@@ -90,4 +90,4 @@ VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQ
 )
 
 
-filter_subscriptions = generic_filter(VALID_FILTER_FUNCTIONS_BY_COLUMN)
+filter_subscriptions = generic_filter(SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN)

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -11,14 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from http import HTTPStatus
 from typing import Callable
-from uuid import UUID
 
 import structlog
 from sqlalchemy import func
 
-from orchestrator.api.error_handling import raise_status
 from orchestrator.api.helpers import _process_text_query
 from orchestrator.db import ProductTable, SubscriptionTable
 from orchestrator.db.database import SearchQuery
@@ -32,16 +29,6 @@ from orchestrator.db.filters.generic_filters import (
 from orchestrator.db.models import SubscriptionSearchView
 
 logger = structlog.get_logger(__name__)
-
-
-def customer_id_filter(query: SearchQuery, value: str) -> SearchQuery:
-    try:
-        value_as_uuid = UUID(value)
-    except (ValueError, AttributeError):
-        msg = f"Not a valid customer_id, must be a UUID: '{value}'"
-        logger.debug(msg)
-        raise_status(HTTPStatus.BAD_REQUEST, msg)
-    return query.filter(SubscriptionTable.customer_id == value_as_uuid)
 
 
 def tsv_filter(query: SearchQuery, value: str) -> SearchQuery:
@@ -75,7 +62,6 @@ SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], 
         "description": generic_is_like_filter(SubscriptionTable.description),
         "status": status_filter,
         "product": product_filter,
-        "customerId": customer_id_filter,
         "insync": generic_bool_filter(SubscriptionTable.insync),
         "note": generic_is_like_filter(SubscriptionTable.note),
         "statuses": status_filter,

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -34,11 +34,11 @@ from orchestrator.db.models import SubscriptionSearchView
 logger = structlog.get_logger(__name__)
 
 
-def organisation_filter(query: SearchQuery, value: str) -> SearchQuery:
+def customer_id_filter(query: SearchQuery, value: str) -> SearchQuery:
     try:
         value_as_uuid = UUID(value)
     except (ValueError, AttributeError):
-        msg = "Not a valid customer_id, must be a UUID: '{value}'"
+        msg = f"Not a valid customer_id, must be a UUID: '{value}'"
         logger.debug(msg)
         raise_status(HTTPStatus.BAD_REQUEST, msg)
     return query.filter(SubscriptionTable.customer_id == value_as_uuid)
@@ -75,7 +75,7 @@ VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQ
         "description": generic_is_like_filter(SubscriptionTable.description),
         "status": status_filter,
         "product": product_filter,
-        "organisation": organisation_filter,
+        "customerId": customer_id_filter,
         "insync": generic_bool_filter(SubscriptionTable.insync),
         "note": generic_is_like_filter(SubscriptionTable.note),
         "statuses": status_filter,

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -1,0 +1,93 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+from typing import Callable
+from uuid import UUID
+
+import structlog
+from sqlalchemy import func
+
+from orchestrator.api.error_handling import raise_status
+from orchestrator.api.helpers import _process_text_query
+from orchestrator.db import ProductTable, SubscriptionTable
+from orchestrator.db.database import SearchQuery
+from orchestrator.db.filters.filters import generic_filter
+from orchestrator.db.filters.generic_filters import (
+    generic_bool_filter,
+    generic_is_like_filter,
+    generic_range_filters,
+    generic_values_in_column_filter,
+)
+from orchestrator.db.models import SubscriptionSearchView
+
+logger = structlog.get_logger(__name__)
+
+
+def organisation_filter(query: SearchQuery, value: str) -> SearchQuery:
+    try:
+        value_as_uuid = UUID(value)
+    except (ValueError, AttributeError):
+        msg = "Not a valid customer_id, must be a UUID: '{value}'"
+        logger.debug(msg)
+        raise_status(HTTPStatus.BAD_REQUEST, msg)
+    return query.filter(SubscriptionTable.customer_id == value_as_uuid)
+
+
+def tsv_filter(query: SearchQuery, value: str) -> SearchQuery:
+    # Quote key:value tokens. This will use the FOLLOWED BY operator (https://www.postgresql.org/docs/13/textsearch-controls.html)
+    processed_text_query = _process_text_query(value)
+
+    logger.debug("Running full-text search query:", value=processed_text_query)
+    # TODO: Make 'websearch_to_tsquery' into a sqlalchemy extension
+    return query.join(SubscriptionSearchView).filter(
+        func.websearch_to_tsquery("simple", processed_text_query).op("@@")(SubscriptionSearchView.tsv)
+    )
+
+
+def subscription_list_filter(query: SearchQuery, value: str) -> SearchQuery:
+    values = [s.lower() for s in value.split(",")]
+    return query.filter(SubscriptionTable.subscription_id.in_(values))
+
+
+status_filter = generic_values_in_column_filter(SubscriptionTable.status)
+product_filter = generic_values_in_column_filter(ProductTable.name)
+tags_filter = generic_values_in_column_filter(ProductTable.tag)
+
+start_date_range_filters = generic_range_filters(SubscriptionTable.start_date)
+end_date_range_filters = generic_range_filters(SubscriptionTable.end_date)
+
+
+VALID_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+    {
+        "subscriptionId": generic_is_like_filter(SubscriptionTable.subscription_id),
+        "subscriptionIds": subscription_list_filter,
+        "description": generic_is_like_filter(SubscriptionTable.description),
+        "status": status_filter,
+        "product": product_filter,
+        "organisation": organisation_filter,
+        "insync": generic_bool_filter(SubscriptionTable.insync),
+        "note": generic_is_like_filter(SubscriptionTable.note),
+        "statuses": status_filter,
+        "tags": tags_filter,
+        "tag": tags_filter,
+        "tsv": tsv_filter,
+        "startDate": generic_is_like_filter(SubscriptionTable.start_date),
+        "endDate": generic_is_like_filter(SubscriptionTable.end_date),
+    }
+    | start_date_range_filters
+    | end_date_range_filters
+)
+
+
+filter_subscriptions = generic_filter(VALID_FILTER_FUNCTIONS_BY_COLUMN)

--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -68,6 +68,7 @@ class UtcTimestamp(TypeDecorator):
 
     impl = sqlalchemy.types.TIMESTAMP(timezone=True)
     cache_ok = False
+    python_type = datetime
 
     def process_bind_param(self, value: Optional[datetime], dialect: Dialect) -> Optional[datetime]:
         if value is not None:

--- a/orchestrator/db/sorting/__init__.py
+++ b/orchestrator/db/sorting/__init__.py
@@ -1,4 +1,6 @@
+from orchestrator.db.sorting.process import sort_processes
 from orchestrator.db.sorting.sorting import Sort, SortOrder, generic_apply_sorts, generic_sort, generic_sorts_validate
+from orchestrator.db.sorting.subscription import sort_subscriptions
 
 __all__ = [
     "Sort",
@@ -6,4 +8,6 @@ __all__ = [
     "generic_sort",
     "generic_apply_sorts",
     "generic_sorts_validate",
+    "sort_processes",
+    "sort_subscriptions",
 ]

--- a/orchestrator/db/sorting/subscription.py
+++ b/orchestrator/db/sorting/subscription.py
@@ -4,10 +4,8 @@ from orchestrator.db.sorting.sorting import generic_sort
 VALID_SORT_KEY_LIST = [
     "subscription_id",
     "product_id",
-    "customer_id",
     "name",
     "description",
-    "customer_descriptions",
     "insync",
     "status",
     "note",

--- a/orchestrator/db/sorting/subscription.py
+++ b/orchestrator/db/sorting/subscription.py
@@ -1,0 +1,20 @@
+from orchestrator.db import SubscriptionTable
+from orchestrator.db.sorting.sorting import generic_sort
+
+VALID_SORT_KEY_LIST = [
+    "subscription_id",
+    "product_id",
+    "customer_id",
+    "name",
+    "description",
+    "customer_descriptions",
+    "insync",
+    "status",
+    "note",
+    "tag",
+    "start_date",
+    "end_date",
+]
+VALID_SORT_KEY_MAP = {key: key for key in VALID_SORT_KEY_LIST}
+
+sort_subscriptions = generic_sort(VALID_SORT_KEY_MAP, SubscriptionTable)

--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -36,7 +36,7 @@ from orchestrator.graphql.resolvers import (
     resolve_processes,
     resolve_products,
     resolve_settings,
-    resolve_subscription,
+    resolve_subscriptions,
 )
 from orchestrator.graphql.schemas.process import ProcessType
 from orchestrator.graphql.schemas.product import ProductType
@@ -60,7 +60,7 @@ class Query:
         resolver=resolve_products, description="Returns list of products"
     )
     subscriptions: Connection[SubscriptionType] = authenticated_field(
-        resolver=resolve_subscription, description="Returns list of subscriptions"
+        resolver=resolve_subscriptions, description="Returns list of subscriptions"
     )
     settings: StatusType = authenticated_field(
         resolver=resolve_settings,

--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -31,10 +31,17 @@ from strawberry.utils.logging import StrawberryLogger
 from orchestrator.graphql.extensions.deprecation_checker_extension import make_deprecation_checker_extension
 from orchestrator.graphql.extensions.ErrorCollectorExtension import ErrorCollectorExtension
 from orchestrator.graphql.pagination import Connection
-from orchestrator.graphql.resolvers import SettingsMutation, resolve_processes, resolve_products, resolve_settings
+from orchestrator.graphql.resolvers import (
+    SettingsMutation,
+    resolve_processes,
+    resolve_products,
+    resolve_settings,
+    resolve_subscription,
+)
 from orchestrator.graphql.schemas.process import ProcessType
 from orchestrator.graphql.schemas.product import ProductType
 from orchestrator.graphql.schemas.settings import StatusType
+from orchestrator.graphql.schemas.subscription import SubscriptionType
 from orchestrator.graphql.types import CustomContext
 from orchestrator.security import get_oidc_user, get_opa_security_graphql
 from orchestrator.settings import app_settings
@@ -51,6 +58,9 @@ class Query:
     )
     products: Connection[ProductType] = authenticated_field(
         resolver=resolve_products, description="Returns list of products"
+    )
+    subscriptions: Connection[SubscriptionType] = authenticated_field(
+        resolver=resolve_subscription, description="Returns list of subscriptions"
     )
     settings: StatusType = authenticated_field(
         resolver=resolve_settings,

--- a/orchestrator/graphql/pagination.py
+++ b/orchestrator/graphql/pagination.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Generic, TypeVar, Union
+from typing import Any, Generic, TypeVar, Union
 
 import strawberry
 
@@ -57,3 +57,15 @@ class Edge(Generic[GenericType]):
 
     node: GenericType
     cursor: str
+
+
+EMPTY_PAGE: Connection[Any] = Connection(
+    page=[],
+    page_info=PageInfo(
+        has_previous_page=False,
+        has_next_page=False,
+        start_cursor=0,
+        end_cursor=-1,
+        total_items="0",
+    ),
+)

--- a/orchestrator/graphql/resolvers/__init__.py
+++ b/orchestrator/graphql/resolvers/__init__.py
@@ -1,6 +1,6 @@
 from orchestrator.graphql.resolvers.process import resolve_processes
 from orchestrator.graphql.resolvers.product import resolve_products
 from orchestrator.graphql.resolvers.settings import SettingsMutation, resolve_settings
-from orchestrator.graphql.resolvers.subscription import resolve_subscription
+from orchestrator.graphql.resolvers.subscription import resolve_subscriptions
 
-__all__ = ["resolve_processes", "resolve_products", "resolve_settings", "SettingsMutation", "resolve_subscription"]
+__all__ = ["resolve_processes", "resolve_products", "resolve_settings", "SettingsMutation", "resolve_subscriptions"]

--- a/orchestrator/graphql/resolvers/__init__.py
+++ b/orchestrator/graphql/resolvers/__init__.py
@@ -1,5 +1,6 @@
 from orchestrator.graphql.resolvers.process import resolve_processes
 from orchestrator.graphql.resolvers.product import resolve_products
 from orchestrator.graphql.resolvers.settings import SettingsMutation, resolve_settings
+from orchestrator.graphql.resolvers.subscription import resolve_subscription
 
-__all__ = ["resolve_processes", "resolve_products", "resolve_settings", "SettingsMutation"]
+__all__ = ["resolve_processes", "resolve_products", "resolve_settings", "SettingsMutation", "resolve_subscription"]

--- a/orchestrator/graphql/resolvers/process.py
+++ b/orchestrator/graphql/resolvers/process.py
@@ -56,10 +56,9 @@ async def resolve_processes(
 ) -> Connection[ProcessType]:
     _error_handler = handle_process_error(info)
 
-    _range: Union[list[int], None] = [after, after + first] if after is not None and first else None
     pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []
     pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
-    logger.info("resolve_processes() called", range=_range, sort=sort_by, filter=pydantic_filter_by)
+    logger.info("resolve_processes() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by)
 
     # the joinedload on ProcessSubscriptionTable.subscription via ProcessBaseSchema.process_subscriptions prevents a query for every subscription later.
     # tracebacks are not presented in the list of processes and can be really large.

--- a/orchestrator/graphql/resolvers/process.py
+++ b/orchestrator/graphql/resolvers/process.py
@@ -41,7 +41,7 @@ def enrich_process(process: ProcessTable) -> ProcessGraphqlSchema:
 def handle_process_error(info: CustomInfo) -> CallableErrorHander:
     def _handle_process_error(message: str, **kwargs) -> None:  # type: ignore
         logger.debug(message, **kwargs)
-        extra_values = dict(kwargs.items()) if kwargs else {}
+        extra_values = kwargs if kwargs else {}
         info.context.errors.append(GraphQLError(message=message, path=info.path, extensions=extra_values))
 
     return _handle_process_error

--- a/orchestrator/graphql/resolvers/product.py
+++ b/orchestrator/graphql/resolvers/product.py
@@ -34,10 +34,9 @@ async def resolve_products(
 ) -> Connection[ProductType]:
     _error_handler = handle_product_error(info)
 
-    _range: Union[list[int], None] = [after, after + first] if after is not None and first else None
     pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []
     pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
-    logger.info("resolve_products() called", range=_range, sort=sort_by, filter=pydantic_filter_by)
+    logger.info("resolve_products() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by)
 
     query = filter_products(ProductTable.query, pydantic_filter_by, _error_handler)
     query = sort_products(query, pydantic_sort_by, _error_handler)

--- a/orchestrator/graphql/resolvers/product.py
+++ b/orchestrator/graphql/resolvers/product.py
@@ -19,7 +19,7 @@ logger = structlog.get_logger(__name__)
 def handle_product_error(info: CustomInfo) -> CallableErrorHander:
     def _handle_product_error(message: str, **kwargs) -> None:  # type: ignore
         logger.debug(message, **kwargs)
-        extra_values = dict(kwargs.items()) if kwargs else {}
+        extra_values = kwargs if kwargs else {}
         info.context.errors.append(GraphQLError(message=message, path=info.path, extensions=extra_values))
 
     return _handle_product_error

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -32,13 +32,13 @@ logger = structlog.get_logger(__name__)
 def handle_subscription_error(info: CustomInfo) -> CallableErrorHander:
     def _handle_subscription_error(message: str, **kwargs) -> None:  # type: ignore
         logger.debug(message, **kwargs)
-        extra_values = dict(kwargs.items()) if kwargs else {}
+        extra_values = kwargs if kwargs else {}
         info.context.errors.append(GraphQLError(message=message, path=info.path, extensions=extra_values))
 
     return _handle_subscription_error
 
 
-async def resolve_subscription(
+async def resolve_subscriptions(
     info: CustomInfo,
     filter_by: Union[list[GraphqlFilter], None] = None,
     sort_by: Union[list[GraphqlSort], None] = None,

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -1,0 +1,81 @@
+# Copyright 2019-2020 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union
+
+import structlog
+from graphql import GraphQLError
+from sqlalchemy.orm import joinedload
+
+from orchestrator.db import SubscriptionTable
+from orchestrator.db.filters import CallableErrorHander, Filter
+from orchestrator.db.filters.subscription import filter_subscriptions
+from orchestrator.db.range import apply_range_to_query
+from orchestrator.db.sorting import Sort, sort_subscriptions
+from orchestrator.graphql.pagination import Connection, PageInfo
+from orchestrator.graphql.schemas.subscription import SubscriptionType
+from orchestrator.graphql.types import CustomInfo, GraphqlFilter, GraphqlSort
+
+logger = structlog.get_logger(__name__)
+
+
+def handle_subscription_error(info: CustomInfo) -> CallableErrorHander:
+    def _handle_subscription_error(message: str, **kwargs) -> None:  # type: ignore
+        logger.debug(message, **kwargs)
+        extra_values = dict(kwargs.items()) if kwargs else {}
+        info.context.errors.append(GraphQLError(message=message, path=info.path, extensions=extra_values))
+
+    return _handle_subscription_error
+
+
+async def resolve_subscription(
+    info: CustomInfo,
+    filter_by: Union[list[GraphqlFilter], None] = None,
+    sort_by: Union[list[GraphqlSort], None] = None,
+    first: int = 10,
+    after: int = 0,
+) -> Connection[SubscriptionType]:
+    _error_handler = handle_subscription_error(info)
+
+    _range: Union[list[int], None] = [after, after + first] if after is not None and first else None
+    pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []
+    pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
+    logger.info("resolve_subscription() called", range=_range, sort=sort_by, filter=pydantic_filter_by)
+
+    query = SubscriptionTable.query.options(joinedload(SubscriptionTable.product))
+
+    query = filter_subscriptions(query, pydantic_filter_by, _error_handler)
+    query = sort_subscriptions(query, pydantic_sort_by, _error_handler)
+    total = query.count()
+    query = apply_range_to_query(query, after, first)
+
+    subscriptions = query.all()
+    has_next_page = len(subscriptions) > first
+
+    # exclude last item as it was fetched to know if there is a next page
+    subscriptions = subscriptions[:first]
+    subscriptions_length = len(subscriptions)
+    start_cursor = after if subscriptions_length else None
+    end_cursor = after + subscriptions_length - 1
+    page_subscriptions = [SubscriptionType.from_pydantic(p) for p in subscriptions]
+
+    return Connection(
+        page=page_subscriptions,
+        page_info=PageInfo(
+            has_previous_page=bool(after),
+            has_next_page=has_next_page,
+            start_cursor=start_cursor,
+            end_cursor=end_cursor,
+            total_items=total if total else None,
+        ),
+    )

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -47,10 +47,9 @@ async def resolve_subscription(
 ) -> Connection[SubscriptionType]:
     _error_handler = handle_subscription_error(info)
 
-    _range: Union[list[int], None] = [after, after + first] if after is not None and first else None
     pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []
     pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
-    logger.info("resolve_subscription() called", range=_range, sort=sort_by, filter=pydantic_filter_by)
+    logger.info("resolve_subscription() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by)
 
     query = SubscriptionTable.query.options(joinedload(SubscriptionTable.product))
 

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -84,7 +84,7 @@ class ProcessType:
     form: strawberry.auto
     current_state: Union[JSON, None]
 
-    @authenticated_field(description="Returns list of processes of the subscription")
+    @authenticated_field(description="Returns list of processes of the subscription")  # type: ignore
     async def subscriptions(
         self,
         info: CustomInfo,
@@ -95,7 +95,7 @@ class ProcessType:
     ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
         from orchestrator.graphql.resolvers.subscription import resolve_subscription
 
-        process = ProcessTable.query.options(load_only(ProcessTable.process_subscriptions)).get(self.id)
+        process: ProcessTable = ProcessTable.query.options(load_only(ProcessTable.process_subscriptions)).get(self.id)
         subscription_ids = [str(s.subscription_id) for s in process.process_subscriptions]
-        filter_by = filter_by or [] + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]  # type: ignore
+        filter_by = (filter_by or []) + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]
         return await resolve_subscription(info, filter_by, sort_by, first, after)

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -9,7 +9,7 @@ from strawberry.scalars import JSON
 
 from orchestrator.config.assignee import Assignee
 from orchestrator.db import ProcessTable
-from orchestrator.graphql.pagination import Connection
+from orchestrator.graphql.pagination import EMPTY_PAGE, Connection
 from orchestrator.graphql.types import CustomInfo, GraphqlFilter, GraphqlSort
 from orchestrator.schemas.base import OrchestratorBaseModel
 from orchestrator.schemas.process import ProcessForm, ProcessStepSchema
@@ -97,5 +97,7 @@ class ProcessType:
 
         process: ProcessTable = ProcessTable.query.options(load_only(ProcessTable.process_subscriptions)).get(self.id)
         subscription_ids = [str(s.subscription_id) for s in process.process_subscriptions]
+        if not subscription_ids:
+            return EMPTY_PAGE
         filter_by = (filter_by or []) + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]
         return await resolve_subscription(info, filter_by, sort_by, first, after)

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -99,5 +99,7 @@ class ProcessType:
         subscription_ids = [str(s.subscription_id) for s in process.process_subscriptions]
         if not subscription_ids:
             return EMPTY_PAGE
-        filter_by = (filter_by or []) + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]
-        return await resolve_subscription(info, filter_by, sort_by, first, after)
+        filter_by_with_related_subscriptions = (filter_by or []) + [
+            GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
+        ]
+        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -84,7 +84,7 @@ class ProcessType:
     form: strawberry.auto
     current_state: Union[JSON, None]
 
-    @authenticated_field(description="Returns list of processes of the subscription")  # type: ignore
+    @authenticated_field(description="Returns list of subscriptions of the process")  # type: ignore
     async def subscriptions(
         self,
         info: CustomInfo,
@@ -93,7 +93,7 @@ class ProcessType:
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
-        from orchestrator.graphql.resolvers.subscription import resolve_subscription
+        from orchestrator.graphql.resolvers.subscription import resolve_subscriptions
 
         process: ProcessTable = ProcessTable.query.options(load_only(ProcessTable.process_subscriptions)).get(self.id)
         subscription_ids = [str(s.subscription_id) for s in process.process_subscriptions]
@@ -102,4 +102,4 @@ class ProcessType:
         filter_by_with_related_subscriptions = (filter_by or []) + [
             GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
         ]
-        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)
+        return await resolve_subscriptions(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/graphql/schemas/product.py
+++ b/orchestrator/graphql/schemas/product.py
@@ -28,7 +28,7 @@ class ProductType:
     fixed_inputs: list[FixedInput]
     workflows: list[Workflow]
 
-    @authenticated_field(description="Returns list of processes of the subscription")  # type: ignore
+    @authenticated_field(description="Returns list of subscriptions of the product type")  # type: ignore
     async def subscriptions(
         self,
         info: CustomInfo,
@@ -37,7 +37,7 @@ class ProductType:
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
-        from orchestrator.graphql.resolvers.subscription import resolve_subscription
+        from orchestrator.graphql.resolvers.subscription import resolve_subscriptions
 
         filter_by_with_related_subscriptions = (filter_by or []) + [GraphqlFilter(field="product", value=self.name)]
-        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)
+        return await resolve_subscriptions(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/graphql/schemas/product.py
+++ b/orchestrator/graphql/schemas/product.py
@@ -1,9 +1,17 @@
-import strawberry
+from typing import TYPE_CHECKING, Annotated, Union
 
+import strawberry
+from oauth2_lib.graphql_authentication import authenticated_field
+
+from orchestrator.graphql.pagination import Connection
 from orchestrator.graphql.schemas.fixed_input import FixedInput
 from orchestrator.graphql.schemas.product_block import ProductBlock
 from orchestrator.graphql.schemas.workflow import Workflow
+from orchestrator.graphql.types import CustomInfo, GraphqlFilter, GraphqlSort
 from orchestrator.schemas.product import ProductSchema
+
+if TYPE_CHECKING:
+    from orchestrator.graphql.schemas.subscription import SubscriptionType
 
 
 @strawberry.experimental.pydantic.type(model=ProductSchema)
@@ -19,3 +27,17 @@ class ProductType:
     product_blocks: list[ProductBlock]
     fixed_inputs: list[FixedInput]
     workflows: list[Workflow]
+
+    @authenticated_field(description="Returns list of processes of the subscription")  # type: ignore
+    async def subscriptions(
+        self,
+        info: CustomInfo,
+        filter_by: Union[list[GraphqlFilter], None] = None,
+        sort_by: Union[list[GraphqlSort], None] = None,
+        first: int = 10,
+        after: int = 0,
+    ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
+        from orchestrator.graphql.resolvers.subscription import resolve_subscription
+
+        filter_by_with_related_subscriptions = (filter_by or []) + [GraphqlFilter(field="product", value=self.name)]
+        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+from itertools import count
+from typing import Any, Generator, List, Optional, Union
+from uuid import UUID
+
+import strawberry
+from oauth2_lib.graphql_authentication import authenticated_field
+from strawberry.scalars import JSON
+
+from orchestrator.domain.base import SubscriptionModel
+from orchestrator.graphql.pagination import Connection
+from orchestrator.graphql.resolvers.process import resolve_processes
+from orchestrator.graphql.schemas.process import ProcessType
+from orchestrator.graphql.types import CustomInfo, GraphqlFilter, GraphqlSort
+from orchestrator.schemas.base import OrchestratorBaseModel
+from orchestrator.schemas.product import ProductSchema
+from orchestrator.schemas.subscription_descriptions import SubscriptionDescriptionSchema
+from orchestrator.services.subscriptions import build_extended_domain_model
+from orchestrator.utils.helpers import to_camel
+
+
+@strawberry.type
+class SubscriptionProductBlock:
+    id: int
+    parent: int | None
+    owner_subscription_id: UUID
+    resource_types: JSON
+
+
+def is_product_block(candidate: Any) -> bool:
+    match candidate:
+        case dict():
+            # TODO: also filter on tag (needs addition of tag in orchestrator endpoint)
+            # NOTE: this crosses subscription boundaries. If needed we can add an additional filter to limit that.
+            return candidate.get("owner_subscription_id", None)
+        case _:
+            return False
+
+
+def get_all_product_blocks(subscription: dict[str, Any], _tags: list[str] | None) -> list[dict[str, Any]]:
+    gen_id = count()
+
+    def locate_product_block(candidate: dict[str, Any]) -> Generator:
+        def new_product_block(item: dict[str, Any]) -> Generator:
+            enriched_item = item | {"id": next(gen_id), "parent": candidate.get("id")}
+            yield enriched_item
+            yield from locate_product_block(enriched_item)
+
+        for value in candidate.values():
+            if is_product_block(value):
+                yield from new_product_block(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if is_product_block(item):
+                        yield from new_product_block(item)
+
+    return list(locate_product_block(subscription))
+
+
+@strawberry.experimental.pydantic.type(model=SubscriptionDescriptionSchema, all_fields=True)
+class SubscriptionDescriptionType:
+    pass
+
+
+class SubscriptionGraphqlSchema(OrchestratorBaseModel):
+    subscription_id: UUID
+    product: ProductSchema
+    customer_descriptions: List[Optional[SubscriptionDescriptionSchema]] = []  # type: ignore
+    description: str
+    start_date: Optional[datetime]
+    end_date: Optional[datetime]
+    product_id: UUID
+    customer_id: UUID
+    status: str
+    insync: bool
+    note: Optional[str]
+    name: Optional[str]
+    tag: Optional[str]
+
+
+@strawberry.experimental.pydantic.type(model=SubscriptionGraphqlSchema, all_fields=True)
+class SubscriptionType:
+    pass
+
+    @strawberry.field(description="Return all products blocks that are part of a subscription")
+    async def product_blocks(
+        self, tags: list[str] | None = None, resource_types: list[str] | None = None
+    ) -> list[SubscriptionProductBlock]:
+        subscription_model = SubscriptionModel.from_subscription(self.subscription_id)  # type: ignore
+        subscription = build_extended_domain_model(subscription_model)
+
+        def to_product_block(product_block: dict[str, Any]) -> SubscriptionProductBlock:
+            def is_resource_type(candidate: Any) -> bool:
+                return isinstance(candidate, bool | str | int | float | None)
+
+            def requested_resource_type(key: str) -> bool:
+                return not resource_types or key in resource_types
+
+            def included(key: str, value: Any) -> bool:
+                return is_resource_type(value) and requested_resource_type(key) and key not in ("id", "parent")
+
+            return SubscriptionProductBlock(
+                id=product_block["id"],
+                parent=product_block.get("parent"),
+                owner_subscription_id=product_block["owner_subscription_id"],
+                resource_types={to_camel(k): v for k, v in product_block.items() if included(k, v)},
+            )
+
+        product_blocks = (
+            to_product_block(product_block) for product_block in get_all_product_blocks(subscription, tags)
+        )
+        return [product_block for product_block in product_blocks if product_block.resource_types]
+
+    @authenticated_field(description="Returns list of processes of the subscription")
+    async def processes(
+        self,
+        info: CustomInfo,
+        filter_by: Union[list[GraphqlFilter], None] = None,
+        sort_by: Union[list[GraphqlSort], None] = None,
+        first: int = 10,
+        after: int = 0,
+    ) -> Connection[ProcessType]:
+        filter_by = filter_by or [] + [GraphqlFilter(field="subscriptionId", value=str(self.subscription_id))]  # type: ignore
+        return await resolve_processes(info, filter_by, sort_by, first, after)

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -136,7 +136,7 @@ class SubscriptionType:
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
-        from orchestrator.graphql.resolvers.subscription import resolve_subscription
+        from orchestrator.graphql.resolvers.subscription import resolve_subscriptions
         from orchestrator.services.subscriptions import query_in_use_by_subscriptions
 
         in_use_by_query = query_in_use_by_subscriptions(self.subscription_id)
@@ -147,7 +147,7 @@ class SubscriptionType:
         filter_by_with_related_subscriptions = (filter_by or []) + [
             GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
         ]
-        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)
+        return await resolve_subscriptions(info, filter_by_with_related_subscriptions, sort_by, first, after)
 
     @authenticated_field(description="Returns list of subscriptions that this subscription depends on")  # type: ignore
     async def depends_on_subscriptions(
@@ -158,7 +158,7 @@ class SubscriptionType:
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionType", strawberry.lazy(".subscription")]]:
-        from orchestrator.graphql.resolvers.subscription import resolve_subscription
+        from orchestrator.graphql.resolvers.subscription import resolve_subscriptions
         from orchestrator.services.subscriptions import query_depends_on_subscriptions
 
         depends_on_query = query_depends_on_subscriptions(self.subscription_id)
@@ -169,4 +169,4 @@ class SubscriptionType:
         filter_by_with_related_subscriptions = (filter_by or []) + [
             GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
         ]
-        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)
+        return await resolve_subscriptions(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -69,7 +69,6 @@ class SubscriptionGraphqlSchema(OrchestratorBaseModel):
     start_date: Optional[datetime]
     end_date: Optional[datetime]
     product_id: UUID
-    customer_id: UUID
     status: str
     insync: bool
     note: Optional[str]
@@ -119,8 +118,10 @@ class SubscriptionType:
         first: int = 10,
         after: int = 0,
     ) -> Connection[ProcessType]:
-        filter_by = filter_by or [] + [GraphqlFilter(field="subscriptionId", value=str(self.subscription_id))]
-        return await resolve_processes(info, filter_by, sort_by, first, after)
+        filter_by_with_related_processes = filter_by or [] + [
+            GraphqlFilter(field="subscriptionId", value=str(self.subscription_id))
+        ]
+        return await resolve_processes(info, filter_by_with_related_processes, sort_by, first, after)
 
     @authenticated_field(description="Returns list of subscriptions that use this subscription")  # type: ignore
     async def in_use_by_subscriptions(
@@ -139,8 +140,10 @@ class SubscriptionType:
         subscription_ids = [str(s.subscription_id) for s in query_results]
         if not subscription_ids:
             return EMPTY_PAGE
-        filter_by = (filter_by or []) + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]
-        return await resolve_subscription(info, filter_by, sort_by, first, after)
+        filter_by_with_related_subscriptions = (filter_by or []) + [
+            GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
+        ]
+        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)
 
     @authenticated_field(description="Returns list of subscriptions that this subscription depends on")  # type: ignore
     async def depends_on_subscriptions(
@@ -159,5 +162,7 @@ class SubscriptionType:
         subscription_ids = [str(s.subscription_id) for s in query_results]
         if not subscription_ids:
             return EMPTY_PAGE
-        filter_by = (filter_by or []) + [GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))]
-        return await resolve_subscription(info, filter_by, sort_by, first, after)
+        filter_by_with_related_subscriptions = (filter_by or []) + [
+            GraphqlFilter(field="subscriptionIds", value=",".join(subscription_ids))
+        ]
+        return await resolve_subscription(info, filter_by_with_related_subscriptions, sort_by, first, after)

--- a/orchestrator/types.py
+++ b/orchestrator/types.py
@@ -16,6 +16,7 @@ from http import HTTPStatus
 from typing import Any, Callable, Dict, Generator, List, Literal, Optional, Tuple, Type, TypedDict, TypeVar, Union
 from uuid import UUID
 
+import strawberry
 from pydantic import BaseModel
 from pydantic.typing import get_args, get_origin, is_union
 
@@ -45,6 +46,7 @@ class strEnum(str, Enum):
         return [obj.value for obj in cls]
 
 
+@strawberry.enum
 class SubscriptionLifecycle(strEnum):
     INITIAL = "initial"
     ACTIVE = "active"
@@ -54,6 +56,7 @@ class SubscriptionLifecycle(strEnum):
     PROVISIONING = "provisioning"
 
 
+@strawberry.enum
 class AcceptItemType(strEnum):
     INFO = "info"
     LABEL = "label"

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -21,7 +21,6 @@ from orchestrator.services.processes import shutdown_thread_pool
 from orchestrator.settings import app_settings
 from orchestrator.targets import Target
 from orchestrator.workflow import ProcessStatus, done, init, step, workflow
-from test.unit_tests.conftest import CUSTOMER_ID
 from test.unit_tests.workflows import WorkflowInstanceForTests
 
 test_condition = Condition()
@@ -399,8 +398,6 @@ def test_processes_filterable(test_client, mocked_processes, generic_subscriptio
     assert response.json()[0]["assignee"] == "NOC"
     response = test_client.get("/api/processes?sort=started&filter=istask,y")
     assert 4 == len(response.json())
-    response = test_client.get(f"/api/processes?filter=istask,y,organisation,{CUSTOMER_ID}")
-    assert 2 == len(response.json())
 
 
 def test_processes_filterable_response_model(

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -318,7 +318,7 @@ def test_processes_filtering_with_invalid_filter(
                     "status",
                     "workflow",
                     "creator",
-                    "organisation",
+                    "customerId",
                     "product",
                     "tag",
                     "subscription",
@@ -340,7 +340,7 @@ def test_processes_filtering_with_invalid_filter(
         assert process["status"] == "COMPLETED"
 
 
-def test_processes_filtering_with_invalid_organisation(
+def test_processes_filtering_with_invalid_customer_id(
     test_client, mocked_processes, mocked_processes_resumeall, generic_subscription_2, generic_subscription_1
 ):
     # when
@@ -348,7 +348,7 @@ def test_processes_filtering_with_invalid_organisation(
     data = get_processes_query(
         filter_by=[
             {"field": "status", "value": "completed"},
-            {"field": "organisation", "value": "54321447"},
+            {"field": "customerId", "value": "54321447"},
         ]
     )
     response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
@@ -364,10 +364,10 @@ def test_processes_filtering_with_invalid_organisation(
 
     assert errors == [
         {
-            "message": "Not a valid organisation, must be a UUID: '54321447'",
+            "message": "Not a valid customer_id, must be a UUID: '54321447'",
             "path": [None, "processes", "Query"],
             "extensions": {
-                "field": "organisation",
+                "field": "customerId",
                 "value": "54321447",
             },
         }

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -21,7 +21,6 @@ process_fields = [
     "isTask",
     "lastStep",
     "traceback",
-    "customer",
     "id",
     "lastModified",
     "started",
@@ -48,7 +47,6 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
       isTask
       lastStep
       traceback
-      customer
       id
       lastModified
       started
@@ -97,7 +95,6 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
       isTask
       lastStep
       traceback
-      customer
       id
       lastModified
       started
@@ -111,7 +108,6 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
           insync
           endDate
           description
-          customerId
           productId
           startDate
           status
@@ -318,57 +314,12 @@ def test_processes_filtering_with_invalid_filter(
                     "status",
                     "workflow",
                     "creator",
-                    "customerId",
                     "product",
                     "tag",
                     "subscription",
                     "subscriptionId",
                     "target",
                 ],
-            },
-        }
-    ]
-    assert pageinfo == {
-        "hasPreviousPage": False,
-        "hasNextPage": False,
-        "startCursor": 0,
-        "endCursor": 3,
-        "totalItems": "4",
-    }
-
-    for process in processes:
-        assert process["status"] == "COMPLETED"
-
-
-def test_processes_filtering_with_invalid_customer_id(
-    test_client, mocked_processes, mocked_processes_resumeall, generic_subscription_2, generic_subscription_1
-):
-    # when
-
-    data = get_processes_query(
-        filter_by=[
-            {"field": "status", "value": "completed"},
-            {"field": "customerId", "value": "54321447"},
-        ]
-    )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
-
-    # then
-
-    assert HTTPStatus.OK == response.status_code
-    result = response.json()
-    processes_data = result["data"]["processes"]
-    errors = result["errors"]
-    processes = processes_data["page"]
-    pageinfo = processes_data["pageInfo"]
-
-    assert errors == [
-        {
-            "message": "Not a valid customer_id, must be a UUID: '54321447'",
-            "path": [None, "processes", "Query"],
-            "extensions": {
-                "field": "customerId",
-                "value": "54321447",
             },
         }
     ]

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -1,0 +1,649 @@
+# Copyright 2022 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+import json
+from http import HTTPStatus
+from typing import Union
+
+from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.api.test_subscriptions import PORT_A_SUBSCRIPTION_ID, SERVICE_SUBSCRIPTION_ID, seed  # noqa: F401
+
+subscription_fields = [
+    "endDate",
+    "description",
+    "subscriptionId",
+    "startDate",
+    "customerId",
+    "productId",
+    "status",
+    "tag",
+    "insync",
+    "name",
+    "note",
+]
+
+
+def get_subscriptions_query(
+    first: int = 10,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+) -> bytes:
+    query = """
+query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!]) {
+  subscriptions(first: $first, after: $after, sortBy: $sortBy, filterBy: $filterBy) {
+    page {
+      endDate
+      description
+      subscriptionId
+      startDate
+      customerId
+      productId
+      status
+      tag
+      insync
+      name
+      note
+    }
+    pageInfo {
+      startCursor
+      totalItems
+      hasPreviousPage
+      endCursor
+      hasNextPage
+    }
+  }
+}
+    """
+    return json.dumps(
+        {
+            "operationName": "SubscriptionQuery",
+            "query": query,
+            "variables": {
+                "first": first,
+                "after": after,
+                "sortBy": sort_by if sort_by else [],
+                "filterBy": filter_by if filter_by else [],
+            },
+        }
+    ).encode("utf-8")
+
+
+def get_subscriptions_query_with_relations(
+    first: int = 10,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+) -> bytes:
+    query = """
+query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!]) {
+  subscriptions(first: $first, after: $after, sortBy: $sortBy, filterBy: $filterBy) {
+    page {
+      endDate
+      description
+      subscriptionId
+      startDate
+      customerId
+      productId
+      status
+      tag
+      insync
+      name
+      note
+      processes {
+        page {
+          assignee
+          createdBy
+          failedReason
+          isTask
+          lastStep
+          traceback
+          customer
+          id
+          lastModified
+          started
+          workflowName
+          status
+          step
+          product
+        }
+      }
+      dependsOnSubscriptions {
+        page {
+          name
+          insync
+          endDate
+          description
+          customerId
+          productId
+          startDate
+          status
+          subscriptionId
+          tag
+          note
+        }
+      }
+      inUseBySubscriptions {
+        page {
+          name
+          insync
+          endDate
+          description
+          customerId
+          productId
+          startDate
+          status
+          subscriptionId
+          tag
+          note
+        }
+      }
+    }
+    pageInfo {
+      startCursor
+      totalItems
+      hasPreviousPage
+      endCursor
+      hasNextPage
+    }
+  }
+}
+    """
+    return json.dumps(
+        {
+            "operationName": "SubscriptionQuery",
+            "query": query,
+            "variables": {
+                "first": first,
+                "after": after,
+                "sortBy": sort_by if sort_by else [],
+                "filterBy": filter_by if filter_by else [],
+            },
+        }
+    ).encode("utf-8")
+
+
+def test_subscriptions_single_page(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(7)
+    data = get_subscriptions_query()
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 6,
+        "totalItems": "7",
+    }
+
+    for subscription in subscriptions:
+        for field in subscription_fields:
+            assert field in subscription
+
+
+def test_subscriptions_has_next_page(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(30)
+    data = get_subscriptions_query()
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": True,
+        "startCursor": 0,
+        "endCursor": 9,
+        "totalItems": "30",
+    }
+
+    for subscription in subscriptions:
+        for field in subscription_fields:
+            assert field in subscription
+
+
+def test_subscriptions_has_previous_page(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(30)
+    data = get_subscriptions_query(after=1)
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert len(subscriptions) == 10
+
+    assert pageinfo == {
+        "hasPreviousPage": True,
+        "hasNextPage": True,
+        "startCursor": 1,
+        "endCursor": 10,
+        "totalItems": "30",
+    }
+
+
+def test_subscriptions_sorting_asc(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(30)
+    data = get_subscriptions_query(sort_by=[{"field": "start_date", "order": "ASC"}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": True,
+        "startCursor": 0,
+        "endCursor": 9,
+        "totalItems": "30",
+    }
+
+    for i in range(0, 8):
+        assert subscriptions[i]["startDate"] < subscriptions[i + 1]["startDate"]
+
+
+def test_subscriptions_sorting_desc(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(30)
+    data = get_subscriptions_query(sort_by=[{"field": "start_date", "order": "DESC"}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": True,
+        "startCursor": 0,
+        "endCursor": 9,
+        "totalItems": "30",
+    }
+
+    for i in range(0, 8):
+        assert subscriptions[i + 1]["startDate"] < subscriptions[i]["startDate"]
+
+
+def test_subscriptions_filtering_on_status(test_client, generic_subscriptions_factory, generic_product_type_1):
+    # when
+
+    subscription_ids = generic_subscriptions_factory(30)
+
+    GenericProductOneInactive, GenericProductOne = generic_product_type_1
+    subscription_1 = GenericProductOne.from_subscription(subscription_ids[0])
+    subscription_1 = subscription_1.from_other_lifecycle(subscription_1, SubscriptionLifecycle.TERMINATED)
+    subscription_1.save()
+    subscription_9 = GenericProductOne.from_subscription(subscription_ids[8])
+    subscription_9 = subscription_9.from_other_lifecycle(subscription_9, SubscriptionLifecycle.TERMINATED)
+    subscription_9.save()
+
+    data = get_subscriptions_query(filter_by=[{"field": "status", "value": SubscriptionLifecycle.TERMINATED}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 1,
+        "totalItems": "2",
+    }
+
+    assert subscriptions[0]["subscriptionId"] == str(subscription_1.subscription_id)
+    assert subscriptions[0]["status"] == SubscriptionLifecycle.TERMINATED
+    assert subscriptions[1]["subscriptionId"] == str(subscription_9.subscription_id)
+    assert subscriptions[1]["status"] == SubscriptionLifecycle.TERMINATED
+
+
+def test_subscriptions_range_filtering_on_start_date(test_client, generic_subscriptions_factory):
+    # when
+
+    generic_subscriptions_factory(30)
+    higher_then_date = datetime.datetime.now().isoformat()
+    lower_then_date = (datetime.datetime.now() + datetime.timedelta(days=3)).isoformat()
+
+    data = get_subscriptions_query(
+        filter_by=[
+            {"field": "startDateGte", "value": higher_then_date},
+            {"field": "startDateLte", "value": lower_then_date},
+        ]
+    )
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 2,
+        "totalItems": "3",
+    }
+
+    for subscription in subscriptions:
+        assert higher_then_date < subscription["startDate"] < lower_then_date
+
+
+def test_subscriptions_filtering_with_invalid_filter(
+    test_client, generic_subscriptions_factory, generic_product_type_1
+):
+    # when
+
+    subscription_ids = generic_subscriptions_factory(30)
+
+    GenericProductOneInactive, GenericProductOne = generic_product_type_1
+    subscription_1 = GenericProductOne.from_subscription(subscription_ids[0])
+    subscription_1 = subscription_1.from_other_lifecycle(subscription_1, SubscriptionLifecycle.TERMINATED)
+    subscription_1.save()
+    subscription_9 = GenericProductOne.from_subscription(subscription_ids[8])
+    subscription_9 = subscription_9.from_other_lifecycle(subscription_9, SubscriptionLifecycle.TERMINATED)
+    subscription_9.save()
+
+    data = get_subscriptions_query(
+        filter_by=[
+            {"field": "status", "value": SubscriptionLifecycle.TERMINATED},
+            {"field": "test", "value": "invalid"},
+        ]
+    )
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    errors = result["errors"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert errors == [
+        {
+            "message": "Invalid filter arguments",
+            "path": [None, "subscriptions", "Query"],
+            "extensions": {
+                "invalid_filters": [{"field": "test", "value": "invalid"}],
+                "valid_filter_keys": [
+                    "subscriptionId",
+                    "subscriptionIds",
+                    "description",
+                    "status",
+                    "product",
+                    "customerId",
+                    "insync",
+                    "note",
+                    "statuses",
+                    "tags",
+                    "tag",
+                    "tsv",
+                    "startDate",
+                    "endDate",
+                    "startDateGt",
+                    "startDateGte",
+                    "startDateLt",
+                    "startDateLte",
+                    "startDateNe",
+                    "endDateGt",
+                    "endDateGte",
+                    "endDateLt",
+                    "endDateLte",
+                    "endDateNe",
+                ],
+            },
+        }
+    ]
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 1,
+        "totalItems": "2",
+    }
+
+    for subscription in subscriptions:
+        assert subscription["status"] == SubscriptionLifecycle.TERMINATED
+
+
+def test_subscriptions_filtering_with_invalid_customer_id(
+    test_client, generic_subscriptions_factory, generic_product_type_1
+):
+    # when
+
+    subscription_ids = generic_subscriptions_factory(30)
+
+    GenericProductOneInactive, GenericProductOne = generic_product_type_1
+    subscription_1 = GenericProductOne.from_subscription(subscription_ids[0])
+    subscription_1 = subscription_1.from_other_lifecycle(subscription_1, SubscriptionLifecycle.TERMINATED)
+    subscription_1.save()
+    subscription_9 = GenericProductOne.from_subscription(subscription_ids[8])
+    subscription_9 = subscription_9.from_other_lifecycle(subscription_9, SubscriptionLifecycle.TERMINATED)
+    subscription_9.save()
+
+    data = get_subscriptions_query(
+        filter_by=[
+            {"field": "status", "value": SubscriptionLifecycle.TERMINATED},
+            {"field": "customerId", "value": "54321447"},
+        ]
+    )
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    errors = result["errors"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert errors == [
+        {
+            "message": "Not a valid customer_id, must be a UUID: '54321447'",
+            "path": [None, "subscriptions", "Query"],
+            "extensions": {
+                "field": "customerId",
+                "value": "54321447",
+            },
+        }
+    ]
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 1,
+        "totalItems": "2",
+    }
+
+    for subscription in subscriptions:
+        assert subscription["status"] == SubscriptionLifecycle.TERMINATED
+
+
+def test_single_subscription(test_client, generic_subscriptions_factory):
+    # when
+
+    subscription_ids = generic_subscriptions_factory(30)
+    subscription_id = subscription_ids[10]
+    data = get_subscriptions_query(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert len(subscriptions) == 1
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 0,
+        "totalItems": "1",
+    }
+    assert subscriptions[0]["subscriptionId"] == subscription_id
+
+
+def test_single_subscription_with_processes(
+    test_client,
+    generic_subscriptions_factory,
+    mocked_processes,
+    mocked_processes_resumeall,  # noqa: F811
+    generic_subscription_2,  # noqa: F811
+    generic_subscription_1,
+):
+    # when
+
+    generic_subscriptions_factory(30)
+    subscription_id = generic_subscription_1
+    data = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert len(subscriptions) == 1
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 0,
+        "totalItems": "1",
+    }
+    assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert subscriptions[0]["processes"]["page"][0]["id"] == str(mocked_processes[0])
+
+
+def test_single_subscription_with_depends_on_subscriptions(
+    test_client, generic_subscriptions_factory, seed  # noqa: F811
+):
+    # when
+
+    generic_subscriptions_factory(30)
+    subscription_id = SERVICE_SUBSCRIPTION_ID
+    data = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert len(subscriptions) == 1
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 0,
+        "totalItems": "1",
+    }
+    assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert len(subscriptions[0]["processes"]["page"]) == 0
+    assert subscriptions[0]["dependsOnSubscriptions"]["page"][0]["subscriptionId"] == PORT_A_SUBSCRIPTION_ID
+    assert len(subscriptions[0]["inUseBySubscriptions"]["page"]) == 0
+
+
+def test_single_subscription_with_in_use_by_subscriptions(
+    test_client, generic_subscriptions_factory, seed  # noqa: F811
+):
+    # when
+
+    generic_subscriptions_factory(30)
+    subscription_id = PORT_A_SUBSCRIPTION_ID
+    data = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    subscriptions_data = result["data"]["subscriptions"]
+    subscriptions = subscriptions_data["page"]
+    pageinfo = subscriptions_data["pageInfo"]
+
+    assert len(subscriptions) == 1
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": False,
+        "startCursor": 0,
+        "endCursor": 0,
+        "totalItems": "1",
+    }
+    assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert len(subscriptions[0]["processes"]["page"]) == 0
+    assert len(subscriptions[0]["dependsOnSubscriptions"]["page"]) == 0
+    assert subscriptions[0]["inUseBySubscriptions"]["page"][0]["subscriptionId"] == SERVICE_SUBSCRIPTION_ID

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -27,6 +27,12 @@ subscription_fields = [
     "status",
     "tag",
     "insync",
+    "note",
+    "product",
+    "productBlocks",
+]
+subscription_product_fields = [
+    "productId",
     "name",
     "note",
 ]
@@ -52,6 +58,24 @@ query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $fi
       insync
       name
       note
+      startDate
+      endDate
+      productBlocks {
+        id
+        parent
+        ownerSubscriptionId
+        resourceTypes
+      }
+      product {
+        productId
+        name
+        description
+        productType
+        status
+        tag
+        createdAt
+        endDate
+      }
     }
     pageInfo {
       startCursor
@@ -487,6 +511,20 @@ def test_single_subscription(test_client, generic_subscriptions_factory):
         "totalItems": "1",
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert subscriptions[0]["productBlocks"] == [
+        {
+            "id": 0,
+            "ownerSubscriptionId": subscription_id,
+            "parent": None,
+            "resourceTypes": {"label": None, "name": "PB_1", "rt1": "Value1"},
+        },
+        {
+            "id": 1,
+            "ownerSubscriptionId": subscription_id,
+            "parent": None,
+            "resourceTypes": {"label": None, "name": "PB_2", "rt2": 42, "rt3": "Value2"},
+        },
+    ]
 
 
 def test_single_subscription_with_processes(


### PR DESCRIPTION
- use processes_resolver in subscription schema to resolve processes of a subscription.
- use subscriptions_resolver in processes schema to resolve subscriptions of a process.
- add subscriptions db filters and sorting.
- add generic filters to remove duplicated code.
- use subscriptions_resolver in subscriptions schema to resolve depends_on and in_use_by subscriptions.
- make date filter better so you don't need an exact isoformat date.
- test subscriptions schema.