### PR TITLE
Add inUseByRelations to subscription.productBlockInstances

### DIFF
--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -16,7 +16,7 @@ class ProductBlockInstance:
     parent: Optional[int]
     subscription_instance_id: UUID
     owner_subscription_id: UUID
-    in_use_by_ids: list[UUID]
+    in_use_by_relations: list[JSON]
     product_block_instance_values: JSON
 
     @strawberry.field(description="Returns all resource types of a product block", deprecation_reason="changed to product_block_instance_values")  # type: ignore
@@ -76,7 +76,7 @@ async def get_subscription_product_blocks(
             product_block_instance_values=[
                 {"field": to_lower_camel(k), "value": v} for k, v in product_block.items() if included(k, v)
             ],
-            in_use_by_ids=product_block.get("in_use_by_ids", []),
+            in_use_by_relations=product_block.get("in_use_by_relations", []),
         )
 
     product_blocks = (to_product_block(product_block) for product_block in get_all_product_blocks(subscription, tags))

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -16,6 +16,7 @@ class ProductBlockInstance:
     parent: Optional[int]
     subscription_instance_id: UUID
     owner_subscription_id: UUID
+    in_use_by_ids: list[UUID]
     product_block_instance_values: JSON
 
     @strawberry.field(description="Returns all resource types of a product block", deprecation_reason="changed to product_block_instance_values")  # type: ignore
@@ -75,6 +76,7 @@ async def get_subscription_product_blocks(
             product_block_instance_values=[
                 {"field": to_lower_camel(k), "value": v} for k, v in product_block.items() if included(k, v)
             ],
+            in_use_by_ids=product_block.get("in_use_by_ids", []),
         )
 
     product_blocks = (to_product_block(product_block) for product_block in get_all_product_blocks(subscription, tags))

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -68,6 +68,7 @@ query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $fi
         subscriptionInstanceId
         ownerSubscriptionId
         productBlockInstanceValues
+        inUseByIds
       }
       product {
         productId
@@ -121,6 +122,10 @@ query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $fi
       note
       startDate
       endDate
+      productBlockInstances {
+        ownerSubscriptionId
+        inUseByIds
+      }
       processes(sortBy: [{field: "startedAt", order: ASC}]) {
         page {
           processId
@@ -838,6 +843,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
                 {"field": "label", "value": None},
                 {"field": "rt1", "value": "Value1"},
             ],
+            "inUseByIds": [],
         },
         {
             "id": 1,
@@ -850,6 +856,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
                 {"field": "rt2", "value": 42},
                 {"field": "rt3", "value": "Value2"},
             ],
+            "inUseByIds": [],
         },
     ]
 
@@ -975,6 +982,11 @@ def test_single_subscription_with_in_use_by_subscriptions(
         subscription["subscriptionId"] for subscription in subscriptions[0]["inUseBySubscriptions"]["page"]
     ]
     assert result_in_use_by_ids == expected_in_use_by_ids
+
+    list_sub = SubscriptionModel.from_subscription(product_sub_list_union_subscription_1)
+    assert subscriptions[0]["productBlockInstances"] == [
+        {"ownerSubscriptionId": subscription_id, "inUseByIds": [str(list_sub.test_block.subscription_instance_id)]}
+    ]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="types get different origin with 3.10 and higher")

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -68,7 +68,7 @@ query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $fi
         subscriptionInstanceId
         ownerSubscriptionId
         productBlockInstanceValues
-        inUseByIds
+        inUseByRelations
       }
       product {
         productId
@@ -124,7 +124,7 @@ query SubscriptionQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $fi
       endDate
       productBlockInstances {
         ownerSubscriptionId
-        inUseByIds
+        inUseByRelations
       }
       processes(sortBy: [{field: "startedAt", order: ASC}]) {
         page {
@@ -843,7 +843,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
                 {"field": "label", "value": None},
                 {"field": "rt1", "value": "Value1"},
             ],
-            "inUseByIds": [],
+            "inUseByRelations": [],
         },
         {
             "id": 1,
@@ -856,7 +856,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
                 {"field": "rt2", "value": 42},
                 {"field": "rt3", "value": "Value2"},
             ],
-            "inUseByIds": [],
+            "inUseByRelations": [],
         },
     ]
 
@@ -985,7 +985,15 @@ def test_single_subscription_with_in_use_by_subscriptions(
 
     list_sub = SubscriptionModel.from_subscription(product_sub_list_union_subscription_1)
     assert subscriptions[0]["productBlockInstances"] == [
-        {"ownerSubscriptionId": subscription_id, "inUseByIds": [str(list_sub.test_block.subscription_instance_id)]}
+        {
+            "ownerSubscriptionId": subscription_id,
+            "inUseByRelations": [
+                {
+                    "subscription_id": str(product_sub_list_union_subscription_1),
+                    "subscription_instance_id": str(list_sub.test_block.subscription_instance_id),
+                }
+            ],
+        }
     ]
 
 


### PR DESCRIPTION
it returns a list of `{ "subscription_id": id, "subscription_instance_id": instance_id } `. so the relations can be matched with `subscription_id` with the ids from `subscriptions.inUseBySubscriptions`.

Closes: #383