### PR TITLE
288 subscriptions search resolver

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     container: python:${{ matrix.python-version }}-slim
     services:
       postgres:
-        image: postgres:12-alpine
+        image: postgres:15-alpine
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: nwa

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/workfloworchestrator/orchestrator-core/branch/main/graph/badge.svg?token=5ANQFI2DHS)](https://codecov.io/gh/workfloworchestrator/orchestrator-core)
 [![pypi_version](https://img.shields.io/pypi/v/orchestrator-core?color=%2334D058&label=pypi%20package)](https://pypi.org/project/orchestrator-core)
 [![Supported python versions](https://img.shields.io/pypi/pyversions/orchestrator-core.svg?color=%2334D058)](https://pypi.org/project/orchestrator-core)
-<p align="center"><em>Production ready Orchestration Framework to manage product lifecyle and workflows. Easy to use, Built on top of FastAPI</em></p>
+<p style="text-align: center"><em>Production ready Orchestration Framework to manage product lifecycle and workflows. Easy to use, Built on top of FastAPI</em></p>
 
 
 ## Documentation
@@ -73,6 +73,8 @@ More info can be found in `docs/architecture/application/graphql.md`
 
 example:
 ```python
+from orchestrator import OrchestratorCore
+from orchestrator.settings import AppSettings
 app = OrchestratorCore(base_settings=AppSettings())
 # register SUBSCRIPTION_MODEL_REGISTRY
 app.register_graphql()

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -16,7 +16,7 @@ from typing import Callable
 import structlog
 from sqlalchemy import func
 
-from orchestrator.api.helpers import _process_text_query
+from orchestrator.api.helpers import _process_text_query, add_subscription_search_query_filter
 from orchestrator.db import ProductTable, SubscriptionTable
 from orchestrator.db.filters.filters import QueryType, generic_filter
 from orchestrator.db.filters.generic_filters import (
@@ -76,3 +76,5 @@ SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN: dict[str, Callable[[QueryType, str], Qu
 
 subscription_filter_fields = list(SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN.keys())
 filter_subscriptions = generic_filter(SUBSCRIPTION_FILTER_FUNCTIONS_BY_COLUMN)
+
+filter_by_query_string = add_subscription_search_query_filter

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Optional
 
 import structlog
 from pydantic.utils import to_lower_camel
@@ -19,7 +19,7 @@ from sqlalchemy import func, select
 
 from orchestrator.db import ProductTable, SubscriptionTable, db
 from orchestrator.db.filters import Filter
-from orchestrator.db.filters.subscription import filter_subscriptions, subscription_filter_fields
+from orchestrator.db.filters.subscription import filter_subscriptions, subscription_filter_fields, add_subscription_search_query_filter
 from orchestrator.db.range import apply_range_to_statement
 from orchestrator.db.sorting import Sort
 from orchestrator.db.sorting.subscription import sort_subscriptions, subscription_sort_fields
@@ -60,26 +60,31 @@ def get_subscription_details(subscription: SubscriptionTable) -> SubscriptionInt
 
 async def resolve_subscriptions(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: Optional[list[GraphqlFilter]] = None,
+    sort_by: Optional[list[GraphqlSort]] = None,
     first: int = 10,
     after: int = 0,
+    query: Optional[str] = None,
 ) -> Connection[SubscriptionInterface]:
     _error_handler = create_resolver_error_handler(info)
 
     pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []
     pydantic_sort_by: list[Sort] = [item.to_pydantic() for item in sort_by] if sort_by else []
-    logger.debug("resolve_subscription() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by)
+    logger.debug("resolve_subscription() called", range=[after, after + first], sort=sort_by, filter=pydantic_filter_by, query=query)
 
     stmt = select(SubscriptionTable).join(ProductTable)
 
     stmt = filter_subscriptions(stmt, pydantic_filter_by, _error_handler)
+    if query is not None:
+        logger.info("ADDING SEARCH QUERY FILTER")
+        stmt = add_subscription_search_query_filter(stmt, query)
+
     stmt = sort_subscriptions(stmt, pydantic_sort_by, _error_handler)
     total = db.session.scalar(select(func.count()).select_from(stmt.subquery()))
     stmt = apply_range_to_statement(stmt, after, after + first + 1)
 
     subscriptions = db.session.scalars(stmt).all()
-
+    logger.info("SUBSCRIPTIONS RESULT", result=subscriptions)
     if _is_subscription_detailed(info):
         graphql_subscriptions = [get_subscription_details(p) for p in subscriptions]
     else:

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -100,6 +100,13 @@ IPv6InterfaceType = strawberry.scalar(
     parse_value=lambda v: v,
 )
 
+IntType = strawberry.scalar(
+    NewType("Int", int),
+    description="An arbitrary precision integer",
+    serialize=lambda v: v,
+    parse_value=lambda v: v,
+)
+
 SCALAR_OVERRIDES: dict[object, Union[Any, ScalarWrapper, ScalarDefinition]] = {
     dict: JSON,
     VlanRanges: VlanRangesType,
@@ -107,4 +114,5 @@ SCALAR_OVERRIDES: dict[object, Union[Any, ScalarWrapper, ScalarDefinition]] = {
     IPv6Address: IPv6AddressType,
     IPv4Interface: IPv4InterfaceType,
     IPv6Interface: IPv6InterfaceType,
+    int: IntType
 }

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -114,5 +114,5 @@ SCALAR_OVERRIDES: dict[object, Union[Any, ScalarWrapper, ScalarDefinition]] = {
     IPv6Address: IPv6AddressType,
     IPv4Interface: IPv4InterfaceType,
     IPv6Interface: IPv6InterfaceType,
-    int: IntType
+    int: IntType,
 }

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -94,16 +94,17 @@ class Parser:
 
     The following grammar is used. Nodenames starting with a _ will not appear in the final parse tree.
     <Query> ::= <AndExpression> ('|' <AndExpression>)*
-    <AndExpression> ::= <Term>*
-    <_Term> ::= [<Negation>] <PositiveTerm>
+    <AndExpression> ::= <_Term>*
+    <_Term> ::= [<Negation>] <_PositiveTerm>
     <Negation> ::= '-'
     <_PositiveTerm> ::= <Group> | <_Value> | <KVTerm>
     <Group> ::= '(' <Query> ')'
     <Phrase> ::= '"' (<Word> | <PrefixWord>)* '"'
     <KVTerm> ::= <Value> ':' (<_Value> | <ValueGroup>)
+    <_SearchWord> ::= <Word> | <PrefixWord>
     <PrefixWord> ::= <Word> '*'
     <Word> ::= <text without "*()!:<> or whitespace>
-    <_Value> ::= <Phrase> | <SearchWord>
+    <_Value> ::= <Phrase> | <_SearchWord>
     <ValueGroup> ::= '(' <Value> ('|' <Value>)* ')'
     """
 

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -644,6 +644,10 @@ def cache_fixture(monkeypatch):
                 print("failed to delete cache key", key, str(exc))  # noqa: T001, T201
 
 
+def do_refresh_subscriptions_search_view():
+    db.session.execute(text("REFRESH MATERIALIZED VIEW subscriptions_search"))
+
+
 @pytest.fixture
 def refresh_subscriptions_search_view():
-    db.session.execute(text("REFRESH MATERIALIZED VIEW subscriptions_search"))
+    do_refresh_subscriptions_search_view()

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -45,14 +45,6 @@ subscription_product_fields = [
     "endDate",
 ]
 
-SUBSCRIPTION_QUERY_VARIABLES = """
-    $first: Int!,
-    $after: Int!,
-    $sortBy: [GraphqlSort!],
-    $filterBy: [GraphqlFilter!],
-    $query: String
-    """
-
 
 def build_subscriptions_query(body: str) -> str:
     return f"""
@@ -872,10 +864,8 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
     _, GenericProductOne = generic_product_type_1
     subscription_ids = product_type_1_subscriptions_factory(30)
     do_refresh_subscriptions_search_view()
-
     subscription_id = subscription_ids[10]
-    qarg = query_args(subscription_id)
-    data = get_subscriptions_query(**qarg)
+    data = get_subscriptions_query(**query_args(subscription_id))
     response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     subscription = GenericProductOne.from_subscription(subscription_id)

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -14,7 +14,7 @@ import datetime
 import json
 import sys
 from http import HTTPStatus
-from typing import Optional, Union
+from typing import Optional
 
 import pytest
 
@@ -256,8 +256,8 @@ def get_subscriptions_product_block_json_schema_query(
 def get_subscriptions_product_generic_one(
     first: int = 10,
     after: int = 0,
-    filter_by: Union[list[str], None] = None,
-    sort_by: Union[list[dict[str, str]], None] = None,
+    filter_by: Optional[list[str]] = None,
+    sort_by: Optional[list[dict[str, str]]] = None,
     query_string: Optional[str] = None,
 ) -> bytes:
     query = build_subscriptions_query(

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -14,14 +14,14 @@ import datetime
 import json
 import sys
 from http import HTTPStatus
-from typing import Union, Optional
+from typing import Optional, Union
 
 import pytest
 
 from orchestrator.db import SubscriptionMetadataTable, db
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import SubscriptionLifecycle
-from test.unit_tests.conftest import refresh_subscriptions_search_view, do_refresh_subscriptions_search_view
+from test.unit_tests.conftest import do_refresh_subscriptions_search_view
 
 subscription_fields = [
     "endDate",
@@ -55,7 +55,7 @@ SUBSCRIPTION_QUERY_VARIABLES = """
 
 
 def build_subscriptions_query(body: str) -> str:
-    gql_query = f"""
+    return f"""
 query SubscriptionQuery(
     $first: Int!,
     $after: Int!,
@@ -67,17 +67,17 @@ query SubscriptionQuery(
     {body}
 }}
 """
-    return gql_query
 
 
 def get_subscriptions_query(
-        first: int = 10,
-        after: int = 0,
-        filter_by: Optional[list[dict]] = None,
-        sort_by: Optional[list] = None,
-        query_string: Optional[str] = None,
+    first: int = 10,
+    after: int = 0,
+    filter_by: Optional[list[dict]] = None,
+    sort_by: Optional[list] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    gql_query = build_subscriptions_query("""{
+    gql_query = build_subscriptions_query(
+        """{
     page {
       description
       subscriptionId
@@ -114,7 +114,7 @@ def get_subscriptions_query(
     }
   }
 """
-                                          )
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -124,20 +124,21 @@ def get_subscriptions_query(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
 
 
 def get_subscriptions_query_with_relations(
-        first: int = 10,
-        after: int = 0,
-        filter_by: Optional[list[dict[str, str]]] = None,
-        sort_by: Optional[list[dict[str, str]]] = None,
-        query_string: Optional[str] = None,
+    first: int = 10,
+    after: int = 0,
+    filter_by: Optional[list[dict[str, str]]] = None,
+    sort_by: Optional[list[dict[str, str]]] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    query = build_subscriptions_query("""{
+    query = build_subscriptions_query(
+        """{
     page {
       description
       subscriptionId
@@ -206,7 +207,8 @@ def get_subscriptions_query_with_relations(
       hasNextPage
     }
   }
-    """)
+    """
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -216,20 +218,21 @@ def get_subscriptions_query_with_relations(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
 
 
 def get_subscriptions_product_block_json_schema_query(
-        first: int = 10,
-        after: int = 0,
-        filter_by: Optional[list[dict[str, str]]] = None,
-        sort_by: Optional[list[dict[str, str]]] = None,
-        query_string: Optional[str] = None,
+    first: int = 10,
+    after: int = 0,
+    filter_by: Optional[list[dict[str, str]]] = None,
+    sort_by: Optional[list[dict[str, str]]] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    query = build_subscriptions_query("""{
+    query = build_subscriptions_query(
+        """{
     page {
       _schema
     }
@@ -241,7 +244,8 @@ def get_subscriptions_product_block_json_schema_query(
       hasNextPage
     }
   }
-    """)
+    """
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -251,20 +255,21 @@ def get_subscriptions_product_block_json_schema_query(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
 
 
 def get_subscriptions_product_generic_one(
-        first: int = 10,
-        after: int = 0,
-        filter_by: Union[list[str], None] = None,
-        sort_by: Union[list[dict[str, str]], None] = None,
-        query_string: Optional[str] = None,
+    first: int = 10,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    query = build_subscriptions_query("""{
+    query = build_subscriptions_query(
+        """{
     page {
       ... on GenericProductOneSubscription {
         description
@@ -291,7 +296,8 @@ def get_subscriptions_product_generic_one(
       hasNextPage
     }
   }
-    """)
+    """
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -301,20 +307,21 @@ def get_subscriptions_product_generic_one(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
 
 
 def get_subscriptions_product_sub_list_union(
-        first: int = 10,
-        after: int = 0,
-        filter_by: Optional[list[dict[str, str]]] = None,
-        sort_by: Optional[list[str]] = None,
-        query_string: Optional[str] = None,
+    first: int = 10,
+    after: int = 0,
+    filter_by: Optional[list[dict[str, str]]] = None,
+    sort_by: Optional[list[str]] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    query = build_subscriptions_query("""{
+    query = build_subscriptions_query(
+        """{
     page {
       ... on ProductSubListUnionSubscription {
         description
@@ -351,7 +358,8 @@ def get_subscriptions_product_sub_list_union(
       hasNextPage
     }
   }
-    """)
+    """
+    )
 
     return json.dumps(
         {
@@ -362,27 +370,29 @@ def get_subscriptions_product_sub_list_union(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
 
 
 def get_subscriptions_with_metadata_and_schema_query(
-        first: int = 1,
-        after: int = 0,
-        filter_by: Optional[list[dict[str, str]]] = None,
-        sort_by: Optional[list[dict[str, str]]] = None,
-        query_string: Optional[str] = None,
+    first: int = 1,
+    after: int = 0,
+    filter_by: Optional[list[dict[str, str]]] = None,
+    sort_by: Optional[list[dict[str, str]]] = None,
+    query_string: Optional[str] = None,
 ) -> bytes:
-    gql_query = build_subscriptions_query("""{
+    gql_query = build_subscriptions_query(
+        """{
     page {
       subscriptionId
       metadata
       _metadataSchema
     }
   }
-    """)
+    """
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -392,7 +402,7 @@ def get_subscriptions_with_metadata_and_schema_query(
                 "after": after,
                 "sortBy": sort_by if sort_by else [],
                 "filterBy": filter_by if filter_by else [],
-                "query": query_string
+                "query": query_string,
             },
         }
     ).encode("utf-8")
@@ -672,7 +682,16 @@ def test_subscriptions_sorting_invalid_order(test_client, product_type_1_subscri
     assert "Value 'test' does not exist in 'SortOrder'" in result["errors"][0]["message"]
 
 
-def test_subscriptions_filtering_on_status(test_client, product_type_1_subscriptions_factory, generic_product_type_1):
+@pytest.mark.parametrize(
+    "query_args",
+    [
+        {"filter_by": [{"field": "status", "value": SubscriptionLifecycle.TERMINATED}]},
+        {"query_string": "status:terminated"},
+    ],
+)
+def test_subscriptions_filtering_on_status(
+    test_client, product_type_1_subscriptions_factory, generic_product_type_1, query_args
+):
     # when
 
     subscription_ids = product_type_1_subscriptions_factory(30)
@@ -686,19 +705,17 @@ def test_subscriptions_filtering_on_status(test_client, product_type_1_subscript
     subscription_9.save()
     do_refresh_subscriptions_search_view()
 
-    query1 = get_subscriptions_query(filter_by=[{"field": "status", "value": SubscriptionLifecycle.TERMINATED}])
-    query2 = get_subscriptions_query(query_string="status:terminated")
+    subscription_query = get_subscriptions_query(**query_args)
 
-    response = test_client.post("/api/graphql", content=query1, headers={"Content-Type": "application/json"})
-    response2 = test_client.post("/api/graphql", content=query2, headers={"Content-Type": "application/json"})
+    response = test_client.post(
+        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    )
 
     # then
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    result2 = response2.json()
     subscriptions_data = result["data"]["subscriptions"]
-    subscriptions_data2 = result2["data"]["subscriptions"]
 
     subscriptions = subscriptions_data["page"]
     pageinfo = subscriptions_data["pageInfo"]
@@ -717,9 +734,6 @@ def test_subscriptions_filtering_on_status(test_client, product_type_1_subscript
     assert result_subscription_ids == {str(subscription_1.subscription_id), str(subscription_9.subscription_id)}
     assert subscriptions[0]["status"] == "TERMINATED"
     assert subscriptions[1]["status"] == "TERMINATED"
-
-    assert pageinfo == subscriptions_data2["pageInfo"]
-    assert result_subscription_ids == {s["subscriptionId"] for s in subscriptions_data2["page"]}
 
 
 def test_subscriptions_range_filtering_on_start_date(test_client, product_type_1_subscriptions_factory):
@@ -765,7 +779,7 @@ def test_subscriptions_range_filtering_on_start_date(test_client, product_type_1
 
 
 def test_subscriptions_filtering_with_invalid_filter(
-        test_client, product_type_1_subscriptions_factory, generic_product_type_1
+    test_client, product_type_1_subscriptions_factory, generic_product_type_1
 ):
     # when
 
@@ -842,13 +856,26 @@ def test_subscriptions_filtering_with_invalid_filter(
         assert subscription["status"] == "TERMINATED"
 
 
-def test_single_subscription(test_client, product_type_1_subscriptions_factory, generic_product_type_1):
+@pytest.mark.parametrize(
+    "query_args",
+    [
+        lambda sid: {"filter_by": [{"field": "subscriptionId", "value": sid}]},
+        lambda sid: {"query_string": f"subscription_id:{sid}"},
+        lambda sid: {"query_string": f"subscriptionId:{sid}"},
+        lambda sid: {"query_string": f"{sid}"},
+        lambda sid: {"query_string": f"{sid.split('-')[0]}"},
+    ],
+)
+def test_single_subscription(test_client, product_type_1_subscriptions_factory, generic_product_type_1, query_args):
     # when
 
     _, GenericProductOne = generic_product_type_1
     subscription_ids = product_type_1_subscriptions_factory(30)
+    do_refresh_subscriptions_search_view()
+
     subscription_id = subscription_ids[10]
-    data = get_subscriptions_query(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    qarg = query_args(subscription_id)
+    data = get_subscriptions_query(**qarg)
     response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     subscription = GenericProductOne.from_subscription(subscription_id)
@@ -900,20 +927,30 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
     ]
 
 
+@pytest.mark.parametrize(
+    "query_args",
+    [
+        lambda sid: {"filter_by": [{"field": "subscriptionId", "value": sid}]},
+        lambda sid: {"query_string": sid},
+    ],
+)
 def test_single_subscription_with_processes(
-        fastapi_app_graphql,
-        test_client,
-        product_type_1_subscriptions_factory,
-        mocked_processes,
-        mocked_processes_resumeall,  # noqa: F811
-        generic_subscription_2,  # noqa: F811
-        generic_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_type_1_subscriptions_factory,
+    mocked_processes,
+    mocked_processes_resumeall,  # noqa: F811
+    generic_subscription_2,  # noqa: F811
+    generic_subscription_1,
+    query_args,
 ):
     # when
 
     product_type_1_subscriptions_factory(30)
     subscription_id = generic_subscription_1
-    data = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    do_refresh_subscriptions_search_view()
+
+    data = get_subscriptions_query_with_relations(**query_args(subscription_id))
     response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
@@ -938,18 +975,20 @@ def test_single_subscription_with_processes(
 
 
 def test_single_subscription_with_depends_on_subscriptions(
-        fastapi_app_graphql,
-        test_client,
-        product_type_1_subscriptions_factory,
-        sub_one_subscription_1,
-        sub_two_subscription_1,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_type_1_subscriptions_factory,
+    sub_one_subscription_1,
+    sub_two_subscription_1,
+    product_sub_list_union_subscription_1,
 ):
     # when
 
     product_type_1_subscriptions_factory(30)
+    do_refresh_subscriptions_search_view()
+
     subscription_id = str(product_sub_list_union_subscription_1)
-    data = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
+    data = get_subscriptions_query_with_relations(query_string=subscription_id)
     response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     expected_depends_on_ids = {
@@ -981,22 +1020,24 @@ def test_single_subscription_with_depends_on_subscriptions(
 
 
 def test_single_subscription_with_in_use_by_subscriptions(
-        fastapi_app_graphql,
-        test_client,
-        product_type_1_subscriptions_factory,
-        sub_one_subscription_1,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_type_1_subscriptions_factory,
+    sub_one_subscription_1,
+    product_sub_list_union_subscription_1,
 ):
     # when
 
     product_type_1_subscriptions_factory(30)
     do_refresh_subscriptions_search_view()
     subscription_id = str(sub_one_subscription_1.subscription_id)
-    query1 = get_subscriptions_query_with_relations(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
-    query2 = get_subscriptions_query_with_relations(query_string=subscription_id.split("-")[0])
+    subscription_query = get_subscriptions_query_with_relations(
+        filter_by=[{"field": "subscriptionId", "value": subscription_id}]
+    )
 
-    response = test_client.post("/api/graphql", content=query1, headers={"Content-Type": "application/json"})
-    response2 = test_client.post("/api/graphql", content=query2, headers={"Content-Type": "application/json"})
+    response = test_client.post(
+        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    )
 
     expected_in_use_by_ids = [str(product_sub_list_union_subscription_1)]
 
@@ -1004,7 +1045,6 @@ def test_single_subscription_with_in_use_by_subscriptions(
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    result2 = response2.json()
     subscriptions_data = result["data"]["subscriptions"]
     subscriptions = subscriptions_data["page"]
     pageinfo = subscriptions_data["pageInfo"]
@@ -1039,18 +1079,15 @@ def test_single_subscription_with_in_use_by_subscriptions(
         }
     ]
 
-    assert pageinfo == result2["data"]["subscriptions"]["pageInfo"]
-    assert subscriptions == result2["data"]["subscriptions"]["page"]
-
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="types get different origin with 3.10 and higher")
 def test_single_subscription_schema(
-        fastapi_app_graphql,
-        test_client,
-        product_type_1_subscriptions_factory,
-        sub_one_subscription_1,
-        sub_two_subscription_1,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_type_1_subscriptions_factory,
+    sub_one_subscription_1,
+    sub_two_subscription_1,
+    product_sub_list_union_subscription_1,
 ):
     # when
 
@@ -1183,9 +1220,9 @@ def test_single_subscription_schema(
 
 
 def test_single_subscription_metadata_and_schema(
-        fastapi_app_graphql,
-        test_client,
-        sub_one_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    sub_one_subscription_1,
 ):
     # when
     expected_metadata = {"some_metadata_prop": ["test value 1", "test 2"]}
@@ -1224,9 +1261,9 @@ def expect_fail_test_if_too_many_duplicate_types_in_interface(result):
 
 
 def test_subscriptions_product_generic_one(
-        fastapi_app_graphql,
-        test_client,
-        product_type_1_subscriptions_factory,
+    fastapi_app_graphql,
+    test_client,
+    product_type_1_subscriptions_factory,
 ):
     # when
 
@@ -1259,9 +1296,9 @@ def test_subscriptions_product_generic_one(
 
 
 def test_single_subscription_product_list_union_type(
-        fastapi_app_graphql,
-        test_client,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_sub_list_union_subscription_1,
 ):
     # when
 
@@ -1297,9 +1334,9 @@ def test_single_subscription_product_list_union_type(
 
 
 def test_single_subscription_product_list_union_type_provisioning_subscription(
-        fastapi_app_graphql,
-        test_client,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_sub_list_union_subscription_1,
 ):
     # when
 
@@ -1339,9 +1376,9 @@ def test_single_subscription_product_list_union_type_provisioning_subscription(
 
 
 def test_single_subscription_product_list_union_type_terminated_subscription(
-        fastapi_app_graphql,
-        test_client,
-        product_sub_list_union_subscription_1,
+    fastapi_app_graphql,
+    test_client,
+    product_sub_list_union_subscription_1,
 ):
     # when
 


### PR DESCRIPTION
Resolves #413 

- Adds a `query` parameter to the Subscriptions graphql query. Works in conjunction with the existing `filter_by` parameter to remain backwards compatible.