### PR TITLE
Add JSON Schema of subscription to subscription graphql type

### DIFF
--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -19,6 +19,7 @@ from orchestrator.graphql.types import GraphqlFilter, GraphqlSort, OrchestratorI
 from orchestrator.graphql.utils.get_subscription_product_blocks import (
     ProductBlockInstance,
     get_subscription_product_blocks,
+    get_subscription_product_blocks_json_schema,
 )
 from orchestrator.services.subscriptions import (
     get_subscription_metadata,
@@ -49,6 +50,10 @@ class SubscriptionInterface:
         self, tags: Optional[list[str]] = None, resource_types: Optional[list[str]] = None
     ) -> list[ProductBlockInstance]:
         return await get_subscription_product_blocks(self.subscription_id, tags, resource_types)
+
+    @strawberry.field(description="Return all products block instances of a subscription as JSON Schema")  # type: ignore
+    async def product_block_instance_shema(self) -> dict:
+        return await get_subscription_product_blocks_json_schema(self.subscription_id)
 
     @strawberry.field(description="Return all products blocks that are part of a subscription", deprecation_reason="changed to product_block_instances")  # type: ignore
     async def product_blocks(

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -52,7 +52,7 @@ class SubscriptionInterface:
         return await get_subscription_product_blocks(self.subscription_id, tags, resource_types)
 
     @strawberry.field(description="Return all products block instances of a subscription as JSON Schema")  # type: ignore
-    async def product_block_instance_shema(self) -> dict:
+    async def product_blocks_json_schema(self) -> dict:
         return await get_subscription_product_blocks_json_schema(self.subscription_id)
 
     @strawberry.field(description="Return all products blocks that are part of a subscription", deprecation_reason="changed to product_block_instances")  # type: ignore

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -12,20 +12,12 @@ from orchestrator.domain.base import SubscriptionModel
 from orchestrator.services.subscriptions import build_extended_domain_model
 
 
-class ProductBlockInstancePydantic(BaseModel):
+@strawberry.type
+class ProductBlockInstance:
     id: int
     parent: Optional[int]
     subscription_instance_id: UUID
     owner_subscription_id: UUID
-    product_block_instance_values: dict
-
-
-@strawberry.experimental.pydantic.type(ProductBlockInstancePydantic)
-class ProductBlockInstance:
-    id: strawberry.auto
-    parent: strawberry.auto
-    subscription_instance_id: strawberry.auto
-    owner_subscription_id: strawberry.auto
     product_block_instance_values: JSON
 
     @strawberry.field(description="Returns all resource types of a product block", deprecation_reason="changed to product_block_instance_values")  # type: ignore

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -98,7 +98,7 @@ async def get_subscription_product_blocks_json_schema(subscription_id: UUID) -> 
 
     root_block_paths = [path for path in block_paths if "." not in path and path != "product"]
     pydanticModel: type[BaseModel] = type(
-        "Blocks", (BaseModel,), {path: getattr_in(subscription_model, path) for path in root_block_paths}
+        "ProductBlocks", (BaseModel,), {path: getattr_in(subscription_model, path) for path in root_block_paths}
     )
     json_schema: dict = pydanticModel.schema()
     data = {}

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -97,8 +97,8 @@ async def get_subscription_product_blocks_json_schema(subscription_id: UUID) -> 
 
     def format_property(key: str, item: dict) -> dict:
         data[key] = item["default"]
-        return item["allOf"]
+        del item["default"]
+        return item
 
     json_schema["properties"] = {key: format_property(key, item) for key, item in json_schema["properties"].items()}
-
-    return json_schema | data
+    return {"__schema__": json_schema} | data

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -3,11 +3,9 @@ from typing import Any, Generator, Optional
 from uuid import UUID
 
 import strawberry
-from pydantic import BaseModel
 from pydantic.utils import to_lower_camel
 from strawberry.scalars import JSON
 
-from orchestrator.api.helpers import getattr_in, product_block_paths
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.services.subscriptions import build_extended_domain_model
 
@@ -81,24 +79,3 @@ async def get_subscription_product_blocks(
 
     product_blocks = (to_product_block(product_block) for product_block in get_all_product_blocks(subscription, tags))
     return [product_block for product_block in product_blocks if product_block.product_block_instance_values]
-
-
-async def get_subscription_product_blocks_json_schema(subscription_id: UUID) -> dict:
-    subscription_model = SubscriptionModel.from_subscription(subscription_id)
-    subscription = build_extended_domain_model(subscription_model)
-    block_paths = product_block_paths(subscription)
-
-    root_block_paths = [path for path in block_paths if "." not in path and path != "product"]
-    pydanticModel: type[BaseModel] = type(
-        "ProductBlocks", (BaseModel,), {path: getattr_in(subscription_model, path) for path in root_block_paths}
-    )
-    json_schema: dict = pydanticModel.schema()
-    data = {}
-
-    def format_property(key: str, item: dict) -> dict:
-        data[key] = item["default"]
-        del item["default"]
-        return item
-
-    json_schema["properties"] = {key: format_property(key, item) for key, item in json_schema["properties"].items()}
-    return {"__schema__": json_schema} | data

--- a/orchestrator/utils/vlans.py
+++ b/orchestrator/utils/vlans.py
@@ -183,3 +183,12 @@ class VlanRanges(abc.Set):
         if isinstance(v, VlanRanges):
             return v
         return cls(v)
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: dict) -> None:
+        field_schema.update(
+            pattern="^([1-4][0-9]{0,3}(-[1-4][0-9]{0,3})?,?)+$",
+            examples=["345", "20-23,45,50-100"],
+            type="string",
+            format="vlan",
+        )

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 import datetime
 import json
+import sys
 from http import HTTPStatus
 from typing import Union
 
@@ -944,6 +945,7 @@ def test_single_subscription_with_in_use_by_subscriptions(
     assert result_in_use_by_ids == expected_in_use_by_ids
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="types get different origin with 3.10 and higher")
 def test_single_subscription_with_product_block_instance_schema(
     fastapi_app_graphql,
     test_client,

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -974,81 +974,88 @@ def test_single_subscription_with_product_block_instance_schema(
 
     assert "errors" not in result
     assert subscriptions[0]["productBlocksJsonSchema"] == {
-        "title": "ProductBlocks",
-        "type": "object",
-        "properties": {"test_block": [{"$ref": "#/definitions/ProductBlockWithListUnionForTest"}]},
-        "definitions": {
-            "SubBlockTwoForTest": {
-                "title": "SubBlockTwoForTest",
-                "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field_2:\n            Type :class:`~builtins.int`",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "subscription_instance_id": {
-                        "title": "Subscription Instance Id",
-                        "type": "string",
-                        "format": "uuid",
-                    },
-                    "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
-                    "label": {"title": "Label", "type": "string"},
-                    "int_field_2": {"title": "Int Field 2", "type": "integer"},
-                },
-                "required": ["name", "subscription_instance_id", "owner_subscription_id", "int_field_2"],
+        "__schema__": {
+            "title": "ProductBlocks",
+            "type": "object",
+            "properties": {
+                "test_block": {
+                    "title": "Test Block",
+                    "allOf": [{"$ref": "#/definitions/ProductBlockWithListUnionForTest"}],
+                }
             },
-            "SubBlockOneForTest": {
-                "title": "SubBlockOneForTest",
-                "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field:\n            Type :class:`~builtins.int`\n        str_field:\n            Type :class:`~builtins.str`",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "subscription_instance_id": {
-                        "title": "Subscription Instance Id",
-                        "type": "string",
-                        "format": "uuid",
-                    },
-                    "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
-                    "label": {"title": "Label", "type": "string"},
-                    "int_field": {"title": "Int Field", "type": "integer"},
-                    "str_field": {"title": "Str Field", "type": "string"},
-                },
-                "required": ["name", "subscription_instance_id", "owner_subscription_id", "int_field", "str_field"],
-            },
-            "ProductBlockWithListUnionForTest": {
-                "title": "ProductBlockWithListUnionForTest",
-                "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field:\n            Type :class:`~builtins.int`\n        str_field:\n            Type :class:`~builtins.str`\n        list_field:\n            \n\n            Type :class:`~typing.List`\nBlocks:\n\n        list_union_blocks:\n            \n\n            Type :class:`~typing.List`",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "subscription_instance_id": {
-                        "title": "Subscription Instance Id",
-                        "type": "string",
-                        "format": "uuid",
-                    },
-                    "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
-                    "label": {"title": "Label", "type": "string"},
-                    "list_union_blocks": {
-                        "title": "List Union Blocks",
-                        "type": "array",
-                        "items": {
-                            "anyOf": [
-                                {"$ref": "#/definitions/SubBlockTwoForTest"},
-                                {"$ref": "#/definitions/SubBlockOneForTest"},
-                            ]
+            "definitions": {
+                "SubBlockTwoForTest": {
+                    "title": "SubBlockTwoForTest",
+                    "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field_2:\n            Type :class:`~builtins.int`",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "subscription_instance_id": {
+                            "title": "Subscription Instance Id",
+                            "type": "string",
+                            "format": "uuid",
                         },
+                        "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
+                        "label": {"title": "Label", "type": "string"},
+                        "int_field_2": {"title": "Int Field 2", "type": "integer"},
                     },
-                    "int_field": {"title": "Int Field", "type": "integer"},
-                    "str_field": {"title": "Str Field", "type": "string"},
-                    "list_field": {"title": "List Field", "type": "array", "items": {"type": "integer"}},
+                    "required": ["name", "subscription_instance_id", "owner_subscription_id", "int_field_2"],
                 },
-                "required": [
-                    "name",
-                    "subscription_instance_id",
-                    "owner_subscription_id",
-                    "list_union_blocks",
-                    "int_field",
-                    "str_field",
-                    "list_field",
-                ],
+                "SubBlockOneForTest": {
+                    "title": "SubBlockOneForTest",
+                    "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field:\n            Type :class:`~builtins.int`\n        str_field:\n            Type :class:`~builtins.str`",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "subscription_instance_id": {
+                            "title": "Subscription Instance Id",
+                            "type": "string",
+                            "format": "uuid",
+                        },
+                        "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
+                        "label": {"title": "Label", "type": "string"},
+                        "int_field": {"title": "Int Field", "type": "integer"},
+                        "str_field": {"title": "Str Field", "type": "string"},
+                    },
+                    "required": ["name", "subscription_instance_id", "owner_subscription_id", "int_field", "str_field"],
+                },
+                "ProductBlockWithListUnionForTest": {
+                    "title": "ProductBlockWithListUnionForTest",
+                    "description": "Valid for statuses: active\n\n\nInstance Values:\n\n        int_field:\n            Type :class:`~builtins.int`\n        str_field:\n            Type :class:`~builtins.str`\n        list_field:\n            \n\n            Type :class:`~typing.List`\nBlocks:\n\n        list_union_blocks:\n            \n\n            Type :class:`~typing.List`",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "subscription_instance_id": {
+                            "title": "Subscription Instance Id",
+                            "type": "string",
+                            "format": "uuid",
+                        },
+                        "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
+                        "label": {"title": "Label", "type": "string"},
+                        "list_union_blocks": {
+                            "title": "List Union Blocks",
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {"$ref": "#/definitions/SubBlockTwoForTest"},
+                                    {"$ref": "#/definitions/SubBlockOneForTest"},
+                                ]
+                            },
+                        },
+                        "int_field": {"title": "Int Field", "type": "integer"},
+                        "str_field": {"title": "Str Field", "type": "string"},
+                        "list_field": {"title": "List Field", "type": "array", "items": {"type": "integer"}},
+                    },
+                    "required": [
+                        "name",
+                        "subscription_instance_id",
+                        "owner_subscription_id",
+                        "list_union_blocks",
+                        "int_field",
+                        "str_field",
+                        "list_field",
+                    ],
+                },
             },
         },
         "test_block": {


### PR DESCRIPTION
adds `_schema` to subscription type which returns a dict with JSON Schema data. anything with `__` is reserved by graphql introspect.

example of a ProductBlocksJsonSchema:
```json
{
    "title": "ProductSubListUnionInactive",
    "description": "Valid for statuses: all others\n\nSee `active` version.",
    "type": "object",
    "properties": {
        "product": {"$ref": "#/definitions/ProductModel"},
        "customer_id": {"title": "Customer Id", "type": "string"},
        "subscription_id": {"title": "Subscription Id", "type": "string", "format": "uuid"},
        "description": {"title": "Description", "default": "Initial subscription", "type": "string"},
        "status": {"default": "initial", "allOf": [{"$ref": "#/definitions/SubscriptionLifecycle"}]},
        "insync": {"title": "Insync", "default": False, "type": "boolean"},
        "start_date": {"title": "Start Date", "type": "string", "format": "date-time"},
        "end_date": {"title": "End Date", "type": "string", "format": "date-time"},
        "note": {"title": "Note", "type": "string"},
        "test_block": {"$ref": "#/definitions/ProductBlockWithListUnionForTestInactive"},
    },
    "required": ["product", "customer_id"],
    "definitions": {
        "ProductLifecycle": {
            "title": "ProductLifecycle",
            "description": "An enumeration.",
            "enum": ["active", "pre production", "phase out", "end of life"],
            "type": "string",
        },
        "ProductModel": {
            "title": "ProductModel",
            "description": "Represent the product as defined in the database as a dataclass.",
            "type": "object",
            "properties": {
                "product_id": {"title": "Product Id", "type": "string", "format": "uuid"},
                "name": {"title": "Name", "type": "string"},
                "description": {"title": "Description", "type": "string"},
                "product_type": {"title": "Product Type", "type": "string"},
                "tag": {"title": "Tag", "type": "string"},
                "status": {"$ref": "#/definitions/ProductLifecycle"},
                "created_at": {"title": "Created At", "type": "string", "format": "date-time"},
                "end_date": {"title": "End Date", "type": "string", "format": "date-time"},
            },
            "required": ["product_id", "name", "description", "product_type", "tag", "status"],
        },
        "SubscriptionLifecycle": {
            "title": "SubscriptionLifecycle",
            "description": "An enumeration.",
            "enum": ["initial", "active", "migrating", "disabled", "terminated", "provisioning"],
            "type": "string",
        },
        "SubBlockTwoForTestInactive": {
            "title": "SubBlockTwoForTestInactive",
            "description": "Valid for statuses: all others\n\nSee `active` version.",
            "type": "object",
            "properties": {
                "name": {"title": "Name", "type": "string"},
                "subscription_instance_id": {
                    "title": "Subscription Instance Id",
                    "type": "string",
                    "format": "uuid",
                },
                "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
                "label": {"title": "Label", "type": "string"},
                "int_field_2": {"title": "Int Field 2", "type": "integer"},
            },
            "required": ["name", "subscription_instance_id", "owner_subscription_id", "int_field_2"],
        },
        "SubBlockOneForTestInactive": {
            "title": "SubBlockOneForTestInactive",
            "description": "Valid for statuses: all others\n\nSee `active` version.",
            "type": "object",
            "properties": {
                "name": {"title": "Name", "type": "string"},
                "subscription_instance_id": {
                    "title": "Subscription Instance Id",
                    "type": "string",
                    "format": "uuid",
                },
                "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
                "label": {"title": "Label", "type": "string"},
                "int_field": {"title": "Int Field", "type": "integer"},
                "str_field": {"title": "Str Field", "type": "string"},
            },
            "required": ["name", "subscription_instance_id", "owner_subscription_id"],
        },
        "ProductBlockWithListUnionForTestInactive": {
            "title": "ProductBlockWithListUnionForTestInactive",
            "description": "Valid for statuses: all others\n\nSee `active` version.",
            "type": "object",
            "properties": {
                "name": {"title": "Name", "type": "string"},
                "subscription_instance_id": {
                    "title": "Subscription Instance Id",
                    "type": "string",
                    "format": "uuid",
                },
                "owner_subscription_id": {"title": "Owner Subscription Id", "type": "string", "format": "uuid"},
                "label": {"title": "Label", "type": "string"},
                "list_union_blocks": {
                    "title": "List Union Blocks",
                    "type": "array",
                    "items": {
                        "anyOf": [
                            {"$ref": "#/definitions/SubBlockTwoForTestInactive"},
                            {"$ref": "#/definitions/SubBlockOneForTestInactive"},
                        ]
                    },
                },
                "int_field": {"title": "Int Field", "type": "integer"},
                "str_field": {"title": "Str Field", "type": "string"},
                "list_field": {"title": "List Field", "type": "array", "items": {"type": "integer"}},
            },
            "required": ["name", "subscription_instance_id", "owner_subscription_id", "list_union_blocks"],
        },
    },
}
```

Related: #270