### PR TITLE
Fix Phrase in ValueGroup error

### DIFF
--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -15,7 +15,7 @@ class Token(Enum):
     ASTERISK = "*"
     LPAREN = "("
     RPAREN = ")"
-    SEMICOLON = ":"
+    COLON = ":"
     QUOTE = '"'
     END = "$"
 
@@ -29,7 +29,7 @@ SPECIAL_CHARS = {
     "*": Token.ASTERISK,
     "(": Token.LPAREN,
     ")": Token.RPAREN,
-    ":": Token.SEMICOLON,
+    ":": Token.COLON,
     '"': Token.QUOTE,
 }
 
@@ -42,7 +42,7 @@ Lexeme = Union[tuple[Token], tuple[Token, Any]]
 
 
 class Lexer:
-    word_boundary_regex = r'[()|!:<>*\s"]'
+    word_boundary_regex = re.compile(r'[()|!:<>*\s"]')
 
     def __init__(self, source: str):
         self.source = source
@@ -202,7 +202,7 @@ class Parser:
         if not value:
             return None
         next_token = self.peek()
-        if next_token and next_token[0] == Token.SEMICOLON:
+        if next_token and next_token[0] == Token.COLON:
             # It's a KVTerm, e.g. status:active
             self.next_token()
             next_token = self.peek()
@@ -269,7 +269,7 @@ class TSQueryVisitor:
         if value_node[0] == "ValueGroup":
             acc.append("(")
             for v in value_node[1]:
-                TSQueryVisitor.visit_search_word(v, acc)
+                TSQueryVisitor.visit_term(v, acc)
                 acc.append(" | ")
             acc.pop()
             acc.append(")")

--- a/test/unit_tests/utils/test_search_query.py
+++ b/test/unit_tests/utils/test_search_query.py
@@ -67,7 +67,7 @@ def test_parse_edge_cases():
 def test_parse_complex_query():
     q = "".join(
         [
-            '"phrase1 phrase2 phrase3" word1 word2 prefixword* field1:(val1 | val2* | val3)',
+            '"phrase1 phrase2 phrase3" word1 word2 prefixword* field1:(val1 | val2* | "val3 val4*")',
             " | ",
             '"phrase21 phrase22" ((klm tag:lp) | (sinica tag:fw)) -("not this" "or this") something else',
         ]
@@ -81,7 +81,7 @@ def test_parse_complex_query():
     assert len(second_subexpression[1]) == 5, "subexpression 2 has 5 terms"
     assert tsquery == "".join(
         [
-            "phrase1 <-> phrase2 <-> phrase3 & word1 & word2 & prefixword:* & field1 <-> (val1 | val2:* | val3)",
+            "phrase1 <-> phrase2 <-> phrase3 & word1 & word2 & prefixword:* & field1 <-> (val1 | val2:* | val3 <-> val4:*)",
             " | ",
             "phrase21 <-> phrase22 & ((klm & tag <-> lp) | (sinica & tag <-> fw))",
             " & !(not <-> this & or <-> this) & something & else",


### PR DESCRIPTION
Renamed the incorrectly named SEMICOLON token to COLON. Regular expression used for word boundary has also been compiled at its initialization to enhance regex operation's performance. Matching test cases have been updated accordingly.