### PR TITLE
Update SQLAlchemy queries to use v2 instead of v1 for graphql resolvers

### DIFF
--- a/orchestrator/db/filters/__init__.py
+++ b/orchestrator/db/filters/__init__.py
@@ -1,6 +1,7 @@
 from orchestrator.db.filters.filters import (
     CallableErrorHandler,
     Filter,
+    QueryType,
     generic_apply_filters,
     generic_filter,
     generic_filters_validate,
@@ -12,4 +13,5 @@ __all__ = [
     "generic_filter",
     "generic_apply_filters",
     "generic_filters_validate",
+    "QueryType",
 ]

--- a/orchestrator/db/filters/filters.py
+++ b/orchestrator/db/filters/filters.py
@@ -15,9 +15,9 @@ from typing import Any, Callable, Iterator, Protocol
 
 from more_itertools import partition
 from pydantic import BaseModel
+from sqlalchemy import Select
 
 from orchestrator.api.error_handling import ProblemDetailException
-from orchestrator.db.database import SearchQuery
 
 
 class CallableErrorHandler(Protocol):
@@ -30,7 +30,7 @@ class Filter(BaseModel):
     value: str
 
 
-QueryType = SearchQuery
+QueryType = Select
 ValidFilterFunctionsByColumnType = dict[str, Callable[[QueryType, str], QueryType]]
 
 

--- a/orchestrator/db/filters/generic_filters/bool_filter.py
+++ b/orchestrator/db/filters/generic_filters/bool_filter.py
@@ -15,11 +15,11 @@ from typing import Callable
 
 from sqlalchemy import Column
 
-from orchestrator.db.database import SearchQuery
+from orchestrator.db.filters.filters import QueryType
 
 
-def generic_bool_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
-    def bool_filter(query: SearchQuery, value: str) -> SearchQuery:
+def generic_bool_filter(field: Column) -> Callable[[QueryType, str], QueryType]:
+    def bool_filter(query: QueryType, value: str) -> QueryType:
         value_as_bool = value.lower() in ("yes", "y", "true", "1", "ja", "j")
         return query.filter(field.is_(value_as_bool))
 

--- a/orchestrator/db/filters/generic_filters/is_like_filter.py
+++ b/orchestrator/db/filters/generic_filters/is_like_filter.py
@@ -16,11 +16,11 @@ from typing import Callable
 
 from sqlalchemy import Column, String, cast
 
-from orchestrator.db.database import SearchQuery
+from orchestrator.db.filters.filters import QueryType
 
 
-def generic_is_like_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
-    def like_filter(query: SearchQuery, value: str) -> SearchQuery:
+def generic_is_like_filter(field: Column) -> Callable[[QueryType, str], QueryType]:
+    def like_filter(query: QueryType, value: str) -> QueryType:
         return query.filter(cast(field, String).ilike("%" + value + "%"))
 
     return like_filter

--- a/orchestrator/db/filters/generic_filters/range_filter.py
+++ b/orchestrator/db/filters/generic_filters/range_filter.py
@@ -18,7 +18,7 @@ import pytz
 from dateutil.parser import parse
 from sqlalchemy import Column
 
-from orchestrator.db.database import SearchQuery
+from orchestrator.db.filters.filters import QueryType
 
 # from sqlalchemy.sql.expression import ColumnOperators
 from orchestrator.utils.helpers import to_camel
@@ -58,11 +58,11 @@ def get_filter_value_convert_function(field: Column) -> Callable:
     return lambda x: x
 
 
-def generic_range_filter(range_type_fn: Callable, field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
+def generic_range_filter(range_type_fn: Callable, field: Column) -> Callable[[QueryType, str], QueryType]:
     filter_operator = partial(range_type_fn, field)
     convert_filter_value = get_filter_value_convert_function(field)
 
-    def use_filter(query: SearchQuery, value: str) -> SearchQuery:
+    def use_filter(query: QueryType, value: str) -> QueryType:
         converted_value = convert_filter_value(value)
         return query.filter(filter_operator(converted_value))
 
@@ -71,7 +71,7 @@ def generic_range_filter(range_type_fn: Callable, field: Column) -> Callable[[Se
 
 def generic_range_filters(
     column: Column, column_alias: Optional[str] = None
-) -> dict[str, Callable[[SearchQuery, str], SearchQuery]]:
+) -> dict[str, Callable[[QueryType, str], QueryType]]:
     column_name = to_camel(column_alias or column.name)
 
     return {

--- a/orchestrator/db/filters/generic_filters/values_in_column_filter.py
+++ b/orchestrator/db/filters/generic_filters/values_in_column_filter.py
@@ -16,11 +16,11 @@ from typing import Callable
 
 from sqlalchemy import Column, func
 
-from orchestrator.db.database import SearchQuery
+from orchestrator.db.filters.filters import QueryType
 
 
-def generic_values_in_column_filter(field: Column) -> Callable[[SearchQuery, str], SearchQuery]:
-    def list_filter(query: SearchQuery, value: str) -> SearchQuery:
+def generic_values_in_column_filter(field: Column) -> Callable[[QueryType, str], QueryType]:
+    def list_filter(query: QueryType, value: str) -> QueryType:
         values = [s.lower() for s in value.split("-")]
         return query.filter(func.lower(field).in_(values))
 

--- a/orchestrator/db/filters/product.py
+++ b/orchestrator/db/filters/product.py
@@ -3,20 +3,19 @@ from typing import Callable
 import structlog
 
 from orchestrator.db import ProductBlockTable, ProductTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.filters import generic_filter
+from orchestrator.db.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import generic_is_like_filter, generic_values_in_column_filter
 
 logger = structlog.get_logger(__name__)
 
 
-def product_block_filter(query: SearchQuery, value: str) -> SearchQuery:
+def product_block_filter(query: QueryType, value: str) -> QueryType:
     """Filter ProductBlocks by '-'-separated list of Product block 'name' (column) values."""
     blocks = value.split("-")
     return query.filter(ProductTable.product_blocks.any(ProductBlockTable.name.in_(blocks)))
 
 
-PRODUCT_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
+PRODUCT_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], QueryType]] = {
     "product_id": generic_is_like_filter(ProductTable.product_id),
     "name": generic_is_like_filter(ProductTable.name),
     "description": generic_is_like_filter(ProductTable.description),

--- a/orchestrator/db/filters/product_block.py
+++ b/orchestrator/db/filters/product_block.py
@@ -3,8 +3,7 @@ from typing import Callable
 import structlog
 
 from orchestrator.db import ProductBlockTable, ProductTable, ResourceTypeTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.filters import generic_filter
+from orchestrator.db.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import (
     generic_is_like_filter,
     generic_range_filters,
@@ -14,13 +13,13 @@ from orchestrator.db.filters.generic_filters import (
 logger = structlog.get_logger(__name__)
 
 
-def products_filter(query: SearchQuery, value: str) -> SearchQuery:
+def products_filter(query: QueryType, value: str) -> QueryType:
     """Filter ProductBlocks by '-'-separated list of Product 'name' (column) values."""
     products = value.split("-")
     return query.filter(ProductBlockTable.products.any(ProductTable.name.in_(products)))
 
 
-def resource_types_filter(query: SearchQuery, value: str) -> SearchQuery:
+def resource_types_filter(query: QueryType, value: str) -> QueryType:
     """Filter ProductBlocks by '-'-separated list of Resource Type 'resource_type' (column) values."""
     resource_types = value.split("-")
     return query.filter(ProductBlockTable.resource_types.any(ResourceTypeTable.resource_type.in_(resource_types)))
@@ -29,7 +28,7 @@ def resource_types_filter(query: SearchQuery, value: str) -> SearchQuery:
 created_at_range_filters = generic_range_filters(ProductBlockTable.created_at)
 end_date_range_filters = generic_range_filters(ProductBlockTable.end_date)
 
-PRODUCT_BLOCK_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+PRODUCT_BLOCK_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], QueryType]] = (
     {
         "product_block_id": generic_is_like_filter(ProductBlockTable.product_block_id),
         "name": generic_is_like_filter(ProductBlockTable.name),

--- a/orchestrator/db/filters/resource_type.py
+++ b/orchestrator/db/filters/resource_type.py
@@ -3,20 +3,19 @@ from typing import Callable
 import structlog
 
 from orchestrator.db import ProductBlockTable, ResourceTypeTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.filters import generic_filter
+from orchestrator.db.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import generic_is_like_filter
 
 logger = structlog.get_logger(__name__)
 
 
-def product_blocks_filter(query: SearchQuery, value: str) -> SearchQuery:
+def product_blocks_filter(query: QueryType, value: str) -> QueryType:
     """Filter ResourceTypes by '-'-separated list of Product block 'name' (column) values."""
     product_blocks = value.split("-")
     return query.filter(ResourceTypeTable.product_blocks.any(ProductBlockTable.name.in_(product_blocks)))
 
 
-RESOURCE_TYPE_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = {
+RESOURCE_TYPE_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], QueryType]] = {
     "resourceTypeId": generic_is_like_filter(ResourceTypeTable.resource_type_id),
     "resourceType": generic_is_like_filter(ResourceTypeTable.resource_type),
     "description": generic_is_like_filter(ResourceTypeTable.description),

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -18,8 +18,7 @@ from sqlalchemy import func
 
 from orchestrator.api.helpers import _process_text_query
 from orchestrator.db import ProductTable, SubscriptionTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.filters.filters import generic_filter
+from orchestrator.db.filters.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import (
     generic_bool_filter,
     generic_is_like_filter,
@@ -31,7 +30,7 @@ from orchestrator.db.models import SubscriptionSearchView
 logger = structlog.get_logger(__name__)
 
 
-def tsv_filter(query: SearchQuery, value: str) -> SearchQuery:
+def tsv_filter(query: QueryType, value: str) -> QueryType:
     # Quote key:value tokens. This will use the FOLLOWED BY operator (https://www.postgresql.org/docs/13/textsearch-controls.html)
     processed_text_query = _process_text_query(value)
 
@@ -42,7 +41,7 @@ def tsv_filter(query: SearchQuery, value: str) -> SearchQuery:
     )
 
 
-def subscription_list_filter(query: SearchQuery, value: str) -> SearchQuery:
+def subscription_list_filter(query: QueryType, value: str) -> QueryType:
     values = [s.lower() for s in value.split(",")]
     return query.filter(SubscriptionTable.subscription_id.in_(values))
 
@@ -55,7 +54,7 @@ start_date_range_filters = generic_range_filters(SubscriptionTable.start_date)
 end_date_range_filters = generic_range_filters(SubscriptionTable.end_date)
 
 
-SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], QueryType]] = (
     {
         "subscriptionId": generic_is_like_filter(SubscriptionTable.subscription_id),
         "subscriptionIds": subscription_list_filter,

--- a/orchestrator/db/filters/workflow.py
+++ b/orchestrator/db/filters/workflow.py
@@ -4,8 +4,7 @@ import structlog
 from sqlalchemy.inspection import inspect
 
 from orchestrator.db import ProductTable, WorkflowTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.filters import generic_filter
+from orchestrator.db.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import generic_is_like_filter, generic_range_filters
 from orchestrator.utils.helpers import to_camel
 
@@ -14,7 +13,7 @@ logger = structlog.get_logger(__name__)
 created_at_range_filters = generic_range_filters(WorkflowTable.created_at)
 
 
-def products_filter(query: SearchQuery, value: str) -> SearchQuery:
+def products_filter(query: QueryType, value: str) -> QueryType:
     """Filter ProductBlocks by '-'-separated list of Product 'name' (column) values."""
     products = value.split("-")
     return query.filter(WorkflowTable.products.any(ProductTable.name.in_(products)))
@@ -22,7 +21,7 @@ def products_filter(query: SearchQuery, value: str) -> SearchQuery:
 
 BASE_CAMEL = {to_camel(key): generic_is_like_filter(value) for key, value in inspect(WorkflowTable).columns.items()}
 
-WORKFLOW_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[SearchQuery, str], SearchQuery]] = (
+WORKFLOW_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], QueryType]] = (
     BASE_CAMEL | {"products": products_filter} | created_at_range_filters
 )
 

