### PR TITLE
Small change to error log message in subscription endpoint (fixes #437)

### DIFF
--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -330,7 +330,7 @@ def subscription_set_in_sync(subscription_id: UUID, current_user: Optional[OIDCU
             else:
                 raise_status(
                     HTTPStatus.UNPROCESSABLE_ENTITY,
-                    f"Subscription {subscription_id} has still failed processes with id's: {failed_processes}",
+                    f"Subscription {subscription_id} has still failed processes with id's: {failed_processes_list}",
                 )
         else:
             logger.info("Subscription already in sync")


### PR DESCRIPTION
See linked issue for more description.

Just a small change to reference the correct variable in an error returned by the API in /subscription endpoint