### PR TITLE
remove unnecessary json loads in continue_awaiting_process_endpoint

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -13,11 +13,10 @@
 
 """Module that implements process related API endpoints."""
 
-import json
 import struct
 import zlib
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 from uuid import UUID
 
 import structlog
@@ -63,7 +62,7 @@ from orchestrator.services.processes import (
     start_process,
 )
 from orchestrator.settings import app_settings
-from orchestrator.types import JSON
+from orchestrator.types import JSON, State
 from orchestrator.utils.enrich_process import enrich_process
 from orchestrator.websocket import WS_CHANNELS, send_process_data_to_websocket, websocket_manager
 from orchestrator.workflow import ProcessStatus
@@ -173,7 +172,7 @@ def continue_awaiting_process_endpoint(
         raise_status(HTTPStatus.CONFLICT, "This process is not in an awaiting state.")
 
     try:
-        continue_awaiting_process(process, token=token, input_data=json.loads(json_data))
+        continue_awaiting_process(process, token=token, input_data=cast(json_data, State))
     except AssertionError as e:
         raise_status(HTTPStatus.NOT_FOUND, str(e))
 


### PR DESCRIPTION
Copied from [this issue](https://github.com/workfloworchestrator/orchestrator-core/issues/360)


Hi considering this code

```python 
@router.post(
    "/{process_id}/callback/{token}",
    response_model=None,
    status_code=HTTPStatus.OK,
    dependencies=[Depends(check_global_lock, use_cache=False)],
)
def continue_awaiting_process_endpoint(
    process_id: UUID,
    token: str,
    request: Request,
    json_data: JSON = Body(...),
) -> None:
    check_global_lock()

    process = _get_process(process_id)

    if process.last_status != ProcessStatus.AWAITING_CALLBACK:
        raise_status(HTTPStatus.CONFLICT, "This process is not in an awaiting state.")

    try:
        continue_awaiting_process(process, token=token, input_data=json.loads(json_data))
    except AssertionError as e:
        raise_status(HTTPStatus.NOT_FOUND, str(e))
```
        

The `json_data: JSON = Body(...)`  line in this function argument already instructs FastAPI to take the JSON content from the request body and convert it into the appropriate Python type. Therefore, you can use json_data directly in your function as a Python object without the need for `json.loads.`
     