--- a/orchestrator/db/range/__init__.py
+++ b/orchestrator/db/range/__init__.py
@@ -1,5 +1,6 @@
-from orchestrator.db.range.range import apply_range_to_query
+from orchestrator.db.range.range import apply_range_to_query, apply_range_to_statement
 
 __all__ = [
     "apply_range_to_query",
+    "apply_range_to_statement",
 ]

--- a/orchestrator/db/sorting/process.py
+++ b/orchestrator/db/sorting/process.py
@@ -5,16 +5,15 @@ from sqlalchemy.inspection import inspect
 from sqlalchemy.sql import expression
 
 from orchestrator.db import ProcessSubscriptionTable, ProcessTable, ProductTable, SubscriptionTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.sorting.sorting import SortOrder, generic_column_sort, generic_sort
+from orchestrator.db.sorting.sorting import QueryType, SortOrder, generic_column_sort, generic_sort
 from orchestrator.utils.helpers import to_camel
 
 PROCESS_CAMEL_SORT = {to_camel(key): generic_column_sort(value) for key, value in inspect(ProcessTable).columns.items()}
 PROCESS_SNAKE_SORT = {key: generic_column_sort(value) for key, value in inspect(ProcessTable).columns.items()}
 
 
-def generic_process_relation_sort(field: Column) -> Callable[[SearchQuery, SortOrder], SearchQuery]:
-    def sort_function(query: SearchQuery, order: SortOrder) -> SearchQuery:
+def generic_process_relation_sort(field: Column) -> Callable[[QueryType, SortOrder], QueryType]:
+    def sort_function(query: QueryType, order: SortOrder) -> QueryType:
         joined_query = query.join(ProcessSubscriptionTable).join(SubscriptionTable).join(ProductTable)
         if order == SortOrder.DESC:
             return joined_query.order_by(expression.desc(field))

