### PR TITLE
Add test coverage for SubscriptionInstanceList.__init_subclass__

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -92,5 +92,6 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -92,6 +92,6 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
         with:
-          # token: ${{ secrets.CODECOV_TOKEN }}  # gives error 'Could not find a repository associated with upload token'
+          token: ${{ secrets.CODECOV_TOKEN }}  # gives error 'Could not find a repository associated with upload token'
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -92,6 +92,6 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }}  # gives error 'Could not find a repository associated with upload token'
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -1099,6 +1099,24 @@ def test_is_constrained_list_type():
     assert _is_constrained_list_type(List[int]) is False
 
 
+def test_product_block_with_si_list(test_product_one):
+    """Test a SubscriptionInstanceList within a ProductBlockModel.
+
+    This provides test coverage for SubscriptionInstanceList.__init_subclass__()
+    """
+
+    class ListOfValues(SubscriptionInstanceList[float]):
+        max_items = 3
+
+    class ProductBlockOneForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneForTest"):
+        values: ListOfValues = Field(default_factory=list)
+
+    block = ProductBlockOneForTestInactive(
+        subscription_instance_id=uuid4(), owner_subscription_id=uuid4(), values=["1.3", 2]
+    )
+    assert block.dict()["values"] == [1.3, 2.0]
+
+
 def test_diff_in_db_empty(test_product_one, test_product_type_one):
     ProductTypeOneForTestInactive, _, _ = test_product_type_one
 


### PR DESCRIPTION
None of the existing tests break when removing the method `SubscriptionInstanceList.__init_subclass__()`. This test does.