### PR TITLE
Optimize subscription search re-indexing

### DIFF
--- a/orchestrator/migrations/versions/schema/2023-06-28_a09ac125ea73_add_throttling_to_refresh_subscriptions.py
+++ b/orchestrator/migrations/versions/schema/2023-06-28_a09ac125ea73_add_throttling_to_refresh_subscriptions.py
@@ -1,0 +1,28 @@
+"""Add throttling to refresh_subscriptions_view trigger.
+
+Revision ID: a09ac125ea73
+Revises: b1970225392d
+Create Date: 2023-06-28 15:33:36.248121
+
+"""
+from pathlib import Path
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a09ac125ea73"
+down_revision = "b1970225392d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    revision_file_path = Path(__file__)
+    with open(revision_file_path.with_suffix(".sql")) as f:
+        conn.execute(f.read())
+
+
+def downgrade() -> None:
+    pass

--- a/orchestrator/migrations/versions/schema/2023-06-28_a09ac125ea73_add_throttling_to_refresh_subscriptions.sql
+++ b/orchestrator/migrations/versions/schema/2023-06-28_a09ac125ea73_add_throttling_to_refresh_subscriptions.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION refresh_subscriptions_search_view()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    should_refresh     bool;
+    current_epoch      int;
+    last_refresh_epoch int;
+    comment_sql        text;
+BEGIN
+    SELECT extract(epoch from now())::int INTO current_epoch;
+    SELECT coalesce(pg_catalog.obj_description('subscriptions_search'::regclass)::int, 0) INTO last_refresh_epoch;
+
+    SELECT (current_epoch - last_refresh_epoch) > 120 INTO should_refresh;
+
+    IF should_refresh THEN
+        REFRESH MATERIALIZED VIEW subscriptions_search;
+
+        comment_sql := 'COMMENT ON MATERIALIZED VIEW subscriptions_search IS ' || quote_literal(current_epoch);
+        EXECUTE comment_sql;
+    END IF;
+    RETURN NULL;
+END;
+$$;


### PR DESCRIPTION
- Put a last refresh timestamp on the subscriptions_search_view metadata
- Update trigger function to check for the last_refresh timestamp
- Don't refresh if last refresh was less than specified interval (currently 120 seconds)