--- a/orchestrator/db/sorting/sorting.py
+++ b/orchestrator/db/sorting/sorting.py
@@ -17,11 +17,10 @@ from typing import Callable, Iterator, TypeVar
 import strawberry
 from more_itertools import partition
 from pydantic import BaseModel
-from sqlalchemy import Column
+from sqlalchemy import Column, Select
 from sqlalchemy.sql import expression
 
 from orchestrator.api.error_handling import ProblemDetailException
-from orchestrator.db.database import SearchQuery
 from orchestrator.db.filters import CallableErrorHandler
 
 
@@ -37,7 +36,7 @@ class Sort(BaseModel):
 
 
 GenericType = TypeVar("GenericType")
-QueryType = SearchQuery
+QueryType = Select
 ValidSortFunctionsByColumnType = dict[str, Callable[[QueryType, SortOrder], QueryType]]
 
 
@@ -112,8 +111,8 @@ def generic_sort(
     return _sort
 
 
-def generic_column_sort(field: Column) -> Callable[[SearchQuery, SortOrder], SearchQuery]:
-    def sort_function(query: SearchQuery, order: SortOrder) -> SearchQuery:
+def generic_column_sort(field: Column) -> Callable[[QueryType, SortOrder], QueryType]:
+    def sort_function(query: QueryType, order: SortOrder) -> QueryType:
         if order == SortOrder.DESC:
             return query.order_by(expression.desc(field))
         return query.order_by(expression.asc(field))

--- a/orchestrator/db/sorting/subscription.py
+++ b/orchestrator/db/sorting/subscription.py
@@ -5,13 +5,12 @@ from sqlalchemy.inspection import inspect
 from sqlalchemy.sql import expression
 
 from orchestrator.db import ProductTable, SubscriptionTable
-from orchestrator.db.database import SearchQuery
-from orchestrator.db.sorting.sorting import SortOrder, generic_column_sort, generic_sort
+from orchestrator.db.sorting.sorting import QueryType, SortOrder, generic_column_sort, generic_sort
 from orchestrator.utils.helpers import to_camel
 
 
-def generic_subscription_relation_sort(field: Column) -> Callable[[SearchQuery, SortOrder], SearchQuery]:
-    def sort_function(query: SearchQuery, order: SortOrder) -> SearchQuery:
+def generic_subscription_relation_sort(field: Column) -> Callable[[QueryType, SortOrder], QueryType]:
+    def sort_function(query: QueryType, order: SortOrder) -> QueryType:
         if order == SortOrder.DESC:
             return query.order_by(expression.desc(field))
         return query.order_by(expression.asc(field))

--- a/orchestrator/graphql/resolvers/product.py
+++ b/orchestrator/graphql/resolvers/product.py
@@ -1,11 +1,13 @@
 from typing import Union
 
 import structlog
+from sqlalchemy import func, select
 
+from orchestrator.db import db
 from orchestrator.db.filters import Filter
 from orchestrator.db.filters.product import filter_products, product_filter_fields
 from orchestrator.db.models import ProductTable
-from orchestrator.db.range.range import apply_range_to_query
+from orchestrator.db.range.range import apply_range_to_statement
 from orchestrator.db.sorting.product import product_sort_fields, sort_products
 from orchestrator.db.sorting.sorting import Sort
 from orchestrator.graphql.pagination import Connection
@@ -30,11 +32,12 @@ async def resolve_products(
     pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
     logger.debug("resolve_products() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by)
 
-    query = filter_products(ProductTable.query, pydantic_filter_by, _error_handler)
-    query = sort_products(query, pydantic_sort_by, _error_handler)
-    total = query.count()
-    query = apply_range_to_query(query, after, first)
+    stmt = select(ProductTable)
+    stmt = filter_products(stmt, pydantic_filter_by, _error_handler)
+    stmt = sort_products(stmt, pydantic_sort_by, _error_handler)
+    total = db.session.scalar(select(func.count()).select_from(stmt.subquery()))
+    stmt = apply_range_to_statement(stmt, after, after + first + 1)
 
-    products = query.all()
+    products = db.session.scalars(stmt).all()
     graphql_products = [ProductType.from_pydantic(p) for p in products]
     return to_graphql_result_page(graphql_products, first, after, total, product_sort_fields, product_filter_fields)

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -8,7 +8,7 @@ from strawberry.scalars import JSON
 from strawberry.unset import UNSET
 
 from oauth2_lib.strawberry import authenticated_field
-from orchestrator.db.models import ProductTable
+from orchestrator.db import ProductTable, db
 from orchestrator.graphql.pagination import EMPTY_PAGE, Connection
 from orchestrator.graphql.schemas.default_customer import DefaultCustomerType
 from orchestrator.graphql.schemas.product import ProductType
@@ -116,8 +116,8 @@ class ProcessType:
 
     @authenticated_field(description="Returns the associated product")  # type: ignore
     def product(self) -> Optional[ProductType]:
-        if self.product_id:
-            return ProductType.from_pydantic(ProductTable.query.get(self.product_id))
+        if self.product_id and (product := db.session.get(ProductTable, self.product_id)):
+            return ProductType.from_pydantic(product)
         return None
 
     @strawberry.field(description="Returns customer of a subscription")  # type: ignore

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -72,9 +72,8 @@ class SubscriptionInterface:
 
     @strawberry.field(description="Return fixed inputs")  # type: ignore
     async def fixed_inputs(self) -> strawberry.scalars.JSON:
-        fixed_inputs: list[FixedInputTable] = FixedInputTable.query.filter(
-            FixedInputTable.product_id == self.product.product_id  # type: ignore
-        ).all()
+        stmt = select(FixedInputTable).where(FixedInputTable.product_id == self.product.product_id)  # type: ignore
+        fixed_inputs = db.session.scalars(stmt).all()
         return [{"field": fi.name, "value": fi.value} for fi in fixed_inputs]
 
     @authenticated_field(description="Returns list of processes of the subscription")  # type: ignore

--- a/orchestrator/graphql/utils/to_graphql_result_page.py
+++ b/orchestrator/graphql/utils/to_graphql_result_page.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 from orchestrator.graphql.pagination import Connection, PageInfo
 
@@ -7,7 +7,7 @@ def to_graphql_result_page(
     items: list[Any],
     first: int,
     after: int,
-    total: int,
+    total: Optional[int],
     sort_fields: Union[List[str], None] = None,
     filter_fields: Union[List[str], None] = None,
 ) -> Connection:

--- a/test/unit_tests/graphql/test_workflows.py
+++ b/test/unit_tests/graphql/test_workflows.py
@@ -67,7 +67,7 @@ def test_workflows_query(test_client):
 
 
 def test_workflows_has_previous_page(test_client):
-    data = get_workflows_query(after=1)
+    data = get_workflows_query(after=1, sort_by={"field": "name", "order": "ASC"})
     response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
@@ -86,8 +86,11 @@ def test_workflows_has_previous_page(test_client):
     }
 
     assert len(workflows) == 3
-    assert workflows[0]["name"] == "task_clean_up_tasks"
-    assert workflows[1]["name"] == "task_resume_workflows"
+    assert [workflow["name"] for workflow in workflows] == [
+        "task_clean_up_tasks",
+        "task_resume_workflows",
+        "task_validate_products",
+    ]
 
 
 def test_workflows_filter_by_name(test_client):


### PR DESCRIPTION
`orchestrator.db.sorting` and `orchestrator.db.filters` are also updated.

related: #386 