### PR TITLE
Fix cleanup_tasks_log stepname and make period configurable

### DIFF
--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -77,6 +77,7 @@ class AppSettings(BaseSettings):
     DEFAULT_CUSTOMER_FULLNAME: str = "Default::Orchestrator-Core Customer"
     DEFAULT_CUSTOMER_SHORTCODE: str = "default-cust"
     DEFAULT_CUSTOMER_IDENTIFIER: str = "59289a57-70fb-4ff5-9c93-10fe67b12434"
+    TASK_LOG_RETENTION_DAYS: int = 3
 
 
 class Oauth2Settings(BaseSettings):

--- a/test/unit_tests/graphql/test_product_blocks.py
+++ b/test/unit_tests/graphql/test_product_blocks.py
@@ -107,6 +107,7 @@ def test_product_blocks_query(test_client):
             "inUseBy": [],
         },
     ]
+    product_blocks.sort(key=lambda x: x["name"])  # No sort in the query; sort before the assert to prevent flaky tests
     assert product_blocks == expected
 
 
@@ -173,7 +174,7 @@ def test_product_block_query_with_relations(test_client):
         },
     ]
 
-    exclude_paths = exclude_paths = [f"root[{i}]['createdAt']" for i in range(len(expected))]
+    exclude_paths = [f"root[{i}]['createdAt']" for i in range(len(expected))]
     assert_no_diff(expected, product_blocks, exclude_paths=exclude_paths)
 
 
@@ -196,6 +197,7 @@ def test_product_blocks_has_previous_page(test_client):
     }
 
     assert len(product_blocks) == 5
+    product_blocks.sort(key=lambda x: x["name"])  # No sort in the query; sort before the assert to prevent flaky tests
     assert product_blocks[0]["name"] == "PB_2"
     assert product_blocks[1]["name"] == "PB_3"
 


### PR DESCRIPTION
The core workflow `cleanup_tasks_log` currently logs `"Clean up tasks older than one week"` while it is actually cleaning tasks older than 3 days. 

This PR fixes changes that to `"Clean up completed tasks older than TASK_LOG_RETENTION_DAYS"` while making the value configurable through `TASK_LOG_RETENTION_DAYS`
