### PR TITLE
Pin mkdocs lower then 1.5 since it fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test = [
     "types-PyYAML"
 ]
 doc = [
-    "mkdocs",
+    "mkdocs<1.5", # mkdocs 1.5 fails to build https://github.com/squidfunk/mkdocs-material/issues/5772
     "mkdocs-material",
     "mkdocs-render-swagger-plugin",
     "mkdocs-include-markdown-plugin"


### PR DESCRIPTION
mkdocs fails in 1.5 and 1.5.1, there is already an issue: https://github.com/squidfunk/mkdocs-material/issues/5772

hopefully this PR fixes it: https://github.com/squidfunk/mkdocs-material/issues/5778

When the above is merged we can test to remove the pin.