### PR TITLE
Add callback_step functionality

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.3.1]
+- Added support for asynchronous callback_steps [\#297](https://github.com/workfloworchestrator/orchestrator-core/issues/297)
+
 ## [1.2.0]
  - Removed the opentelemetry dependancy and added warnings to function calls
  - Renamed an error classes and added warnings

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -154,7 +154,7 @@ def resume_process_endpoint(
 
 
 @router.post(
-    "/{process_id}/continue/{token}",
+    "/{process_id}/callback/{token}",
     response_model=None,
     status_code=HTTPStatus.OK,
     dependencies=[Depends(check_global_lock, use_cache=False)],

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -13,6 +13,7 @@
 
 """Module that implements process related API endpoints."""
 
+import json
 import struct
 import zlib
 from http import HTTPStatus
@@ -56,6 +57,7 @@ from orchestrator.services.processes import (
     _get_process,
     abort_process,
     api_broadcast_process_data,
+    continue_awaiting_process,
     load_process,
     resume_process,
     start_process,
@@ -149,6 +151,31 @@ def resume_process_endpoint(
 
     broadcast_func = api_broadcast_process_data(request)
     resume_process(process, user=user, user_inputs=json_data, broadcast_func=broadcast_func)
+
+
+@router.post(
+    "/{process_id}/continue/{token}",
+    response_model=None,
+    status_code=HTTPStatus.OK,
+    dependencies=[Depends(check_global_lock, use_cache=False)],
+)
+def continue_awaiting_process_endpoint(
+    process_id: UUID,
+    token: str,
+    request: Request,
+    json_data: JSON = Body(...),
+) -> None:
+    check_global_lock()
+
+    process = _get_process(process_id)
+
+    if process.last_status != ProcessStatus.AWAITING_CALLBACK:
+        raise_status(HTTPStatus.CONFLICT, "This process is not in an awaiting state.")
+
+    try:
+        continue_awaiting_process(process, token=token, input_data=json.loads(json_data))
+    except AssertionError as e:
+        raise_status(HTTPStatus.NOT_FOUND, str(e))
 
 
 @router.put(

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -563,11 +563,9 @@ def continue_awaiting_process(
 
     # We need to pass the callback data to the worker executor. Currently, this is not supported.
     # Therefore, we update the step state in the db and kick-off resume_workflow
-    # TODO: Allow passing additional data to be merged to the state upon resume_workflow
-    if "__callback_result_key" in state:
-        state = {**state, state["__callback_result_key"]: input_data}
-    else:
-        state = {**state, **input_data}
+    # Possible improvement: Allow passing additional data to be merged to the state upon resume_workflow
+    result_key = state.get("__callback_result_key", "callback_result")
+    state = {**state, result_key: input_data}
 
     current_step = process.steps[-1]
     current_step.state = state

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -42,7 +42,17 @@ from orchestrator.websocket import (
     websocket_manager,
 )
 from orchestrator.websocket.websocket_manager import WebSocketManager
-from orchestrator.workflow import Failed, ProcessStat, ProcessStatus, Step, StepList, Success, Workflow, abort_wf, runwf
+from orchestrator.workflow import (
+    Failed,
+    ProcessStat,
+    ProcessStatus,
+    Step,
+    StepList,
+    Success,
+    Workflow,
+    abort_wf,
+    runwf,
+)
 from orchestrator.workflow import Process as WFProcess
 from orchestrator.workflows import get_workflow
 from orchestrator.workflows.removed_workflow import removed_workflow
@@ -515,7 +525,6 @@ def resume_process(
 
     """
     pstat = load_process(process)
-    logger.debug("Resume process pstat", pstat=pstat)
     try:
         post_form(pstat.log[0].form, pstat.state.unwrap(), user_inputs=user_inputs or [])
     except FormValidationError:
@@ -524,6 +533,50 @@ def resume_process(
 
     resume_func = get_execution_context()["resume"]
     return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
+
+
+def continue_awaiting_process(
+    process: ProcessTable,
+    *,
+    token: str,
+    input_data: State,
+) -> UUID:
+    """Continue a process awaiting data from a callback.
+
+    Args:
+        process: Process from database
+        token: The token which was generated for the process. This must match.
+        input_data: Data posted to the callback
+
+    Returns:
+        process id
+
+    """
+
+    pstat = load_process(process)
+    state = pstat.state.unwrap()
+
+    # Check if the token matches
+    token_from_state = state.get("__callback_token")
+    if token != token_from_state:
+        raise AssertionError("Invalid token")
+
+    # We need to pass the callback data to the worker executor. Currently, this is not supported.
+    # Therefore, we update the step state in the db and kick-off resume_workflow
+    # TODO: Allow passing additional data to be merged to the state upon resume_workflow
+    if "__callback_result_key" in state:
+        state = {**state, state["__callback_result_key"]: input_data}
+    else:
+        state = {**state, **input_data}
+
+    current_step = process.steps[-1]
+    current_step.state = state
+    db.session.add(current_step)
+    db.session.commit()
+
+    # Continue the workflow
+    resume_func = get_execution_context()["resume"]
+    return resume_func(process)
 
 
 async def _async_resume_processes(
@@ -583,14 +636,18 @@ def abort_process(process: ProcessTable, user: str, broadcast_func: Optional[Cal
 
 
 def _recoverwf(wf: Workflow, log: List[WFProcess]) -> Tuple[WFProcess, StepList]:
-    # Remove all extra steps (Failed, Suspended and Waiting steps add extra steps in db)
-    persistent = list(filter(lambda p: not (p.isfailed() or p.issuspend() or p.iswaiting()), log))
+    # Remove all extra steps (Failed, Suspended and (A)waiting steps in db). Only keep cleared steps.
+
+    persistent = list(
+        filter(lambda p: not (p.isfailed() or p.issuspend() or p.iswaiting() or p.isawaitingcallback()), log)
+    )
     stepcount = len(persistent)
 
-    # Make sure we get the last state from the suspend step (since we removed it before)
-    if log and log[-1].issuspend():
+    if log and (log[-1].issuspend() or log[-1].isawaitingcallback()):
+        # Use the state from the suspended/awaiting steps
         state = log[-1]
     elif persistent:
+        # Otherwise, use the state from the last cleared step.
         state = persistent[-1]
     else:
         state = Success({})

--- a/orchestrator/utils/state.py
+++ b/orchestrator/utils/state.py
@@ -249,10 +249,8 @@ def inject_args(func: StepFunc) -> Callable[[State], State]:
             ...
             return new_state
 
-    Both `subscription_id` and `sap1` need to be present in the state. However `sap2` can be present but does not need
+    Both `subscription_id` and `sap1` need to be present in the state. However, `sap2` can be present but does not need
     to be. If it is not present in the state it will get the value `None`
-
-    Default values are supported to!
 
     .. _domain-models-processing:
 
@@ -271,12 +269,12 @@ def inject_args(func: StepFunc) -> Callable[[State], State]:
     It will use the UUID found to retrieve the domain model from the DB and inject it into the step function. None of
     the other data from the domain model (in case of it being a dict representation) will be used! At the end of the
     step function any domain models explicitly returned will be automatically saved to the DB; this includes any new
-    domain models that might be created in the step and returned by the step. Hence the automatic save is not limited
+    domain models that might be created in the step and returned by the step. Hence, the automatic save is not limited
     to domain models requested as part of the step parameter list.
 
     If the key `light_path` was not found in the state, the parameter is interpreted as a request to create a
     domain model of the given type. For that to work correctly the keys `product` and `organisation` need to be
-    present in the state. This will not work for more than one domain model. Eg. you can't request two domain
+    present in the state. This will not work for more than one domain model. E.g. you can't request two domain
     models to be created as we will not know to which of the two domain models `product` is applicable to.
 
     Also supported is wrapping a domain model in ``Optional`` or ``List``. Other types are not supported.
@@ -308,7 +306,7 @@ def inject_args(func: StepFunc) -> Callable[[State], State]:
 def form_inject_args(func: InputStepFunc) -> StateInputStepFunc:
     """See :func:`state_parms` for description.
 
-    This decorator behaves similarly to :func:`inject_args`. `form_inject_args` can be used on generatorfunctions.
+    This decorator behaves similarly to :func:`inject_args`. `form_inject_args` can be used on generator functions.
     """
 
     if inspect.isgeneratorfunction(func):

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -338,7 +338,7 @@ def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
 def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
     def stepfunc(process_id: UUID) -> State:
         token = secrets.token_urlsafe()
-        route = f"/processes/{process_id}/continue/{token}"
+        route = f"/processes/{process_id}/callback/{token}"
         # Also add the token under __callback_token for internal use
         return {key: route, "__callback_token": token}
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextvars
 import functools
 import inspect
+import secrets
 from dataclasses import asdict, dataclass
 from itertools import dropwhile
 from typing import (
@@ -68,6 +69,8 @@ StepLogFuncInternal = Callable[["Step", "Process"], "Process"]
 StepToProcessFunc = Callable[[State], "Process"]
 
 step_log_fn_var: contextvars.ContextVar[StepLogFuncInternal] = contextvars.ContextVar("log_step_fn")
+
+DEFAULT_CALLBACK_ROUTE_KEY = "callback_route"
 
 
 @runtime_checkable
@@ -259,7 +262,7 @@ def inputstep(name: str, assignee: Assignee) -> Callable[[InputStepFunc], Step]:
     """Add user input step to workflow.
 
     IMPORTANT: In contrast to other workflow steps, the `@inputstep` wrapped function will not run in the
-    workflow engine! This means that it should never do any changes in the database and external systems!
+    workflow engine! This means that it must be free of side effects!
 
     Example::
 
@@ -289,7 +292,7 @@ def inputstep(name: str, assignee: Assignee) -> Callable[[InputStepFunc], Step]:
     return decorator
 
 
-def step_group(name: str, steps: StepList) -> Step:
+def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
     """Add a group of steps to the workflow as a single step.
 
     A step group is a sequence of steps that act as a single step.
@@ -297,6 +300,11 @@ def step_group(name: str, steps: StepList) -> Step:
     The state of the group will be the last state of the sub-steps. So if one of the steps goes to FAILED,
     the group goes to failed. If a step goes to SUSPEND, the group is in SUSPEND. If a step goes to SUCCESS however,
     the group is still RUNNING. It will be in SUCCESS only of all the sub-steps are in SUCCESS.
+
+    Args:
+        name: The name of the step
+        steps: The sub steps in the step group
+        extract_form: Whether to attach the first form of the sub steps to the step group
     """
 
     def func(initial_state: State) -> Process:
@@ -313,7 +321,7 @@ def step_group(name: str, steps: StepList) -> Step:
                 p = p.on_success(lambda s: {k: v for k, v in s.items() if k not in ["__sub_step", "__step_group"]})
             return p
 
-        # If sub_step information is present in the state. Resume from the corresponding sub step
+        # If sub_step information is present in the state. Resume from the next sub step
         if "__sub_step" in initial_state:
             step_list = StepList(dropwhile(lambda s: s.name != initial_state.get("__sub_step"), steps))[1:]
         else:
@@ -323,8 +331,68 @@ def step_group(name: str, steps: StepList) -> Step:
         return _exec_steps(step_list, process, dblogstep)
 
     # Make sure we return a form is a sub step has a form
-    form = next((sub_step.form for sub_step in steps if sub_step.form), None)
+    form = next((sub_step.form for sub_step in steps if sub_step.form), None) if extract_form else None
     return make_step_function(func, name, form)
+
+
+def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
+    def stepfunc(process_id: UUID) -> State:
+        token = secrets.token_urlsafe()
+        route = f"/processes/{process_id}/continue/{token}"
+        # Also add the token under __callback_token for internal use
+        return {key: route, "__callback_token": token}
+
+    return stepfunc
+
+
+def awaitstep(name: str, result_key: Optional[str] = None) -> Step:
+    """Add step to workflow for awaiting callbacks and validating received data.
+
+    IMPORTANT: The `@awaitstep` wrapped function will not run in the workflow engine and must be free of side effects!
+
+    Example::
+
+        @awaitstep("Await data")
+        def validate(state: State) -> FormGenerator:
+            class Form(FormPage):
+                name: str
+            ext_data = yield Form
+            return ext_data.dict()
+
+    """
+
+    def await_(state: State) -> Process:
+        if result_key:
+            state = {**state, "__callback_result_key": result_key}
+        return AwaitingCallback(state)
+
+    return make_step_function(await_, name)
+
+
+def callback_step(
+    name: str,
+    action_fn: StepFunc,
+    validate_fn: StepFunc,
+    callback_route_key: str = DEFAULT_CALLBACK_ROUTE_KEY,
+    result_key: Optional[str] = None,
+) -> Step:
+    """Creates an asynchronous callback step.
+
+    Internally creates a step group with the following sub steps:
+
+    - Action - This performs the required side effect to an external system. After this, an endpoint is generated and
+    stored with the process and the process goes into AWAITING_CALLBACK state.
+    - Validate - Uses the provided validate_fn to validate the data coming from the external system.
+
+    The data returned in the callback will be merged in the state. An optional result_key parameter can be supplied
+    to specify under which key the data will be merged.
+    """
+    action_step = step(name=f"{name} - Action")(action_fn)
+    create_endpoint_step = step(f"{name} - Create endpoint")(_create_endpoint_step(key=callback_route_key))
+    await_step = awaitstep(f"{name} - Await callback", result_key=result_key)
+    validate_step = step(f"{name} - Validate")(validate_fn)
+
+    return step_group(name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step)
 
 
 def _purestep(name: str) -> Callable[[StepToProcessFunc], StepList]:
@@ -337,7 +405,7 @@ def _purestep(name: str) -> Callable[[StepToProcessFunc], StepList]:
 
 
 def conditional(p: Callable[[State], bool]) -> Callable[..., StepList]:
-    """Use a predicate to control whether or not a step is run."""
+    """Use a predicate to control whether a step is run."""
 
     def _conditional(steps_or_func: Union[StepList, Step]) -> StepList:
         if isinstance(steps_or_func, Step):
@@ -1141,8 +1209,7 @@ class Process(Generic[S]):
         """
 
         next_state = self._fold(Success, Success, Success, Success, Success, Abort, Success, Complete)
-
-        if self.issuspend():
+        if self.issuspend() or self.isawaitingcallback():
             return resume_suspend(next_state)  # type: ignore
 
         return next_state  # type: ignore
@@ -1311,7 +1378,6 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
     """Execute the workflow steps one by one until a Process state other than Success or Skipped is reached."""
     consolelogger = cond_bind(logger, starting_process.unwrap(), "reporter", "created_by")
     process = starting_process
-
     for step in steps:
         # Check if we need to continue with the process
         if not (process.issuccess() or process.isskipped()):
@@ -1331,7 +1397,6 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
                     "Not executing Step as the workflow engine is Paused. Process will remain in state 'running'"
                 )
                 return process
-
             step_result_process = process.execute_step(step)
         except Exception as e:
             consolelogger.error("An exception occurred while executing the workflow step.")

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -356,10 +356,10 @@ def _awaitstep(name: str, result_key: Optional[str] = None) -> Step:
 
 def callback_step(
     name: str,
-    action_fn: StepFunc,
-    validate_fn: StepFunc,
-    callback_route_key: str = DEFAULT_CALLBACK_ROUTE_KEY,
+    action_step: Step,
+    validate_step: Step,
     result_key: Optional[str] = None,
+    callback_route_key: str = DEFAULT_CALLBACK_ROUTE_KEY,
 ) -> Step:
     """Creates an asynchronous callback step.
 
@@ -372,10 +372,8 @@ def callback_step(
     The data returned in the callback will be merged in the state. An optional result_key parameter can be supplied
     to specify under which key the data will be merged.
     """
-    action_step = step(name=f"{name} - Action")(action_fn)
     create_endpoint_step = step(f"{name} - Create endpoint")(_create_endpoint_step(key=callback_route_key))
     await_step = _awaitstep(f"{name} - Await callback", result_key=result_key)
-    validate_step = step(f"{name} - Validate")(validate_fn)
 
     return step_group(name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step)
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -345,22 +345,7 @@ def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
     return stepfunc
 
 
-def awaitstep(name: str, result_key: Optional[str] = None) -> Step:
-    """Add step to workflow for awaiting callbacks and validating received data.
-
-    IMPORTANT: The `@awaitstep` wrapped function will not run in the workflow engine and must be free of side effects!
-
-    Example::
-
-        @awaitstep("Await data")
-        def validate(state: State) -> FormGenerator:
-            class Form(FormPage):
-                name: str
-            ext_data = yield Form
-            return ext_data.dict()
-
-    """
-
+def _awaitstep(name: str, result_key: Optional[str] = None) -> Step:
     def await_(state: State) -> Process:
         if result_key:
             state = {**state, "__callback_result_key": result_key}
@@ -389,7 +374,7 @@ def callback_step(
     """
     action_step = step(name=f"{name} - Action")(action_fn)
     create_endpoint_step = step(f"{name} - Create endpoint")(_create_endpoint_step(key=callback_route_key))
-    await_step = awaitstep(f"{name} - Await callback", result_key=result_key)
+    await_step = _awaitstep(f"{name} - Await callback", result_key=result_key)
     validate_step = step(f"{name} - Validate")(validate_fn)
 
     return step_group(name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step)

--- a/test/unit_tests/workflows/test_async_workflow.py
+++ b/test/unit_tests/workflows/test_async_workflow.py
@@ -21,16 +21,17 @@ def step2(steps):
 
 
 def test_workflow_with_callback():
-    def action_fn() -> State:
+    @step("Action")
+    def action() -> State:
         return {"ext_response": "Request received"}
 
-    def validate_fn(state: State) -> State:
-        code = state.get("code")
+    @step("Validate")
+    def validate(code: str) -> State:
         if code != "12345":
             raise ValueError("Response code is wrong")
         return {"status": "ok"}
 
-    call_ext_system = callback_step(name="Call ext system", action_fn=action_fn, validate_fn=validate_fn)
+    call_ext_system = callback_step(name="Call ext system", action_step=action, validate_step=validate)
 
     @workflow("Test wf", target="Target.CREATE")
     def testwf():
@@ -52,14 +53,16 @@ def test_workflow_with_callback():
 
 
 def test_callback_wf_with_custom_callback_route():
-    def action_fn() -> State:
+    @step("Action")
+    def action() -> State:
         return {"ext_response": "Request received"}
 
-    def validate_fn() -> State:
+    @step("Validate")
+    def validate() -> State:
         return {}
 
     call_ext_system = callback_step(
-        name="Call ext system", action_fn=action_fn, validate_fn=validate_fn, callback_route_key="custom_route_key"
+        name="Call ext system", action_step=action, validate_step=validate, callback_route_key="custom_route_key"
     )
 
     @workflow("Test wf", target="Target.CREATE")

--- a/test/unit_tests/workflows/test_async_workflow.py
+++ b/test/unit_tests/workflows/test_async_workflow.py
@@ -1,0 +1,74 @@
+from orchestrator.types import State
+from orchestrator.workflow import AwaitingCallback, begin, callback_step, done, runwf, step, workflow
+from test.unit_tests.workflows import (
+    WorkflowInstanceForTests,
+    _store_step,
+    assert_awaiting_callback,
+    assert_complete,
+    assert_state,
+    run_workflow,
+)
+
+
+@step("Step 1")
+def step1():
+    return {"steps": [1]}
+
+
+@step("Step 2")
+def step2(steps):
+    return {"steps": [*steps, 2]}
+
+
+def test_workflow_with_callback():
+    def action_fn() -> State:
+        return {"ext_response": "Request received"}
+
+    def validate_fn(state: State) -> State:
+        code = state.get("code")
+        if code != "12345":
+            raise ValueError("Response code is wrong")
+        return {"status": "ok"}
+
+    call_ext_system = callback_step(name="Call ext system", action_fn=action_fn, validate_fn=validate_fn)
+
+    @workflow("Test wf", target="Target.CREATE")
+    def testwf():
+        return begin >> step1 >> call_ext_system >> step2 >> done
+
+    with WorkflowInstanceForTests(testwf, "testwf"):
+        result, process, step_log = run_workflow("testwf", {})
+        assert_awaiting_callback(result)
+        state = result.unwrap()
+        assert "callback_route" in state
+        assert state.get("__sub_step") == "Call ext system - Await callback"
+
+        step_log = [step_log[0]] + [step_log[-1]]
+
+        process = process.update(log=process.workflow.steps[1:], state=AwaitingCallback({**state, "code": "12345"}))
+        result = runwf(process, _store_step(step_log))
+        assert_complete(result)
+        assert_state(result, {"steps": [1, 2], "code": "12345"})
+
+
+def test_callback_wf_with_custom_callback_route():
+    def action_fn() -> State:
+        return {"ext_response": "Request received"}
+
+    def validate_fn() -> State:
+        return {}
+
+    call_ext_system = callback_step(
+        name="Call ext system", action_fn=action_fn, validate_fn=validate_fn, callback_route_key="custom_route_key"
+    )
+
+    @workflow("Test wf", target="Target.CREATE")
+    def testwf():
+        return begin >> call_ext_system >> done
+
+    with WorkflowInstanceForTests(testwf, "testwf"):
+        result, process, step_log = run_workflow("testwf", {})
+        assert_awaiting_callback(result)
+        state = result.unwrap()
+        assert "callback_route" not in state
+        assert "custom_route_key" in state


### PR DESCRIPTION
Resolves #297

Implements a `callback_step` function which uses a step_group to handle workflows with asynchronous communication with subsystems.

- The `callback_step` is supplied with an `action_fn` and a `validate_fn`.
- Upon execution, an api endpoint is generated with a random token and added to the process state.
- The `action_fn` can then invoke the subsystem with any data (including the callback endpoint)
- The process enters  `Awaiting Callback` status
- When the endpoint is invoked, the token is matched. If it passes, the workflow continues with the `validate_fn` step. 
- If an error occurs, a retry will start from the beginning of the callback_step: creating a new endpoint and invoking the action_fn.