### PR TITLE
Fix product sorting for processes graphql resource

### DIFF
--- a/orchestrator/db/filters/workflow.py
+++ b/orchestrator/db/filters/workflow.py
@@ -1,15 +1,17 @@
 from typing import Callable
 
 import structlog
+from sqlalchemy.inspection import inspect
 
 from orchestrator.db import ProductTable, WorkflowTable
 from orchestrator.db.database import SearchQuery
 from orchestrator.db.filters import generic_filter
 from orchestrator.db.filters.generic_filters import generic_is_like_filter, generic_range_filters
+from orchestrator.utils.helpers import to_camel
 
 logger = structlog.get_logger(__name__)
 
-start_date_range_filters = generic_range_filters(WorkflowTable.created_at)
+created_at_range_filters = generic_range_filters(WorkflowTable.created_at)
 
 
 def products_filter(query: SearchQuery, value: str) -> SearchQuery:
@@ -18,12 +20,10 @@ def products_filter(query: SearchQuery, value: str) -> SearchQuery:
     return query.filter(WorkflowTable.products.any(ProductTable.name.in_(products)))
 
 
-WORKFLOW_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
-    "workflowId": generic_is_like_filter(WorkflowTable.workflow_id),
-    "name": generic_is_like_filter(WorkflowTable.name),
-    "description": generic_is_like_filter(WorkflowTable.description),
-    "createdAt": generic_is_like_filter(WorkflowTable.created_at),
-    "products": products_filter,
-} | start_date_range_filters
+BASE_CAMEL = {to_camel(key): generic_is_like_filter(value) for key, value in inspect(WorkflowTable).columns.items()}
+
+WORKFLOW_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+    BASE_CAMEL | {"products": products_filter} | created_at_range_filters
+)
 
 filter_workflows = generic_filter(WORKFLOW_FILTER_FUNCTIONS_BY_COLUMN)

--- a/orchestrator/db/sorting/process.py
+++ b/orchestrator/db/sorting/process.py
@@ -1,32 +1,45 @@
-from sqlalchemy.inspection import inspect
+from typing import Callable
 
-from orchestrator.db import ProcessTable
-from orchestrator.db.sorting.product import PRODUCT_SORT_FUNCTIONS_BY_COLUMN
-from orchestrator.db.sorting.sorting import generic_column_sort, generic_sort
+from sqlalchemy import Column
+from sqlalchemy.inspection import inspect
+from sqlalchemy.sql import expression
+
+from orchestrator.db import ProcessSubscriptionTable, ProcessTable, ProductTable, SubscriptionTable
+from orchestrator.db.database import SearchQuery
+from orchestrator.db.sorting.sorting import SortOrder, generic_column_sort, generic_sort
 from orchestrator.utils.helpers import to_camel
 
 PROCESS_CAMEL_SORT = {to_camel(key): generic_column_sort(value) for key, value in inspect(ProcessTable).columns.items()}
 PROCESS_SNAKE_SORT = {key: generic_column_sort(value) for key, value in inspect(ProcessTable).columns.items()}
+
+
+def generic_process_product_sort(field: Column) -> Callable[[SearchQuery, SortOrder], SearchQuery]:
+    def sort_function(query: SearchQuery, order: SortOrder) -> SearchQuery:
+        joined_query = query.join(ProcessSubscriptionTable).join(SubscriptionTable).join(ProductTable)
+        if order == SortOrder.DESC:
+            return joined_query.order_by(expression.desc(field))
+        return joined_query.order_by(expression.asc(field))
+
+    return sort_function
+
+
 PROCESS_PRODUCT_SORT = {
-    to_camel(key if "product" in key else f"product_{key}"): value
-    for key, value in PRODUCT_SORT_FUNCTIONS_BY_COLUMN.items()
+    to_camel(key if "product" in key else f"product_{key}"): generic_process_product_sort(value)
+    for key, value in inspect(ProductTable).columns.items()
 }
 
-PROCESS_SORT_FUNCTIONS_BY_COLUMN = PROCESS_PRODUCT_SORT | PROCESS_SNAKE_SORT | PROCESS_CAMEL_SORT
-PROCESS_SORT_FUNCTIONS_BY_COLUMN["workflow"] = generic_column_sort(
-    ProcessTable.workflow_name
-)  # TODO: deprecated, remove in 1.3
-PROCESS_SORT_FUNCTIONS_BY_COLUMN["status"] = generic_column_sort(
-    ProcessTable.last_status
-)  # TODO: deprecated, remove in 1.3
-PROCESS_SORT_FUNCTIONS_BY_COLUMN["creator"] = generic_column_sort(
-    ProcessTable.created_by
-)  # TODO: deprecated, remove in 1.3
-PROCESS_SORT_FUNCTIONS_BY_COLUMN["started"] = generic_column_sort(
-    ProcessTable.started_at
-)  # TODO: deprecated, remove in 1.3
-PROCESS_SORT_FUNCTIONS_BY_COLUMN["modified"] = generic_column_sort(
-    ProcessTable.last_modified_at
-)  # TODO: deprecated, remove in 1.3
+
+PROCESS_SORT_FUNCTIONS_BY_COLUMN = (
+    PROCESS_PRODUCT_SORT
+    | PROCESS_CAMEL_SORT
+    | PROCESS_SNAKE_SORT
+    | {
+        "workflow": generic_column_sort(ProcessTable.workflow_name),  # TODO: deprecated, remove in 1.4
+        "status": generic_column_sort(ProcessTable.last_status),  # TODO: deprecated, remove in 1.4
+        "creator": generic_column_sort(ProcessTable.created_by),  # TODO: deprecated, remove in 1.4
+        "started": generic_column_sort(ProcessTable.started_at),  # TODO: deprecated, remove in 1.4
+        "modified": generic_column_sort(ProcessTable.last_modified_at),  # TODO: deprecated, remove in 1.4
+    }
+)
 
 sort_processes = generic_sort(PROCESS_SORT_FUNCTIONS_BY_COLUMN)

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -460,3 +460,45 @@ def test_single_process_with_subscriptions(
     }
     assert processes[0]["processId"] == process_pid
     assert processes[0]["subscriptions"]["page"][0]["subscriptionId"] == generic_subscription_1
+
+
+def test_processes_sorting_product_tag_asc(
+    test_client,
+    mocked_processes,
+    mocked_processes_resumeall,
+    generic_subscription_2,
+    generic_subscription_1,
+):
+    # when
+
+    data = get_processes_query(sort_by=[{"field": "productTag", "order": "ASC"}])
+    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    # then
+
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    processes_data = result["data"]["processes"]
+    processes = processes_data["page"]
+    pageinfo = processes_data["pageInfo"]
+
+    assert pageinfo == {
+        "hasPreviousPage": False,
+        "hasNextPage": True,
+        "startCursor": 0,
+        "endCursor": 9,
+        "totalItems": 15,
+    }
+
+    assert [process["product"]["tag"] for process in processes] == [
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN1",
+        "GEN2",
+        "GEN2",
+    ]


### PR DESCRIPTION
also improved workflow filter because `workflow.target` wasn't filterable yet.

Closes: #352 