### PR TITLE
Callback wf improvements

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -16,7 +16,7 @@
 import struct
 import zlib
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 import structlog

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -162,7 +162,7 @@ def continue_awaiting_process_endpoint(
     process_id: UUID,
     token: str,
     request: Request,
-    json_data: JSON = Body(...),
+    json_data: State = Body(...),
 ) -> None:
     check_global_lock()
 
@@ -172,7 +172,7 @@ def continue_awaiting_process_endpoint(
         raise_status(HTTPStatus.CONFLICT, "This process is not in an awaiting state.")
 
     try:
-        continue_awaiting_process(process, token=token, input_data=cast(json_data, State))
+        continue_awaiting_process(process, token=token, input_data=json_data)
     except AssertionError as e:
         raise_status(HTTPStatus.NOT_FOUND, str(e))
 

--- a/orchestrator/db/database.py
+++ b/orchestrator/db/database.py
@@ -251,7 +251,7 @@ def disable_commit(db: Database, log: BoundLogger) -> Iterator:
 def transactional(db: Database, log: BoundLogger) -> Iterator:
     """Run a step function in an implicit transaction with automatic rollback or commit.
 
-    It will rollback in case of error, commit otherwise. It will also disable the `commit()` method
+    It will roll back in case of error, commit otherwise. It will also disable the `commit()` method
     on `BaseModel.session` for the time `transactional` is in effect.
     """
     try:
@@ -263,6 +263,6 @@ def transactional(db: Database, log: BoundLogger) -> Iterator:
         log.warning("Rolling back transaction.")
         raise
     finally:
-        # Extra safe guard rollback. If the commit failed there is still a failed transaction open.
+        # Extra safeguard rollback. If the commit failed there is still a failed transaction open.
         # BTW: without a transaction in progress this method is a pass-through.
         db.session.rollback()

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -16,7 +16,7 @@ import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 from uuid import UUID, uuid4
 
 import structlog

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -16,7 +16,7 @@ import threading
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple
 from uuid import UUID, uuid4
 
 import structlog
@@ -43,6 +43,7 @@ from orchestrator.websocket import (
 )
 from orchestrator.websocket.websocket_manager import WebSocketManager
 from orchestrator.workflow import (
+    CALLBACK_TOKEN_KEY,
     Failed,
     ProcessStat,
     ProcessStatus,
@@ -158,31 +159,30 @@ def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> P
 def _get_current_step_to_update(
     stat: ProcessStat, p: ProcessTable, step: Step, process_state: WFProcess
 ) -> ProcessStepTable:
-    """Checks if last error state is identical to determine if we add a new step or update the last one."""
+    """Checks if last error state is identical to determine if we add a new step or update the last one.
+
+    There are some special internal keys checked to customise how the step is updated in the database.
+    These keys are only used for this purpose and not stored in the database.
+    - '__step_name_override' - When this key is present, the value will be used as the ProcessStepTable.name
+    - '__replace_last_state' - When the value for this key is truthy, the previous state in the db will be overridden
+    - '__remove_keys' - Removes the keys in this given list from the state
+    """
     step_state: State = process_state.unwrap()
     current_step = None
     last_db_step = p.steps[-1] if len(p.steps) else None
-    current_sub_step, current_step_group = step_state.get("__sub_step"), step_state.get("__step_group")
-    db_sub_step, db_step_group = (
-        (last_db_step.state.get("__sub_step"), last_db_step.state.get("__step_group")) if last_db_step else (None, None)
-    )
+    step_name = step_state.pop("__step_name_override", step.name)
 
-    if current_sub_step is None and db_sub_step is None:
-        pass  # Skip step group logic
-    elif (db_sub_step is None and current_sub_step) or (db_sub_step and current_sub_step is None):
-        # New entry
-        current_step = ProcessStepTable(
-            process_id=stat.process_id,
-            name=current_step_group or db_step_group,
-            status=process_state.status,
-            state=step_state,
-            created_by=stat.current_user,
-        )
-    else:
-        # Update last step entry in db
-        last_db_step.status = process_state.status
-        last_db_step.state = step_state
+    if step_state.pop("__replace_last_state", None):
         current_step = last_db_step
+        current_step.status = process_state.status
+        current_step.state = step_state
+
+    if "__remove_keys" in step_state:
+        keys_to_remove = step_state.get("__remove_keys")
+        keys_to_remove = keys_to_remove if isinstance(keys_to_remove, Iterable) else []
+        for k in keys_to_remove:
+            step_state.pop(k, None)
+        step_state.pop("__remove_keys", None)
 
     if process_state.isfailed() or process_state.iswaiting():
         if (
@@ -209,7 +209,7 @@ def _get_current_step_to_update(
         # add a new entry to the process stat
         current_step = ProcessStepTable(
             process_id=stat.process_id,
-            name=step.name,
+            name=step_name,
             status=process_state.status,
             state=step_state,
             created_by=stat.current_user,
@@ -236,7 +236,7 @@ def _db_log_step(
         broadcast_func: Optional function to broadcast process data
 
     Returns:
-        WFProcess
+        WFProcess: The process as stored in the database
 
     """
     p = _update_process(stat.process_id, step, process_state)
@@ -557,7 +557,7 @@ def continue_awaiting_process(
     state = pstat.state.unwrap()
 
     # Check if the token matches
-    token_from_state = state.get("__callback_token")
+    token_from_state = state.get(CALLBACK_TOKEN_KEY)
     if token != token_from_state:
         raise AssertionError("Invalid token")
 

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -183,7 +183,6 @@ def _get_current_step_to_update(
     # Core internal: __remove_keys
     try:
         keys_to_remove = step_state.get("__remove_keys", [])
-        keys_to_remove = keys_to_remove if isinstance(keys_to_remove, Iterable) else []
         for k in keys_to_remove:
             step_state.pop(k, None)
     except TypeError:

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -338,7 +338,7 @@ def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
 def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
     def stepfunc(process_id: UUID) -> State:
         token = secrets.token_urlsafe()
-        route = f"/processes/{process_id}/callback/{token}"
+        route = f"/api/processes/{process_id}/callback/{token}"
         # Also add the token under __callback_token for internal use
         return {key: route, "__callback_token": token}
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -302,7 +302,7 @@ def _extend_step_group_steps(name: str, steps: StepList) -> StepList:
     enter_step = begin >> step(f"{name} - Enter")(add_sub_group_info_to_state)
     exit_step = step(f"{name} - Exit")(remove_sub_group_info_from_state)
 
-    return begin >> enter_step >> steps >> exit_step
+    return enter_step >> steps >> exit_step
 
 
 def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -63,7 +63,6 @@ from pydantic_forms.types import (
 
 logger = structlog.get_logger(__name__)
 
-
 StepLogFunc = Callable[["ProcessStat", "Step", "Process"], "Process"]
 StepLogFuncInternal = Callable[["Step", "Process"], "Process"]
 StepToProcessFunc = Callable[[State], "Process"]
@@ -71,6 +70,7 @@ StepToProcessFunc = Callable[[State], "Process"]
 step_log_fn_var: contextvars.ContextVar[StepLogFuncInternal] = contextvars.ContextVar("log_step_fn")
 
 DEFAULT_CALLBACK_ROUTE_KEY = "callback_route"
+CALLBACK_TOKEN_KEY = "__callback_token"  # noqa: S105
 
 
 @runtime_checkable
@@ -292,6 +292,19 @@ def inputstep(name: str, assignee: Assignee) -> Callable[[InputStepFunc], Step]:
     return decorator
 
 
+def _extend_step_group_steps(name: str, steps: StepList) -> StepList:
+    def add_sub_group_info_to_state() -> State:
+        return {"__step_name_override": name, "__step_group": name}
+
+    def remove_sub_group_info_from_state() -> State:
+        return {"__remove_keys": ["__step_group", "__sub_step"]}
+
+    enter_step = begin >> step(f"{name} - Enter")(add_sub_group_info_to_state)
+    exit_step = step(f"{name} - Exit")(remove_sub_group_info_from_state)
+
+    return begin >> enter_step >> steps >> exit_step
+
+
 def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
     """Add a group of steps to the workflow as a single step.
 
@@ -307,19 +320,10 @@ def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
         extract_form: Whether to attach the first form of the sub steps to the step group
     """
 
+    steps = _extend_step_group_steps(name, steps)
+
     def func(initial_state: State) -> Process:
         step_log_fn = step_log_fn_var.get()
-
-        def dblogstep(step_: Step, p: Process) -> Process:
-            # Add sub_step info to state
-            p = p.map(lambda s: s | {"__sub_step": step_.name, "__step_group": name})
-            p = step_log_fn(step_, p)
-            # If this was the last sub step, remove sub_step info from state
-            step_state = p.unwrap()
-            if step_state.get("__sub_step") == steps[-1].name and step_state.get("__step_group") == name:
-                # The step group is finished. Remove sub step data from state
-                p = p.on_success(lambda s: {k: v for k, v in s.items() if k not in ["__sub_step", "__step_group"]})
-            return p
 
         # If sub_step information is present in the state. Resume from the next sub step
         if "__sub_step" in initial_state:
@@ -327,8 +331,18 @@ def step_group(name: str, steps: StepList, extract_form: bool = True) -> Step:
         else:
             step_list = steps
 
+        def dblogstep(step_: Step, p: Process) -> Process:
+            p = p.map(lambda s: s | {"__sub_step": step_.name, "__step_name_override": name})
+            # If this is not the first step to be executed, replace previous state
+            if step_list[0] != step_ or "__sub_step" in initial_state:
+                p = p.map(lambda s: s | {"__replace_last_state": True})
+            return step_log_fn(step_, p)
+
         process: Process = Success(initial_state)
-        return _exec_steps(step_list, process, dblogstep)
+        process = _exec_steps(step_list, process, dblogstep)
+
+        # Add instruction to replace state of last sub step before returning process _exec_steps higher in the call tree
+        return process.map(lambda s: s | {"__replace_last_state": True})
 
     # Make sure we return a form is a sub step has a form
     form = next((sub_step.form for sub_step in steps if sub_step.form), None) if extract_form else None
@@ -340,7 +354,7 @@ def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
         token = secrets.token_urlsafe()
         route = f"/api/processes/{process_id}/callback/{token}"
         # Also add the token under __callback_token for internal use
-        return {key: route, "__callback_token": token}
+        return {key: route, CALLBACK_TOKEN_KEY: token}
 
     return stepfunc
 
@@ -374,8 +388,10 @@ def callback_step(
     """
     create_endpoint_step = step(f"{name} - Create endpoint")(_create_endpoint_step(key=callback_route_key))
     await_step = _awaitstep(f"{name} - Await callback", result_key=result_key)
-
-    return step_group(name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step)
+    cleanup_step = step(f"{name} - Cleanup callback step")(lambda: {"__remove_keys": [CALLBACK_TOKEN_KEY]})
+    return step_group(
+        name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step >> cleanup_step
+    )
 
 
 def _purestep(name: str) -> Callable[[StepToProcessFunc], StepList]:

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -221,7 +221,7 @@ def db_session(database):
     perspective it looks like everything will indeed be committed; allowing for queries on the database to be
     performed to see if functions under test have persisted their changes to the database correctly. However once
     the test function returns this fixture will clean everything up by rolling back the outer transaction; leaving the
-    database in a known state (=empty with the exception of what migrations have added as the initial state).
+    database in a known state (=empty except what migrations have added as the initial state).
 
     Args:
         database: fixture for providing an initialized database.

--- a/test/unit_tests/test_workflow.py
+++ b/test/unit_tests/test_workflow.py
@@ -422,7 +422,8 @@ def store(log) -> StepLogFunc:
     def _store(_: ProcessStat, step_: Step, process: Process):
         state = process.unwrap()
         step_name = state.pop("__step_name_override", step_.name)
-        for k in state.get("__remove_keys", []) + ["__remove_keys"]:
+        keys_to_remove = state.get("__remove_keys", []) + ["__remove_keys"]
+        for k in keys_to_remove:
             state.pop(k, None)
         if state.pop("__replace_last_state", None):
             log[-1] = (step_name, process)

--- a/test/unit_tests/workflows/test_async_workflow.py
+++ b/test/unit_tests/workflows/test_async_workflow.py
@@ -1,6 +1,3 @@
-import time
-
-from orchestrator import app_settings
 from orchestrator.targets import Target
 from orchestrator.workflow import (
     DEFAULT_CALLBACK_ROUTE_KEY,
@@ -32,11 +29,47 @@ def step2(steps):
     return {"steps": [*steps, 2]}
 
 
-def test_workflow_with_callback():
-    @step("Action")
-    def action():
-        return {"ext_response": "Request received"}
+@step("Action")
+def action():
+    return {"ext_response": "Request received"}
 
+
+@step("Action - Dry run")
+def action_dr():
+    return {"phase": "DRY_RUN"}
+
+
+@step("Action - For real")
+def action_fr():
+    return {"phase": "FOR_REAL"}
+
+
+@step("Validate")
+def validate_state(phase, callback_result):
+    if not callback_result["ext_data"].isnumeric():
+        raise ValueError("ext_data must be numeric")
+    if phase == "DRY_RUN":
+        return {"dr_ext_data": callback_result["ext_data"]}
+    if phase == "FOR_REAL":
+        return {"ext_data": callback_result["ext_data"]}
+    raise AssertionError(f"Unknown phase: {phase}")
+
+
+@step("Cleanup")
+def cleanup():
+    return {"phase": None}
+
+
+cb1 = callback_step("Dry run", action_step=action_dr, validate_step=validate_state)
+cb2 = callback_step("For real", action_step=action_fr, validate_step=validate_state)
+
+
+@workflow("Multiple callback wf", target=Target.CREATE)
+def multiple_callback_wf():
+    return begin >> cb1 >> cb2 >> cleanup >> done
+
+
+def test_workflow_with_callback():
     @step("Validate")
     def validate(code):
         if code != "12345":
@@ -45,12 +78,12 @@ def test_workflow_with_callback():
 
     call_ext_system = callback_step(name="Call ext system", action_step=action, validate_step=validate)
 
-    @workflow("Test wf", target="Target.CREATE")
-    def testwf():
+    @workflow("Test wf", target=Target.CREATE)
+    def test_wf():
         return begin >> step1 >> call_ext_system >> step2 >> done
 
-    with WorkflowInstanceForTests(testwf, "testwf"):
-        result, process, step_log = run_workflow("testwf", {})
+    with WorkflowInstanceForTests(test_wf, "test_wf"):
+        result, process, step_log = run_workflow("test_wf", {})
         assert_awaiting_callback(result)
         state = result.unwrap()
         assert DEFAULT_CALLBACK_ROUTE_KEY in state
@@ -65,24 +98,16 @@ def test_workflow_with_callback():
 
 
 def test_callback_wf_with_custom_callback_route():
-    @step("Action")
-    def action():
-        return {"ext_response": "Request received"}
-
-    @step("Validate")
-    def validate():
-        return {}
-
     call_ext_system = callback_step(
-        name="Call ext system", action_step=action, validate_step=validate, callback_route_key="custom_route_key"
+        name="Call ext system", action_step=action, validate_step=step1, callback_route_key="custom_route_key"
     )
 
-    @workflow("Test wf", target="Target.CREATE")
-    def testwf():
+    @workflow("Test wf", target=Target.CREATE)
+    def test_wf():
         return begin >> call_ext_system >> done
 
-    with WorkflowInstanceForTests(testwf, "testwf"):
-        result, process, step_log = run_workflow("testwf", {})
+    with WorkflowInstanceForTests(test_wf, "test_wf"):
+        result, process, step_log = run_workflow("test_wf", {})
         assert_awaiting_callback(result)
         state = result.unwrap()
         assert DEFAULT_CALLBACK_ROUTE_KEY not in state
@@ -90,44 +115,11 @@ def test_callback_wf_with_custom_callback_route():
 
 
 def test_wf_with_multiple_callback_steps(test_client):
-    app_settings.TESTING = False
-
-    @step("Action - Dry run")
-    def action_dr():
-        return {"phase": "DRY_RUN"}
-
-    @step("Action - For real")
-    def action_fr():
-        return {"phase": "FOR_REAL"}
-
-    @step("Validate")
-    def validate_state(phase, callback_result):
-        if phase == "DRY_RUN":
-            return {"dr_ext_data": callback_result["ext_data"]}
-        if phase == "FOR_REAL":
-            return {"ext_data": callback_result["ext_data"]}
-        raise AssertionError(f"Unknown phase: {phase}")
-
-    @step("Cleanup")
-    def cleanup():
-        return {
-            "phase": None,
-        }
-
-    cb1 = callback_step("Dry run", action_step=action_dr, validate_step=validate_state)
-    cb2 = callback_step("For real", action_step=action_fr, validate_step=validate_state)
-
-    @workflow("Multiple callback wf", target=Target.CREATE)
-    def test_wf():
-        return begin >> cb1 >> cb2 >> cleanup >> done
-
-    with WorkflowInstanceForTests(test_wf, "test_wf"):
+    with WorkflowInstanceForTests(multiple_callback_wf, "multiple_callback_wf"):
         # Start workflow
-        response = test_client.post("/api/processes/test_wf", json=[{}])
+        response = test_client.post("/api/processes/multiple_callback_wf", json=[{}])
         assert response.status_code == 201
         process_id = response.json()["id"]
-
-        time.sleep(1)
 
         # Check process status
         response = test_client.get(f"api/processes/{process_id}")
@@ -143,8 +135,6 @@ def test_wf_with_multiple_callback_steps(test_client):
         callback_route1 = state["callback_route"]
         response = test_client.post(callback_route1, json={"ext_data": "12345", "other": "useless data"})
         assert response.status_code == 200
-
-        time.sleep(1)
 
         # Check process status
         response = test_client.get(f"api/processes/{process_id}")
@@ -165,8 +155,6 @@ def test_wf_with_multiple_callback_steps(test_client):
         response = test_client.post(callback_route2, json={"ext_data": "56789", "other": "very useful data"})
         assert response.status_code == 200
 
-        time.sleep(1)
-
         # Final check
         response = test_client.get(f"api/processes/{process_id}")
         response_data = response.json()
@@ -177,5 +165,3 @@ def test_wf_with_multiple_callback_steps(test_client):
         assert state["ext_data"] == "56789"
 
         assert state["phase"] is None
-
-    app_settings.TESTING = True


### PR DESCRIPTION
A refactor to simplify some workings of dblogstep and accompanying changes to step_group

- `_db_log_step` which handles persisting `process` and `process_steps` in the db now looks at certain internal keys in the state to customize this handling. It is now step_group agnostic.
- The Step group `step_list` is now extended with and `enter` and `exit` step which handles initialization and cleanup.
- Added a multistep unit_test for an async workflow with persistence.