### PR TITLE
Search parser

### DIFF
--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -28,7 +28,7 @@ from starlette.responses import Response
 
 from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.api.error_handling import raise_status
-from orchestrator.api.helpers import add_response_range, query_with_filters
+from orchestrator.api.helpers import add_response_range, add_subscription_search_query_filter, query_with_filters
 from orchestrator.db import (
     ProcessStepTable,
     ProcessSubscriptionTable,
@@ -229,6 +229,38 @@ def subscriptions_filterable(
     stmt = query_with_filters(stmt, sort_, filter_)
     stmt = add_response_range(stmt, range_, response)
 
+    sequence = db.session.execute(stmt).all()
+    return [{**s.__dict__, "metadata": md} for s, md in sequence]
+
+
+@router.get("/search", response_model=list[SubscriptionWithMetadata])
+def subscriptions_search(
+    response: Response, query: str, range: Optional[str] = None, sort: Optional[str] = None
+) -> list[dict]:
+    """Get subscriptions filtered based on a search query string.
+
+    Args:
+        response: Fastapi Response object
+        query: The search query
+        range: Range
+        sort: Sort
+
+    Returns:
+        List of subscriptions
+
+    """
+    range_ = list(map(int, range.split(","))) if range else None
+    sort_ = sort.split(",") if sort else None
+    logger.info("subscriptions_search() called", range=range_, sort=sort_)
+    stmt = select(SubscriptionTable, SubscriptionMetadataTable.metadata_).join_from(
+        SubscriptionTable, SubscriptionMetadataTable, isouter=True
+    )
+
+    stmt = stmt.join(SubscriptionTable.product).options(
+        contains_eager(SubscriptionTable.product), defer(SubscriptionTable.product_id)
+    )
+    stmt = add_subscription_search_query_filter(stmt, query)
+    stmt = add_response_range(stmt, range_, response)
     sequence = db.session.execute(stmt).all()
     return [{**s.__dict__, "metadata": md} for s, md in sequence]
 

--- a/orchestrator/api/helpers.py
+++ b/orchestrator/api/helpers.py
@@ -151,7 +151,13 @@ def add_response_range(stmt: Selectable, range_: Optional[list[int]], response: 
     return stmt
 
 
+MAX_QUERY_STRING_LENGTH = 512
+
+
 def add_subscription_search_query_filter(stmt: Select, search_query: str) -> Select:
+    if len(search_query) > MAX_QUERY_STRING_LENGTH:
+        raise_status(HTTPStatus.BAD_REQUEST, f"Max query length of {MAX_QUERY_STRING_LENGTH} characters exceeded.")
+
     ts_query = create_ts_query_string(search_query)
     return stmt.join(SubscriptionSearchView).filter(
         func.to_tsquery("simple", ts_query).op("@@")(SubscriptionSearchView.tsv)

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -115,7 +115,7 @@ def update_subscription_status(subscription_id: UUIDstr, status: str) -> Subscri
 
 
 def update_subscription_description(subscription_id: UUIDstr, description: str) -> SubscriptionTable:
-    """Update a subscriptions' description.
+    """Update a subscription's description.
 
     Args:
         subscription_id: subscription id of the subscription to update

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -115,7 +115,7 @@ def update_subscription_status(subscription_id: UUIDstr, status: str) -> Subscri
 
 
 def update_subscription_description(subscription_id: UUIDstr, description: str) -> SubscriptionTable:
-    """Update a subscriptions description.
+    """Update a subscriptions' description.
 
     Args:
         subscription_id: subscription id of the subscription to update

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -1,36 +1,48 @@
+import re
 from enum import Enum
 from itertools import chain
-from typing import Optional, Iterable
-import re
+from typing import Any, Iterable, Iterator, Optional, Union, cast
+
+import structlog
+
+logger = structlog.getLogger(__name__)
 
 
 class Token(Enum):
     WORD = "WORD"
     OP_OR = "|"
     OP_NEG = "-"
-    OP_PREFIX = "*"
+    ASTERISK = "*"
     LPAREN = "("
     RPAREN = ")"
     SEMICOLON = ":"
-    QUOTE = "\""
+    QUOTE = '"'
     END = "$"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name
 
 
 SPECIAL_CHARS = {
     "|": Token.OP_OR,
     "-": Token.OP_NEG,
-    "*": Token.OP_PREFIX,
+    "*": Token.ASTERISK,
     "(": Token.LPAREN,
     ")": Token.RPAREN,
     ":": Token.SEMICOLON,
-    "\"": Token.QUOTE
+    '"': Token.QUOTE,
 }
 
 
+class ParseError(RuntimeError):
+    pass
+
+
+Lexeme = Union[tuple[Token], tuple[Token, Any]]
+
+
 class Lexer:
+    word_boundary_regex = r'[()|!:<>*\s"]'
 
     def __init__(self, source: str):
         self.source = source
@@ -44,41 +56,47 @@ class Lexer:
             ch = self.source[self.pos]
             self.pos += 1
             return ch
+        return None
 
     def read_word(self) -> str:
         chars = []
-        while (ch := self.next_char()) and ch not in '()|!:<>*"' and not re.fullmatch(r'\s', ch):
+        while (ch := self.next_char()) and not re.fullmatch(Lexer.word_boundary_regex, ch):
             chars.append(ch)
 
         # Rewind one, since we read something not part of the word
         if ch:
             self.pos -= 1
-        return ''.join(chars)
+        return "".join(chars)
 
-    def lex(self):
+    def lex(self) -> Iterable[Lexeme]:
         self.pos = 0
         max_pos = len(self.source)
 
         while self.pos < max_pos:
-            ch = self.peek()
+            ch = cast(str, self.peek())  # We know ch can't be None here
             if ch in SPECIAL_CHARS:
                 self.pos += 1
                 yield SPECIAL_CHARS[ch],
-            elif re.match(r'\s', ch):
+            elif re.fullmatch(Lexer.word_boundary_regex, ch):
                 self.pos += 1
             else:
-                yield Token.WORD, self.read_word()
+                word = self.read_word()
+                yield Token.WORD, word
 
         yield Token.END,
 
 
+Node = tuple[str, Any]
+
+
 class Parser:
-    """
-    <Query> ::= <AndExpression> (<OrOperator> <AndExpression>)*
-    <_OrOperator> ::= '|'
+    """Class for creating a parse tree from the list of tokens.
+
+    The following grammar is used. Nodenames starting with a _ will not appear in the final parse tree.
+    <Query> ::= <AndExpression> ('|' <AndExpression>)*
     <AndExpression> ::= <Term>*
-    <_Term> ::= [<NegationOperator>] <PositiveTerm>
-    <NegationOperator> ::= '-'
+    <_Term> ::= [<Negation>] <PositiveTerm>
+    <Negation> ::= '-'
     <_PositiveTerm> ::= <Group> | <_Value> | <KVTerm>
     <Group> ::= '(' <Query> ')'
     <Phrase> ::= '"' (<Word> | <PrefixWord>)* '"'
@@ -86,144 +104,143 @@ class Parser:
     <PrefixWord> ::= <Word> '*'
     <Word> ::= <text without "*()!:<> or whitespace>
     <_Value> ::= <Phrase> | <SearchWord>
-    <ValueGroup> ::= '(' <Value> (<OrOperator> <Value>)* ')'
+    <ValueGroup> ::= '(' <Value> ('|' <Value>)* ')'
     """
 
-    def __init__(self, tokens: Iterable):
-        self.tokens = tokens
-        self.it = None
+    def __init__(self, tokens: Iterable[Lexeme]):
+        """Args: tokens - An iterable yielding lexemes.
 
-    def peek(self):
-        token = next(self.it, None)
+        `tokens` must not be empty. The result from the Lexer class
+        will always end with (END,) and so is never empty.
+        Ensure that next_token() is never called after the (END,)
+        token is consumed.
+        """
+        self.tokens = tokens
+        self.it: Iterator[Lexeme] = iter([])
+
+    def peek(self) -> Lexeme:
+        token = next(self.it)
         self.it = chain([token], self.it)
         return token
 
-    def next_token(self):
-        return next(self.it, None)
+    def next_token(self) -> Lexeme:
+        return next(self.it)
 
-    def error(self, msg):
-        print(msg)
+    def error(self, msg: str) -> None:
+        logger.debug(msg)
 
-    def expect(self, expected_type):
+    def expect(self, expected_type: Token) -> Lexeme:
         nt = self.next_token()
         if nt[0] != expected_type:
-            self.error(f"Expected {expected_type}, got {nt[0]}")
-            raise Exception("Parse error")
+            msg = f"Expected {expected_type}, got {nt[0]}"
+            self.error(msg)
+            raise ParseError(msg)
         return nt
 
-    def parse_value_group(self):
+    def parse_value_group(self) -> Optional[Node]:
         self.expect(Token.LPAREN)
-        values = [self.parse_value()]
+        value = self.parse_value()
+        if not value:
+            return None
+        values = [value]
         while next_token := self.peek():
-            if next_token[0] == Token.END:
-                self.error("Unexpected end of stream. Expected an ')'")
-            elif next_token[0] == Token.RPAREN:
+            if next_token[0] == Token.RPAREN:
                 break
-            elif next_token[0] == Token.OP_OR:
+            if next_token[0] == Token.OP_OR:
                 self.expect(Token.OP_OR)
-                values.append(self.parse_value())
+                if next_value := self.parse_value():
+                    values.append(next_value)
             else:
-                self.error(f"Expected a Value or ')', got {next_token}")
-        self.expect(Token.RPAREN)
-        return 'ValueGroup', values
+                raise ParseError(f"Expected a Value or ')', got {next_token}")
 
-    def parse_value(self):
+        self.expect(Token.RPAREN)
+        return "ValueGroup", values
+
+    def parse_value(self) -> Optional[Node]:
         next_token = self.peek()
         if next_token[0] == Token.QUOTE:
             return self.parse_phrase()
-        elif next_token[0] == Token.WORD:
+        if next_token[0] == Token.WORD:
             return self.parse_search_word()
-        else:
-            return None
+        return None
 
-    def parse_search_word(self):
-        word = self.expect(Token.WORD)
+    def parse_search_word(self) -> Node:
+        word = cast(tuple, self.expect(Token.WORD))
         next_token = self.peek()
-        if next_token[0] == Token.OP_PREFIX:
+        if next_token[0] == Token.ASTERISK:
             self.next_token()
-            return 'PrefixWord', word[1]
-        else:
-            return 'Word', word[1]
+            return "PrefixWord", word[1]
+        return "Word", word[1]
 
-    def parse_phrase(self):
+    def parse_phrase(self) -> Node:
         self.expect(Token.QUOTE)
         search_words = []
         while not self.peek()[0] == Token.QUOTE:
-            search_word = self.parse_search_word()
-            search_words.append(search_word)
-        self.expect(Token.QUOTE)
-        return 'Phrase', search_words
+            if not (self.peek()[0] == Token.WORD):
+                self.error(f"Expected a Word or PrefixWord inside phrase. Got: {self.peek()}")
+                break
 
-    def parse_group(self):
+            search_words.append(self.parse_search_word())
+
+        self.expect(Token.QUOTE)
+        return "Phrase", search_words
+
+    def parse_group(self) -> Node:
         self.expect(Token.LPAREN)
         query = self.parse_query()
-        if not query:
-            self.error("Expected a subquery inside a group.")
-        else:
-            self.expect(Token.RPAREN)
-            return 'Group', query[1]
+        self.expect(Token.RPAREN)
+        return "Group", query[1] if query else []
 
-    def parse_positive_term(self):
+    def parse_positive_term(self) -> Optional[Node]:
         # Should return None if not a valid term
         token = self.peek()
         if token[0] == Token.LPAREN:
             return self.parse_group()
-        else:
-            value = self.parse_value()
-            if not value:
-                return
-            next_token = self.peek()
-            if next_token and next_token[0] == Token.SEMICOLON:
-                self.next_token()
-                next_token = self.peek()
-                if next_token[0] == Token.END:
-                    self.error("Unexpected end of stream. Expected a Value or ValueGroup")
-                elif next_token[0] == Token.LPAREN:
-                    return 'KVTerm', (value, self.parse_value_group())
-                else:
-                    return 'KVTerm', (value, self.parse_value())
-            else:
-                return value
 
-    def parse_term(self):
+        value = self.parse_value()
+        if not value:
+            return None
+        next_token = self.peek()
+        if next_token and next_token[0] == Token.SEMICOLON:
+            # It's a KVTerm, e.g. status:active
+            self.next_token()
+            next_token = self.peek()
+            kv_value = self.parse_value_group() if next_token[0] == Token.LPAREN else self.parse_value()
+
+            # An empty value is normally not a problem, but it is in a KVTerm, so we check for it.
+            if not kv_value or kv_value[0] == "Phrase" and not kv_value[1]:
+                raise ParseError("Value term in KVTerm can not be empty.")
+            return "KVTerm", (value, kv_value)
+        return value
+
+    def parse_term(self) -> Optional[Node]:
         token = self.peek()
         if token[0] == Token.OP_NEG:
             self.next_token()
             term = self.parse_positive_term()
-            print("Negative term", term)
-            if not term:
-                self.error(f"Expected a TERM, but got {self.peek()}")
-                return
-            else:
-                return 'Negation', term
-        else:
-            return self.parse_positive_term()
+            return ("Negation", term) if term else None
+        return self.parse_positive_term()
 
-    def parse_and_expression(self):
+    def parse_and_expression(self) -> Optional[Node]:
         terms = []
         while term := self.parse_term():
             terms.append(term)
 
-        return ('AndExpression', terms) if terms else None
+        return ("AndExpression", terms) if terms else None
 
-    def parse_query(self):
+    def parse_query(self) -> Node:
         expressions = []
-        and_expression = self.parse_and_expression()
-        if not and_expression:
-            return
-
-        expressions.append(and_expression)
-
-        while (next_token := self.peek())[0]:
-            if next_token[0] == Token.OP_OR:
-                self.expect(Token.OP_OR)
-                and_expression = self.parse_and_expression()
+        while True:
+            and_expression = self.parse_and_expression()
+            if and_expression:
                 expressions.append(and_expression)
+            if self.peek()[0] not in [Token.END, Token.RPAREN]:
+                self.expect(Token.OP_OR)
             else:
                 break
-        return 'Query', expressions
+        return "Query", expressions
 
-    def parse(self):
+    def parse(self) -> Node:
         self.it = iter(self.tokens)
         query = self.parse_query()
         self.expect(Token.END)
@@ -231,89 +248,101 @@ class Parser:
 
 
 class TSQueryVisitor:
-
     @staticmethod
-    def visit_group(node, acc):
-        acc.append('(')
+    def visit_group(node: Node, acc: list[str]) -> None:
+        acc.append("(")
         for expr in node[1]:
             TSQueryVisitor.visit_and_expression(expr, acc)
-            acc.append(' | ')
+            acc.append(" | ")
         acc.pop()
-        acc.append(')')
+        acc.append(")")
 
     @staticmethod
-    def visit_kv_term(node, acc):
+    def visit_kv_term(node: Node, acc: list[str]) -> None:
         key_node, value_node = node[1]
+
         # Re-use visit_term
         TSQueryVisitor.visit_term(key_node, acc)
-        acc.append(' <-> ')
+        acc.append(" <-> ")
 
-        if value_node[0] == 'ValueGroup':
-            acc.append('(')
+        if value_node[0] == "ValueGroup":
+            acc.append("(")
             for v in value_node[1]:
                 TSQueryVisitor.visit_search_word(v, acc)
-                acc.append(' | ')
+                acc.append(" | ")
             acc.pop()
-            acc.append(')')
+            acc.append(")")
         else:
             TSQueryVisitor.visit_term(value_node, acc)
 
     @staticmethod
-    def visit_search_word(node, acc):
-        if node[0] == 'Word':
-            acc.append(node[1])
-        elif node[0] == 'PrefixWord':
-            acc.append(f"{node[1]}:*")
+    def visit_search_word(node: Node, acc: list[str]) -> None:
+        # Postgres is finicky with single quotes in the query. In some situations it throws an error.
+        # To avoid the special handling of ' by PG, we replace it with double quotes.
+        text = node[1].replace("'", '"')
+        if node[0] == "Word":
+            acc.append(text)
+        elif node[0] == "PrefixWord":
+            acc.append(f"{text}:*")
         else:
-            print(f"Invalid SearchWord type {node[0]}")
+            raise Exception(f"Invalid SearchWord type {node[0]}")
 
     @staticmethod
-    def visit_phrase(node, acc):
+    def visit_phrase(node: Node, acc: list[str]) -> None:
         for search_word in node[1]:
             TSQueryVisitor.visit_search_word(search_word, acc)
-            acc.append(' <-> ')
+            acc.append(" <-> ")
 
         if len(node[1]):
             acc.pop()  # Remove trailing space
 
     @staticmethod
-    def visit_term(node, acc):
+    def visit_term(node: Node, acc: list[str]) -> None:
         node_type = node[0]
-        if node_type == 'Phrase':
+        if node_type == "Phrase":
             TSQueryVisitor.visit_phrase(node, acc)
-        elif node_type in ['Word', 'PrefixWord']:
+        elif node_type in ["Word", "PrefixWord"]:
             TSQueryVisitor.visit_search_word(node, acc)
-        elif node_type == 'KVTerm':
+        elif node_type == "KVTerm":
             TSQueryVisitor.visit_kv_term(node, acc)
-        elif node_type == 'Group':
+        elif node_type == "Group":
             TSQueryVisitor.visit_group(node, acc)
-        elif node_type == 'Negation':
-            acc.append('!')
+        elif node_type == "Negation":
+            acc.append("!")
+            should_group = node[1][0] in ["Phrase", "KVTerm"]
+            if should_group:
+                acc.append("(")
             TSQueryVisitor.visit_term(node[1], acc)
+            if should_group:
+                acc.append(")")
         else:
-            print(f'Unexpected term node type: {node_type}')
+            raise Exception(f"Unexpected term node type: {node_type}")
 
     @staticmethod
-    def visit_and_expression(node, acc):
+    def visit_and_expression(node: Node, acc: list[str]) -> None:
         for term in node[1]:
             TSQueryVisitor.visit_term(term, acc)
-            acc.append(' & ')
+            acc.append(" & ")
         if len(node[1]):
             acc.pop()
 
     @staticmethod
-    def visit_query(node, acc):
+    def visit_query(node: Node, acc: list[str]) -> None:
         for expression in node[1]:
             TSQueryVisitor.visit_and_expression(expression, acc)
-            acc.append(' | ')
+            acc.append(" | ")
 
         if len(node[1]):
             acc.pop()
 
     @staticmethod
-    def visit(parse_tree):
-        acc = []
+    def visit(parse_tree: Node) -> str:
+        acc: list[str] = []
         node_type = parse_tree[0]
-        if node_type == 'Query':
+        if node_type == "Query":
             TSQueryVisitor.visit_query(parse_tree, acc)
-        return ''.join(acc)
+        return "".join(acc)
+
+
+def create_ts_query_string(search_query: str) -> str:
+    return TSQueryVisitor.visit(Parser(Lexer(search_query).lex()).parse())

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -1,0 +1,319 @@
+from enum import Enum
+from itertools import chain
+from typing import Optional, Iterable
+import re
+
+
+class Token(Enum):
+    WORD = "WORD"
+    OP_OR = "|"
+    OP_NEG = "-"
+    OP_PREFIX = "*"
+    LPAREN = "("
+    RPAREN = ")"
+    SEMICOLON = ":"
+    QUOTE = "\""
+    END = "$"
+
+    def __repr__(self):
+        return self.name
+
+
+SPECIAL_CHARS = {
+    "|": Token.OP_OR,
+    "-": Token.OP_NEG,
+    "*": Token.OP_PREFIX,
+    "(": Token.LPAREN,
+    ")": Token.RPAREN,
+    ":": Token.SEMICOLON,
+    "\"": Token.QUOTE
+}
+
+
+class Lexer:
+
+    def __init__(self, source: str):
+        self.source = source
+        self.pos = 0
+
+    def peek(self) -> Optional[str]:
+        return self.source[self.pos] if self.pos < len(self.source) else None
+
+    def next_char(self) -> Optional[str]:
+        while self.pos < len(self.source):
+            ch = self.source[self.pos]
+            self.pos += 1
+            return ch
+
+    def read_word(self) -> str:
+        chars = []
+        while (ch := self.next_char()) and ch not in '()|!:<>*"' and not re.fullmatch(r'\s', ch):
+            chars.append(ch)
+
+        # Rewind one, since we read something not part of the word
+        if ch:
+            self.pos -= 1
+        return ''.join(chars)
+
+    def lex(self):
+        self.pos = 0
+        max_pos = len(self.source)
+
+        while self.pos < max_pos:
+            ch = self.peek()
+            if ch in SPECIAL_CHARS:
+                self.pos += 1
+                yield SPECIAL_CHARS[ch],
+            elif re.match(r'\s', ch):
+                self.pos += 1
+            else:
+                yield Token.WORD, self.read_word()
+
+        yield Token.END,
+
+
+class Parser:
+    """
+    <Query> ::= <AndExpression> (<OrOperator> <AndExpression>)*
+    <_OrOperator> ::= '|'
+    <AndExpression> ::= <Term>*
+    <_Term> ::= [<NegationOperator>] <PositiveTerm>
+    <NegationOperator> ::= '-'
+    <_PositiveTerm> ::= <Group> | <_Value> | <KVTerm>
+    <Group> ::= '(' <Query> ')'
+    <Phrase> ::= '"' (<Word> | <PrefixWord>)* '"'
+    <KVTerm> ::= <Value> ':' (<_Value> | <ValueGroup>)
+    <PrefixWord> ::= <Word> '*'
+    <Word> ::= <text without "*()!:<> or whitespace>
+    <_Value> ::= <Phrase> | <SearchWord>
+    <ValueGroup> ::= '(' <Value> (<OrOperator> <Value>)* ')'
+    """
+
+    def __init__(self, tokens: Iterable):
+        self.tokens = tokens
+        self.it = None
+
+    def peek(self):
+        token = next(self.it, None)
+        self.it = chain([token], self.it)
+        return token
+
+    def next_token(self):
+        return next(self.it, None)
+
+    def error(self, msg):
+        print(msg)
+
+    def expect(self, expected_type):
+        nt = self.next_token()
+        if nt[0] != expected_type:
+            self.error(f"Expected {expected_type}, got {nt[0]}")
+            raise Exception("Parse error")
+        return nt
+
+    def parse_value_group(self):
+        self.expect(Token.LPAREN)
+        values = [self.parse_value()]
+        while next_token := self.peek():
+            if next_token[0] == Token.END:
+                self.error("Unexpected end of stream. Expected an ')'")
+            elif next_token[0] == Token.RPAREN:
+                break
+            elif next_token[0] == Token.OP_OR:
+                self.expect(Token.OP_OR)
+                values.append(self.parse_value())
+            else:
+                self.error(f"Expected a Value or ')', got {next_token}")
+        self.expect(Token.RPAREN)
+        return 'ValueGroup', values
+
+    def parse_value(self):
+        next_token = self.peek()
+        if next_token[0] == Token.QUOTE:
+            return self.parse_phrase()
+        elif next_token[0] == Token.WORD:
+            return self.parse_search_word()
+        else:
+            return None
+
+    def parse_search_word(self):
+        word = self.expect(Token.WORD)
+        next_token = self.peek()
+        if next_token[0] == Token.OP_PREFIX:
+            self.next_token()
+            return 'PrefixWord', word[1]
+        else:
+            return 'Word', word[1]
+
+    def parse_phrase(self):
+        self.expect(Token.QUOTE)
+        search_words = []
+        while not self.peek()[0] == Token.QUOTE:
+            search_word = self.parse_search_word()
+            search_words.append(search_word)
+        self.expect(Token.QUOTE)
+        return 'Phrase', search_words
+
+    def parse_group(self):
+        self.expect(Token.LPAREN)
+        query = self.parse_query()
+        if not query:
+            self.error("Expected a subquery inside a group.")
+        else:
+            self.expect(Token.RPAREN)
+            return 'Group', query[1]
+
+    def parse_positive_term(self):
+        # Should return None if not a valid term
+        token = self.peek()
+        if token[0] == Token.LPAREN:
+            return self.parse_group()
+        else:
+            value = self.parse_value()
+            if not value:
+                return
+            next_token = self.peek()
+            if next_token and next_token[0] == Token.SEMICOLON:
+                self.next_token()
+                next_token = self.peek()
+                if next_token[0] == Token.END:
+                    self.error("Unexpected end of stream. Expected a Value or ValueGroup")
+                elif next_token[0] == Token.LPAREN:
+                    return 'KVTerm', (value, self.parse_value_group())
+                else:
+                    return 'KVTerm', (value, self.parse_value())
+            else:
+                return value
+
+    def parse_term(self):
+        token = self.peek()
+        if token[0] == Token.OP_NEG:
+            self.next_token()
+            term = self.parse_positive_term()
+            print("Negative term", term)
+            if not term:
+                self.error(f"Expected a TERM, but got {self.peek()}")
+                return
+            else:
+                return 'Negation', term
+        else:
+            return self.parse_positive_term()
+
+    def parse_and_expression(self):
+        terms = []
+        while term := self.parse_term():
+            terms.append(term)
+
+        return ('AndExpression', terms) if terms else None
+
+    def parse_query(self):
+        expressions = []
+        and_expression = self.parse_and_expression()
+        if not and_expression:
+            return
+
+        expressions.append(and_expression)
+
+        while (next_token := self.peek())[0]:
+            if next_token[0] == Token.OP_OR:
+                self.expect(Token.OP_OR)
+                and_expression = self.parse_and_expression()
+                expressions.append(and_expression)
+            else:
+                break
+        return 'Query', expressions
+
+    def parse(self):
+        self.it = iter(self.tokens)
+        query = self.parse_query()
+        self.expect(Token.END)
+        return query
+
+
+class TSQueryVisitor:
+
+    @staticmethod
+    def visit_group(node, acc):
+        acc.append('(')
+        for expr in node[1]:
+            TSQueryVisitor.visit_and_expression(expr, acc)
+            acc.append(' | ')
+        acc.pop()
+        acc.append(')')
+
+    @staticmethod
+    def visit_kv_term(node, acc):
+        key_node, value_node = node[1]
+        # Re-use visit_term
+        TSQueryVisitor.visit_term(key_node, acc)
+        acc.append(' <-> ')
+
+        if value_node[0] == 'ValueGroup':
+            acc.append('(')
+            for v in value_node[1]:
+                TSQueryVisitor.visit_search_word(v, acc)
+                acc.append(' | ')
+            acc.pop()
+            acc.append(')')
+        else:
+            TSQueryVisitor.visit_term(value_node, acc)
+
+    @staticmethod
+    def visit_search_word(node, acc):
+        if node[0] == 'Word':
+            acc.append(node[1])
+        elif node[0] == 'PrefixWord':
+            acc.append(f"{node[1]}:*")
+        else:
+            print(f"Invalid SearchWord type {node[0]}")
+
+    @staticmethod
+    def visit_phrase(node, acc):
+        for search_word in node[1]:
+            TSQueryVisitor.visit_search_word(search_word, acc)
+            acc.append(' <-> ')
+
+        if len(node[1]):
+            acc.pop()  # Remove trailing space
+
+    @staticmethod
+    def visit_term(node, acc):
+        node_type = node[0]
+        if node_type == 'Phrase':
+            TSQueryVisitor.visit_phrase(node, acc)
+        elif node_type in ['Word', 'PrefixWord']:
+            TSQueryVisitor.visit_search_word(node, acc)
+        elif node_type == 'KVTerm':
+            TSQueryVisitor.visit_kv_term(node, acc)
+        elif node_type == 'Group':
+            TSQueryVisitor.visit_group(node, acc)
+        elif node_type == 'Negation':
+            acc.append('!')
+            TSQueryVisitor.visit_term(node[1], acc)
+        else:
+            print(f'Unexpected term node type: {node_type}')
+
+    @staticmethod
+    def visit_and_expression(node, acc):
+        for term in node[1]:
+            TSQueryVisitor.visit_term(term, acc)
+            acc.append(' & ')
+        if len(node[1]):
+            acc.pop()
+
+    @staticmethod
+    def visit_query(node, acc):
+        for expression in node[1]:
+            TSQueryVisitor.visit_and_expression(expression, acc)
+            acc.append(' | ')
+
+        if len(node[1]):
+            acc.pop()
+
+    @staticmethod
+    def visit(parse_tree):
+        acc = []
+        node_type = parse_tree[0]
+        if node_type == 'Query':
+            TSQueryVisitor.visit_query(parse_tree, acc)
+        return ''.join(acc)

--- a/test/unit_tests/api/test_subscriptions.py
+++ b/test/unit_tests/api/test_subscriptions.py
@@ -1014,3 +1014,19 @@ def test_product_block_paths(generic_subscription_1, generic_subscription_2):
     subscription_2 = SubscriptionModel.from_subscription(generic_subscription_2)
     assert product_block_paths(subscription_1) == ["product", "pb_1", "pb_2"]
     assert product_block_paths(subscription_2) == ["product", "pb_3"]
+
+
+@pytest.mark.parametrize(
+    "query, num_matches",
+    [
+        ("id", 7),
+        ("tag:(POR* | LP)", 1),
+        ("tag:SP", 3),
+        ("tag:(POR* | LP) | tag:SP", 4),
+        ("tag:(POR* | LP) | tag:SP -status:initial", 3),
+    ],
+)
+def test_subscriptions_search(query, num_matches, seed, test_client, refresh_subscriptions_search_view):
+    response = test_client.get(f"/api/subscriptions/search?query={query}")
+    result = response.json()
+    assert len(result) == num_matches

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -642,3 +642,8 @@ def cache_fixture(monkeypatch):
                 cache.delete(key)
             except Exception as exc:
                 print("failed to delete cache key", key, str(exc))  # noqa: T001, T201
+
+
+@pytest.fixture
+def refresh_subscriptions_search_view():
+    db.session.execute(text("REFRESH MATERIALIZED VIEW subscriptions_search"))

--- a/test/unit_tests/utils/test_search_query.py
+++ b/test/unit_tests/utils/test_search_query.py
@@ -1,0 +1,89 @@
+import pytest
+
+from orchestrator.utils.search_query import Lexer, ParseError, Parser, TSQueryVisitor
+
+
+def _parse_tree_and_tsquery(q: str) -> tuple[tuple, str]:
+    tokens = Lexer(q).lex()
+    tree = Parser(tokens).parse()
+    tsquery = TSQueryVisitor.visit(tree)
+    return tree, tsquery
+
+
+def test_parse_simple_query():
+    q = "simple query with words"
+    parse_tree, tsquery = _parse_tree_and_tsquery(q)
+    assert parse_tree == (
+        "Query",
+        [("AndExpression", [("Word", "simple"), ("Word", "query"), ("Word", "with"), ("Word", "words")])],
+    )
+    assert tsquery == "simple & query & with & words"
+
+
+def test_parse_query_with_phrase():
+    q = 'word1 "some consecutive words" end'
+    parse_tree, tsquery = _parse_tree_and_tsquery(q)
+    assert parse_tree == (
+        "Query",
+        [
+            (
+                "AndExpression",
+                [
+                    ("Word", "word1"),
+                    ("Phrase", [("Word", "some"), ("Word", "consecutive"), ("Word", "words")]),
+                    ("Word", "end"),
+                ],
+            )
+        ],
+    )
+    assert tsquery == "word1 & some <-> consecutive <-> words & end"
+
+
+@pytest.mark.parametrize(
+    "query, msg",
+    [
+        ("a )", "Right paren before left paren"),
+        ('tag:""', "Empty Value in KVTerm"),
+        ("tag:()", "Empty ValueGroup in KVTerm"),
+        ('this "is unbalanced', "Missing closing quote"),
+        ("a (unclosed group", "Missing closing parenthesis"),
+    ],
+)
+def test_parse_errors(query, msg):
+    with pytest.raises(
+        ParseError,
+    ):
+        _parse_tree_and_tsquery(query)
+
+
+def test_parse_edge_cases():
+    # Just test whether this parses without error
+    q = "aa*bb@cc?dd>ee'ff_g<g[hh]ij$kk%;\\=+12`3€crazy!text kk|ll:''"
+    parse_tree, tsquery = _parse_tree_and_tsquery(q)
+    assert tsquery.startswith("aa:*")
+    assert tsquery.endswith('| ll <-> ""')
+
+
+def test_parse_complex_query():
+    q = "".join(
+        [
+            '"phrase1 phrase2 phrase3" word1 word2 prefixword* field1:(val1 | val2* | val3)',
+            " | ",
+            '"phrase21 phrase22" ((klm tag:lp) | (sinica tag:fw)) -("not this" "or this") something else',
+        ]
+    )
+
+    parse_tree, tsquery = _parse_tree_and_tsquery(q)
+    assert len(parse_tree[1]) == 2
+    first_subexpression = parse_tree[1][0]
+    second_subexpression = parse_tree[1][1]
+    assert len(first_subexpression[1]) == 5, "subexpression 1 has 5 terms"
+    assert len(second_subexpression[1]) == 5, "subexpression 2 has 5 terms"
+    assert tsquery == "".join(
+        [
+            "phrase1 <-> phrase2 <-> phrase3 & word1 & word2 & prefixword:* & field1 <-> (val1 | val2:* | val3)",
+            " | ",
+            "phrase21 <-> phrase22 & ((klm & tag <-> lp) | (sinica & tag <-> fw))",
+            " & !(not <-> this & or <-> this) & something & else",
+        ]
+    )


### PR DESCRIPTION
Implement parser and ts_query emitter for formalized search query syntax.

Related to #288

The query syntax introduced here allows for more flexible queries than is supported by Postgres' `websearch_to_tsquery`. A new endpoint `/subscriptions/search` has also been added.

The query syntax is a basically a subset of the ElasticSearch simple query syntax (with a few exceptions).

Features:
- Conjunction: `term1 term2` (default operator = `AND')
- Disjunction: `subquery2 | subquery2`
- Negation: `-term`
- Grouping: `(term1 term2)`
- Phrases: `"word1 word2"` matches consecutive words
- Prefix matching: `gre*` matches words starting with `gre`
- Key-value searching:
  - `field:value` matches items where field = value
  - `"field:(val1 | val2)"` matches items where `field in [val1, val2]`
 