### PR TITLE
#299 load resource types together with productblocks

### DIFF
--- a/orchestrator/api/api_v1/endpoints/products.py
+++ b/orchestrator/api/api_v1/endpoints/products.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from orchestrator.api.error_handling import raise_status
 from orchestrator.api.models import delete, save, update
-from orchestrator.db import ProductTable, SubscriptionTable
+from orchestrator.db import ProductBlockTable, ProductTable, SubscriptionTable
 from orchestrator.domain.lifecycle import ProductLifecycle
 from orchestrator.schemas import ProductCRUDSchema, ProductSchema
 from orchestrator.services.products import get_tags, get_types
@@ -32,7 +32,9 @@ router = APIRouter()
 @router.get("/", response_model=List[ProductSchema])
 def fetch(tag: Optional[str] = None, product_type: Optional[str] = None) -> List[ProductSchema]:
     query = ProductTable.query.options(
-        selectinload("workflows"), selectinload("fixed_inputs"), selectinload("product_blocks")
+        selectinload(ProductTable.workflows),
+        selectinload(ProductTable.fixed_inputs),
+        selectinload(ProductTable.product_blocks).selectinload(ProductBlockTable.resource_types),
     )
     if tag:
         query = query.filter(ProductTable.__dict__["tag"] == tag)


### PR DESCRIPTION
Small improvement to the "get all products" endpoint: resource_types were previously lazy loaded, now they're retrieved in 1 query.

Local tests don't show a big impact on the query time however. This endpoint now performs a few queries to retrieve products, product blocks, resource types, workflows and fixed inputs. The query plans shows each of them performs a sequential scan, which seemed wrong given that there are indexes on all of the ID columns, but this is apparently [a good thing](https://stackoverflow.com/a/5203827/1284043) when all of the table's rows are selected.

Closes #299 