### PR TITLE
Bumpversion to 1.3.5rc1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.4
+current_version = 1.3.5rc1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "1.3.4"
+__version__ = "1.3.5rc1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -580,7 +580,7 @@ def _generate_etag(model: dict) -> str:
     return md5(encoded).hexdigest()  # noqa: S303, S324
 
 
-def convert_subscription_instance(obj: Any) -> dict[str, str]:
+def convert_to_in_use_by_relation(obj: Any) -> dict[str, str]:
     return {"subscription_instance_id": str(obj.subscription_instance_id), "subscription_id": str(obj.subscription_id)}
 
 
@@ -598,7 +598,7 @@ def build_extended_domain_model(subscription_model: SubscriptionModel) -> dict:
             return
 
         in_use_by_ids = [obj.in_use_by_id for obj in in_use_by_subs.col]
-        in_use_by_relations = [convert_subscription_instance(instance) for instance in in_use_by_subs]
+        in_use_by_relations = [convert_to_in_use_by_relation(instance) for instance in in_use_by_subs]
         update_in(subscription, f"{path_to_block}.in_use_by_ids", in_use_by_ids)
         update_in(subscription, f"{path_to_block}.in_use_by_relations", in_use_by_relations)
 


### PR DESCRIPTION
also sneak in rename of indescriptive service.subscription function `convert_subscription_instance` to `convert_to_in_use_by_relation`