### PR TITLE
Bump redis to >=4.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
 ]
 dependencies = [
     "alembic==1.5.4",
+    "anyio>=3.7.0",
     "broadcaster[redis]==0.2.0",
     "click==8.0.3",
     "deepmerge==0.1.0",
@@ -59,7 +60,7 @@ dependencies = [
     "python-dateutil==2.8.2",
     "python-rapidjson==1.9",
     "pytz==2022.7.1",
-    "redis~=4.4.2",
+    "redis>=4.5.5,<4.6",
     "schedule==1.1.0",
     "sentry-sdk[fastapi]==1.15.0",
     "SQLAlchemy==1.4.28",


### PR DESCRIPTION
Because of https://github.com/redis/redis-py/issues/2633