### PR TITLE
Handle words with underscores as consecutive words

### DIFF
--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -291,7 +291,8 @@ class TSQueryVisitor:
     def visit_search_word(node: Node, acc: list[str]) -> None:
         # Postgres is finicky with single quotes in the query. In some situations it throws an error.
         # To avoid the special handling of ' by PG, we replace it with double quotes.
-        text = node[1].replace("'", '"')
+        # We also replace underscores with the 'followed by' operator
+        text = node[1].replace("'", '"').replace("_", " <-> ")
         if node[0] == "Word":
             acc.append(text)
         elif node[0] == "PrefixWord":

--- a/test/unit_tests/utils/test_search_query.py
+++ b/test/unit_tests/utils/test_search_query.py
@@ -87,3 +87,9 @@ def test_parse_complex_query():
             " & !(not <-> this & or <-> this) & something & else",
         ]
     )
+
+
+def test_query_with_underscores():
+    q = 'word_with_underscores prefix_word* key_value:term_1 key_value2:(val_1 | "val_2" | val_3*)'
+    parse_tree, tsquery = _parse_tree_and_tsquery(q)
+    assert tsquery == 'word <-> with <-> underscores & prefix <-> word:* & key <-> value <-> term <-> 1 & key <-> value2 <-> (val <-> 1 | val <-> 2 | val <-> 3:*)'

--- a/test/unit_tests/utils/test_search_query.py
+++ b/test/unit_tests/utils/test_search_query.py
@@ -92,4 +92,7 @@ def test_parse_complex_query():
 def test_query_with_underscores():
     q = 'word_with_underscores prefix_word* key_value:term_1 key_value2:(val_1 | "val_2" | val_3*)'
     parse_tree, tsquery = _parse_tree_and_tsquery(q)
-    assert tsquery == 'word <-> with <-> underscores & prefix <-> word:* & key <-> value <-> term <-> 1 & key <-> value2 <-> (val <-> 1 | val <-> 2 | val <-> 3:*)'
+    assert (
+        tsquery
+        == "word <-> with <-> underscores & prefix <-> word:* & key <-> value <-> term <-> 1 & key <-> value2 <-> (val <-> 1 | val <-> 2 | val <-> 3:*)"
+    )


### PR DESCRIPTION
Fixes issue with searching for terms with underscores.

Postgres will split words with underscores into separate words during `ts_tsvector` and treat it differently in `to tsquery`.

Postgres will to process the query `word_with_underscores <-> value` as `( 'word' & 'with' & 'underscores' ) <-> 'value'` instead of `word <-> with <-> underscores <-> value`. This PR provides a fix for this behavior.