### PR TITLE
#278: Fix lists with false values not saved in subscription

### DIFF
--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -737,11 +737,6 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
             else:
                 instance_values_dict[resource_type_name] = siv.value
 
-        # Make sure values are sorted. This already happens when they come from the db.
-        # However newly created SubscriptionInstances might not have the correct order
-        for field_name in list_field_names:
-            instance_values_dict[field_name] = sorted(instance_values_dict[field_name])
-
         return instance_values_dict
 
     @classmethod
@@ -850,7 +845,7 @@ class ProductBlockModel(DomainModel, metaclass=ProductBlockModelMeta):
                 continue
             if is_list_type(field_type):
                 for val, siv in zip_longest(value, current_values_dict[field_name]):
-                    if val:
+                    if val is not None:
                         if siv:
                             siv.value = str(val)
                             subscription_instance_values.append(siv)

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -1281,3 +1281,31 @@ def test_inherited_serializable_property():
     block = ActiveDomainModel(int_field=1)
 
     assert block.dict() == {"int_field": 1, "double_int_field": 2, "triple_int_field": 30}
+
+
+def test_subscription_save_list_with_zero_values(
+    test_product_type_one, test_product_sub_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    subscription.block.list_field = [10, 0, 20, 30, 40, 0, 0]
+    subscription.save()
+    assert subscription.block.list_field == [10, 0, 20, 30, 40, 0, 0]
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    assert subscription.block.list_field == [10, 0, 20, 30, 40, 0, 0]
+
+
+def test_subscription_save_bool_list_with_false_values(
+    test_product_type_one, test_product_sub_block_one, product_one_subscription_1
+):
+    _, _, ProductTypeOneForTest = test_product_type_one
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    subscription.block.list_field = [True, False, True, False]
+    subscription.save()
+    assert subscription.block.list_field == [True, False, True, False]
+
+    subscription = ProductTypeOneForTest.from_subscription(product_one_subscription_1)
+    assert subscription.block.list_field == [True, False, True, False]


### PR DESCRIPTION
- remove sorting on _load_instances_values.
- add tests.

Closes: #278 