### PR TITLE
Improve ability to override existing graphql models.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1rc1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -50,39 +50,7 @@ jobs:
         env:
           FLIT_ROOT_INSTALL: 1
       - name: Run Unit tests
-        run: CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest --cov-branch --cov=orchestrator --cov-report=xml --ignore=test --ignore=orchestrator/devtools --ignore=examples --ignore=docs --ignore=test/unit_tests/graphql
-        env:
-          POSTGRES_DB: orchestrator-core-test
-          POSTGRES_USER: nwa
-          POSTGRES_PASSWORD: nwa
-          POSTGRES_HOST: postgres
-          ENVIRONMENT: TESTING
-      - name: Run Graphql Unit tests
-        run: AIOCACHE_DISABLE=1 CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest ./test/unit_tests/graphql
-        env:
-          POSTGRES_DB: orchestrator-core-test
-          POSTGRES_USER: nwa
-          POSTGRES_PASSWORD: nwa
-          POSTGRES_HOST: postgres
-          ENVIRONMENT: TESTING
-      - name: Run test_subscriptions_product_generic_one Unit test
-        run: CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest ./test/unit_tests/ -k test_subscriptions_product_generic_one
-        env:
-          POSTGRES_DB: orchestrator-core-test
-          POSTGRES_USER: nwa
-          POSTGRES_PASSWORD: nwa
-          POSTGRES_HOST: postgres
-          ENVIRONMENT: TESTING
-      - name: Run test_single_subscription_product_list_union_type_provisioning_subscription Unit test
-        run: CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest ./test/unit_tests/ -k test_single_subscription_product_list_union_type_provisioning_subscription
-        env:
-          POSTGRES_DB: orchestrator-core-test
-          POSTGRES_USER: nwa
-          POSTGRES_PASSWORD: nwa
-          POSTGRES_HOST: postgres
-          ENVIRONMENT: TESTING
-      - name: Run test_single_subscription_product_list_union_type_terminated_subscription Unit test
-        run: CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest ./test/unit_tests/ -k test_single_subscription_product_list_union_type_terminated_subscription
+        run: CACHE_URI=redis://redis DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST/$POSTGRES_DB  pytest --cov-branch --cov=orchestrator --cov-report=xml --ignore=test --ignore=orchestrator/devtools --ignore=examples --ignore=docs
         env:
           POSTGRES_DB: orchestrator-core-test
           POSTGRES_USER: nwa

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1rc1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -17,7 +17,6 @@ from orchestrator.graphql.autoregistration import (
     register_domain_models,
 )
 from orchestrator.graphql.schema import (
-    GRAPHQL_MODELS,
     Mutation,
     OrchestratorGraphqlRouter,
     OrchestratorSchema,
@@ -25,8 +24,8 @@ from orchestrator.graphql.schema import (
     create_graphql_router,
     custom_context_dependency,
     get_context,
-    graphql_router,
 )
+from orchestrator.graphql.schemas import GRAPHQL_MODELS
 from orchestrator.graphql.types import SCALAR_OVERRIDES
 
 __all__ = [
@@ -38,7 +37,6 @@ __all__ = [
     "OrchestratorSchema",
     "custom_context_dependency",
     "get_context",
-    "graphql_router",
     "create_graphql_router",
     "EnumDict",
     "add_class_to_strawberry",

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -80,7 +80,7 @@ def create_block_strawberry_type(
     return strawberry_wrapper(new_type)
 
 
-def create_subscription_strawberry_type(strawberry_name: str, model: Type[DomainModel], interface: Any) -> Any:
+def create_subscription_strawberry_type(strawberry_name: str, model: Type[DomainModel], interface: Type) -> Type:
     base_type = type(strawberry_name, (interface,), {})
     directives = [Key(fields="subscriptionId", resolvable=UNSET)]
 
@@ -95,7 +95,7 @@ def add_class_to_strawberry(
     model: Type[DomainModel],
     strawberry_models: StrawberryModelType,
     strawberry_enums: EnumDict,
-    interface: Any = None,
+    interface: Union[Type, None] = None,
 ) -> None:
     if model_name in strawberry_models:
         logger.debug("Skip already registered strawberry model", model=repr(model), strawberry_name=model_name)
@@ -118,7 +118,7 @@ def add_class_to_strawberry(
 
 
 def register_domain_models(
-    interface: Any, existing_models: Union[StrawberryModelType, None] = None
+    interface: Union[Type, None], existing_models: Union[StrawberryModelType, None] = None
 ) -> StrawberryModelType:
     strawberry_models = existing_models if existing_models else {}
     strawberry_enums: EnumDict = {}

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -45,11 +45,11 @@ def is_enum(field: Any) -> bool:
 
 def create_strawberry_enums(model: Type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:
     enums = {
-        key: field
+        key: create_strawberry_enum(field)
         for key, field in model._non_product_block_fields_.items()
         if is_enum(field) and is_not_strawberry_enum(key, strawberry_enums)
     }
-    return strawberry_enums | {key: create_strawberry_enum(field) for key, field in enums.items()}
+    return strawberry_enums | enums
 
 
 def graphql_name(name: str) -> str:

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -23,7 +23,7 @@ from strawberry.unset import UNSET
 
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import DomainModel, get_depends_on_product_block_type_list
-from orchestrator.graphql.schemas import GRAPHQL_MODELS, StrawberryModelType
+from orchestrator.graphql.schemas import StrawberryModelType
 from orchestrator.utils.helpers import to_camel
 
 logger = structlog.get_logger(__name__)
@@ -116,8 +116,10 @@ def add_class_to_strawberry(
     logger.debug("Registered strawberry model", model=repr(model), strawberry_name=model_name)
 
 
-def register_domain_models(interface: Any, existing_models: Union[dict[str, Any], None] = None) -> dict[str, Any]:
-    strawberry_models = existing_models if existing_models else GRAPHQL_MODELS
+def register_domain_models(
+    interface: Any, existing_models: Union[StrawberryModelType, None] = None
+) -> StrawberryModelType:
+    strawberry_models = existing_models if existing_models else {}
     strawberry_enums: EnumDict = {}
     products = {
         product_type.__base_type__.__name__: product_type.__base_type__

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -13,7 +13,7 @@
 
 import inspect
 from enum import Enum, EnumMeta
-from typing import Any, Type
+from typing import Any, Type, Union
 
 import strawberry
 import structlog
@@ -23,8 +23,7 @@ from strawberry.unset import UNSET
 
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import DomainModel, get_depends_on_product_block_type_list
-from orchestrator.graphql.schema import GRAPHQL_MODELS, StrawberryModelType
-from orchestrator.graphql.schemas.subscription import SubscriptionInterface
+from orchestrator.graphql.schemas import GRAPHQL_MODELS, StrawberryModelType
 from orchestrator.utils.helpers import to_camel
 
 logger = structlog.get_logger(__name__)
@@ -44,6 +43,15 @@ def is_enum(field: Any) -> bool:
     return inspect.isclass(field) and issubclass(field, Enum)
 
 
+def create_strawberry_enums(model: Type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:
+    enums = {
+        key: field
+        for key, field in model._non_product_block_fields_.items()
+        if is_enum(field) and is_not_strawberry_enum(key, strawberry_enums)
+    }
+    return strawberry_enums | {key: create_strawberry_enum(field) for key, field in enums.items()}
+
+
 def graphql_name(name: str) -> str:
     return to_camel(name.replace(" ", "_"))
 
@@ -53,18 +61,9 @@ def graphql_subscription_name(name: str) -> str:
     return f"{subscription_graphql_name}Subscription"
 
 
-def create_subscription_strawberry_type(strawberry_name: str, model: Type[DomainModel]) -> Type[SubscriptionInterface]:
-    base_type = type(strawberry_name, (SubscriptionInterface,), {})
-    directives = [Key(fields="subscriptionId", resolvable=UNSET)]
-
-    pydantic_wrapper = strawberry.experimental.pydantic.type(
-        model, all_fields=True, directives=directives, description=f"{strawberry_name} Type"
-    )
-    return type(strawberry_name, (pydantic_wrapper(base_type),), {})
-
-
 def create_block_strawberry_type(
-    strawberry_name: str, model: Type[DomainModel]
+    strawberry_name: str,
+    model: Type[DomainModel],
 ) -> Type[StrawberryTypeFromPydantic[DomainModel]]:
     from strawberry.federation.schema_directives import Key
     from strawberry.unset import UNSET
@@ -81,22 +80,22 @@ def create_block_strawberry_type(
     return strawberry_wrapper(new_type)
 
 
-def create_strawberry_enums(model: Type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:
-    enums = {
-        key: field
-        for key, field in model._non_product_block_fields_.items()
-        if is_enum(field) and is_not_strawberry_enum(key, strawberry_enums)
-    }
-    return strawberry_enums | {key: create_strawberry_enum(field) for key, field in enums.items()}
-
-
 def add_class_to_strawberry(
     model_name: str,
     model: Type[DomainModel],
     strawberry_models: StrawberryModelType,
     strawberry_enums: EnumDict,
-    with_interface: bool = False,
+    interface: Any = None,
 ) -> None:
+    def create_subscription_strawberry_type(strawberry_name: str, model: Type[DomainModel]) -> Type[interface]:
+        base_type = type(strawberry_name, (interface,), {})
+        directives = [Key(fields="subscriptionId", resolvable=UNSET)]
+
+        pydantic_wrapper = strawberry.experimental.pydantic.type(
+            model, all_fields=True, directives=directives, description=f"{strawberry_name} Type"
+        )
+        return type(strawberry_name, (pydantic_wrapper(base_type),), {})
+
     if model_name in strawberry_models:
         logger.debug("Skip already registered strawberry model", model=repr(model), strawberry_name=model_name)
         return
@@ -111,14 +110,14 @@ def add_class_to_strawberry(
             add_class_to_strawberry(graphql_field_name, field, strawberry_models, strawberry_enums)
 
     strawberry_type_convert_function = (
-        create_subscription_strawberry_type if with_interface else create_block_strawberry_type
+        create_subscription_strawberry_type if interface else create_block_strawberry_type
     )
     strawberry_models[model_name] = strawberry_type_convert_function(model_name, model)
     logger.debug("Registered strawberry model", model=repr(model), strawberry_name=model_name)
 
 
-def register_domain_models() -> None:
-    strawberry_models = GRAPHQL_MODELS
+def register_domain_models(interface: Any, existing_models: Union[dict[str, Any], None] = None) -> dict[str, Any]:
+    strawberry_models = existing_models if existing_models else GRAPHQL_MODELS
     strawberry_enums: EnumDict = {}
     products = {
         product_type.__base_type__.__name__: product_type.__base_type__
@@ -127,9 +126,10 @@ def register_domain_models() -> None:
     }
     for key, product_type in products.items():
         add_class_to_strawberry(
+            interface=interface,
             model_name=graphql_subscription_name(key),
             model=product_type,
             strawberry_models=strawberry_models,
             strawberry_enums=strawberry_enums,
-            with_interface=True,
         )
+    return strawberry_models

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -65,7 +65,7 @@ def get_subscription_details(subscription: SubscriptionTable) -> SubscriptionInt
     return strawberry_type.from_pydantic(subscription_details)
 
 
-def format_default_subscriptions(subscription: SubscriptionTable) -> SubscriptionInterface:
+def format_base_subscription(subscription: SubscriptionTable) -> SubscriptionInterface:
     from orchestrator.graphql import GRAPHQL_MODELS
 
     strawberry_type = GRAPHQL_MODELS["subscription"]
@@ -108,7 +108,7 @@ async def resolve_subscriptions(
         if _is_subscription_detailed(info):
             graphql_subscriptions = [get_subscription_details(p) for p in subscriptions]
         else:
-            graphql_subscriptions = [format_default_subscriptions(p) for p in subscriptions]
+            graphql_subscriptions = [format_base_subscription(p) for p in subscriptions]
     return to_graphql_result_page(
         graphql_subscriptions, first, after, total, subscription_sort_fields, subscription_filter_fields
     )

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -30,7 +30,7 @@ from orchestrator.db.sorting.subscription import sort_subscriptions, subscriptio
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.graphql.pagination import Connection
 from orchestrator.graphql.schemas.product import ProductModelGraphql
-from orchestrator.graphql.schemas.subscription import Subscription, SubscriptionInterface
+from orchestrator.graphql.schemas.subscription import SubscriptionInterface
 from orchestrator.graphql.types import GraphqlFilter, GraphqlSort, OrchestratorInfo
 from orchestrator.graphql.utils import (
     create_resolver_error_handler,
@@ -49,12 +49,12 @@ base_sub_props = tuple(
     + ["__typename"]
 )
 
-_is_subscription_detailed = is_query_detailed(base_sub_props)
+_is_subscription_detailed = is_query_detailed(base_sub_props, ("SubscriptionInterface",))
 
 
 def get_subscription_details(subscription: SubscriptionTable) -> SubscriptionInterface:
+    from orchestrator.graphql import GRAPHQL_MODELS
     from orchestrator.graphql.autoregistration import graphql_subscription_name
-    from orchestrator.graphql.schema import GRAPHQL_MODELS
 
     subscription_details = SubscriptionModel.from_subscription(subscription.subscription_id)
     base_model = subscription_details.__base_type__ if subscription_details.__base_type__ else subscription_details
@@ -63,6 +63,13 @@ def get_subscription_details(subscription: SubscriptionTable) -> SubscriptionInt
     )
     strawberry_type = GRAPHQL_MODELS[graphql_subscription_name(base_model.__name__)]  # type: ignore
     return strawberry_type.from_pydantic(subscription_details)
+
+
+def format_default_subscriptions(subscription: SubscriptionTable) -> SubscriptionInterface:
+    from orchestrator.graphql import GRAPHQL_MODELS
+
+    strawberry_type = GRAPHQL_MODELS["subscription"]
+    return strawberry_type.from_pydantic(subscription)
 
 
 async def resolve_subscriptions(
@@ -101,7 +108,7 @@ async def resolve_subscriptions(
         if _is_subscription_detailed(info):
             graphql_subscriptions = [get_subscription_details(p) for p in subscriptions]
         else:
-            graphql_subscriptions = [Subscription.from_pydantic(p) for p in subscriptions]
+            graphql_subscriptions = [format_default_subscriptions(p) for p in subscriptions]
     return to_graphql_result_page(
         graphql_subscriptions, first, after, total, subscription_sort_fields, subscription_filter_fields
     )

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from http import HTTPStatus
-from typing import Any, Callable, Union
+from typing import Any, Callable, Type, Union
 
 import strawberry
 import structlog
@@ -154,7 +154,7 @@ def create_graphql_router(
     query: Any = Query,
     mutation: Any = Mutation,
     register_models: bool = True,
-    subscription_interface: Any = SubscriptionInterface,
+    subscription_interface: Union[Type, None] = SubscriptionInterface,
 ) -> OrchestratorGraphqlRouter:
     @strawberry.experimental.pydantic.type(
         model=SubscriptionModel, all_fields=True, directives=federation_key_directives

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -162,7 +162,7 @@ def create_graphql_router(
     class Subscription(SubscriptionInterface):
         pass
 
-    models = GRAPHQL_MODELS_INITIAL
+    models = dict(GRAPHQL_MODELS_INITIAL)
     models["subscription"] = Subscription
 
     if register_models:

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -166,8 +166,8 @@ def create_graphql_router(
     models["subscription"] = Subscription
 
     if register_models:
-        models = register_domain_models(subscription_interface, models)
-    GRAPHQL_MODELS.update(models)
+        models = register_domain_models(subscription_interface, existing_models=models)
+        GRAPHQL_MODELS.update(models)
 
     schema = OrchestratorSchema(
         query=query,

--- a/orchestrator/graphql/schemas/__init__.py
+++ b/orchestrator/graphql/schemas/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2022-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import TypeVar
+
+from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
+
+from orchestrator.graphql.schemas.product import ProductModelGraphql
+
+StrawberryPydanticModel = TypeVar("StrawberryPydanticModel", bound=StrawberryTypeFromPydantic)
+StrawberryModelType = dict[str, StrawberryPydanticModel]
+
+
+GRAPHQL_MODELS: StrawberryModelType = {
+    "ProductModelGraphql": ProductModelGraphql,
+}

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -11,7 +11,6 @@ from strawberry.unset import UNSET
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.db import FixedInputTable, ProductTable, SubscriptionTable, db
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
-from orchestrator.domain.base import SubscriptionModel
 from orchestrator.graphql.pagination import EMPTY_PAGE, Connection
 from orchestrator.graphql.resolvers.process import resolve_processes
 from orchestrator.graphql.schemas.customer import CustomerType
@@ -152,8 +151,3 @@ class SubscriptionInterface:
     @strawberry.field(description="Returns metadata of a subscription")  # type: ignore
     def metadata(self) -> dict:
         return get_subscription_metadata(str(self.subscription_id)) or {}
-
-
-@strawberry.experimental.pydantic.type(model=SubscriptionModel, all_fields=True, directives=federation_key_directives)
-class Subscription(SubscriptionInterface):
-    pass

--- a/orchestrator/graphql/utils/is_query_detailed.py
+++ b/orchestrator/graphql/utils/is_query_detailed.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from more_itertools import flatten, one
 from strawberry.types.nodes import FragmentSpread, InlineFragment, SelectedField, Selection
@@ -14,11 +14,14 @@ def get_selected_field_selections(selected_field: Selection, name: str) -> list[
     return one(page_field).selections if page_field else []
 
 
-def is_query_detailed(basic_fields: tuple) -> Callable[[OrchestratorInfo], bool]:
+def is_query_detailed(
+    basic_fields: tuple, type_conditions: Optional[tuple] = None
+) -> Callable[[OrchestratorInfo], bool]:
     """Function wrapper that validates GraphQL queries against provided basic_fields.
 
     Args:
         basic_fields: tuple of the basic fields.
+        type_conditions: optional tuple of the type conditions.
 
     Returns:
         Function that validates if a GraphQL query includes fields beyond the specified basic_fields.
@@ -29,6 +32,8 @@ def is_query_detailed(basic_fields: tuple) -> Callable[[OrchestratorInfo], bool]
 
         def has_details(selection: Selection) -> bool:
             if isinstance(selection, InlineFragment):
+                if type_conditions and selection.type_condition not in type_conditions:
+                    return True
                 return any(has_details(selection) for selection in selection.selections)
             if isinstance(selection, FragmentSpread):
                 return any(has_details(s) for s in selection.selections)

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Type
 
 from strawberry.field import StrawberryField
 
 
-def override_class(strawberry_class: Any, fields: list[StrawberryField]) -> Any:
+def override_class(strawberry_class: Type, fields: list[StrawberryField]) -> Type:
     """Override fields or add fields to a existing strawberry class.
 
     Usefull for overriding orchestrator core strawberry classes.
@@ -20,7 +20,7 @@ def override_class(strawberry_class: Any, fields: list[StrawberryField]) -> Any:
 
     fields_map = {field.name: field for field in fields}
 
-    def override_fn(field: Any) -> Any:
+    def override_fn(field: StrawberryField) -> StrawberryField:
         if custom_field := fields_map.get(field.name):
             field.base_resolver = custom_field.base_resolver
             return field

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+
+def override_class(strawberry_class: Any, fields: dict) -> Any:
+    """Override fields or add fields to a existing strawberry class.
+
+    Usefull for overriding orchestrator core strawberry classes.
+
+    Parameters:
+        - strawberry_class: The strawberry class which you want to change fields.
+        - fields: a dict with strawberry fields to override or add to the strawberry class.
+
+    returns the strawberry class with changed fields.
+    """
+
+    if not fields:
+        return strawberry_class
+
+    def override_fn(field: Any) -> Any:
+        if custom_field := fields.get(field.name):
+            field.base_resolver = custom_field.base_resolver
+            return field
+        return field
+
+    default_class_field_names = [field.name for field in strawberry_class.__strawberry_definition__._fields]
+
+    new_field_list = [override_fn(field) for field in strawberry_class.__strawberry_definition__._fields]
+    new_field_list.extend([field for field in fields.values() if field.name not in default_class_field_names])
+
+    strawberry_class.__strawberry_definition__._fields = new_field_list
+    return strawberry_class

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+from strawberry.field import StrawberryField
 
-def override_class(strawberry_class: Any, fields: dict) -> Any:
+
+def override_class(strawberry_class: Any, fields: list[StrawberryField]) -> Any:
     """Override fields or add fields to a existing strawberry class.
 
     Usefull for overriding orchestrator core strawberry classes.
@@ -16,8 +18,10 @@ def override_class(strawberry_class: Any, fields: dict) -> Any:
     if not fields:
         return strawberry_class
 
+    fields_map = {field.name: field for field in fields}
+
     def override_fn(field: Any) -> Any:
-        if custom_field := fields.get(field.name):
+        if custom_field := fields_map.get(field.name):
             field.base_resolver = custom_field.base_resolver
             return field
         return field
@@ -25,7 +29,7 @@ def override_class(strawberry_class: Any, fields: dict) -> Any:
     default_class_field_names = [field.name for field in strawberry_class.__strawberry_definition__._fields]
 
     new_field_list = [override_fn(field) for field in strawberry_class.__strawberry_definition__._fields]
-    new_field_list.extend([field for field in fields.values() if field.name not in default_class_field_names])
+    new_field_list.extend([field for field in fields if field.name not in default_class_field_names])
 
     strawberry_class.__strawberry_definition__._fields = new_field_list
     return strawberry_class

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -1277,11 +1277,6 @@ def test_single_subscription_metadata_and_schema(
     }
 
 
-def expect_fail_test_if_too_many_duplicate_types_in_interface(result):
-    if "errors" in result and "are you using a strawberry.field" in result["errors"][0]["message"]:
-        pytest.xfail("Test fails when executed with all tests")
-
-
 def test_subscriptions_product_generic_one(
     fastapi_app_graphql,
     test_client,
@@ -1298,7 +1293,6 @@ def test_subscriptions_product_generic_one(
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    expect_fail_test_if_too_many_duplicate_types_in_interface(result)
 
     subscriptions_data = result["data"]["subscriptions"]
     subscriptions = subscriptions_data["page"]
@@ -1332,7 +1326,6 @@ def test_single_subscription_product_list_union_type(
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    expect_fail_test_if_too_many_duplicate_types_in_interface(result)
 
     subscriptions_data = result["data"]["subscriptions"]
     subscriptions = subscriptions_data["page"]
@@ -1374,7 +1367,6 @@ def test_single_subscription_product_list_union_type_provisioning_subscription(
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    expect_fail_test_if_too_many_duplicate_types_in_interface(result)
 
     subscriptions_data = result["data"]["subscriptions"]
     subscriptions = subscriptions_data["page"]
@@ -1416,7 +1408,6 @@ def test_single_subscription_product_list_union_type_terminated_subscription(
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    expect_fail_test_if_too_many_duplicate_types_in_interface(result)
 
     subscriptions_data = result["data"]["subscriptions"]
     subscriptions = subscriptions_data["page"]

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -20,18 +20,16 @@ def override_class_app_graphql(
     def customer_id_override(self) -> str:
         return "overriden"
 
-    customer_id_override_field = strawberry.field(
-        name="customerId", resolver=customer_id_override, description="Returns customer_id"
-    )
+    customer_id_override_field = strawberry.field(resolver=customer_id_override, description="Returns customer_id")
     customer_id_override_field.name = "customer_id"
 
     def new(self) -> UUID:
         return self.customer_id
 
-    new_field = strawberry.field(name="newField", resolver=new, description="Returns new_field")
+    new_field = strawberry.field(resolver=new, description="Returns new_field")
     new_field.name = "new_field"
 
-    override_class(CustomerType, {"customer_id": customer_id_override_field, "new_field": new_field})
+    override_class(CustomerType, [customer_id_override_field, new_field])
 
     fastapi_app_graphql.register_graphql()
     yield fastapi_app_graphql
@@ -44,7 +42,7 @@ def override_class_app_graphql(
 
     customer_id.name = "customer_id"
 
-    override_class(CustomerType, {"customer_id": customer_id})
+    override_class(CustomerType, [customer_id])
     CustomerType.__strawberry_definition__._fields = [
         field for field in CustomerType.__strawberry_definition__._fields if field.name != "new_field"
     ]

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -1,0 +1,258 @@
+import json
+from http import HTTPStatus
+from typing import Union
+from uuid import UUID
+
+import pytest
+import strawberry
+
+from orchestrator.graphql.schemas.customer import CustomerType
+from orchestrator.graphql.utils.override_class import override_class
+from test.unit_tests.config import GRAPHQL_ENDPOINT, GRAPHQL_HEADERS
+
+
+@pytest.fixture
+def override_class_app_graphql(
+    fastapi_app_graphql,
+    test_client,
+    sub_one_subscription_1,
+):
+    def customer_id_override(self) -> str:
+        return "overriden"
+
+    customer_id_override_field = strawberry.field(
+        name="customerId", resolver=customer_id_override, description="Returns customer_id"
+    )
+    customer_id_override_field.name = "customer_id"
+
+    def new(self) -> UUID:
+        return self.customer_id
+
+    new_field = strawberry.field(name="newField", resolver=new, description="Returns new_field")
+    new_field.name = "new_field"
+
+    override_class(CustomerType, {"customer_id": customer_id_override_field, "new_field": new_field})
+
+    fastapi_app_graphql.register_graphql()
+    yield fastapi_app_graphql
+
+    # reset the overriden fields.
+
+    @strawberry.field(description="Returns customer_id")  # type: ignore
+    def customer_id(self) -> str:
+        return self.customer_id
+
+    customer_id.name = "customer_id"
+
+    override_class(CustomerType, {"customer_id": customer_id})
+    CustomerType.__strawberry_definition__._fields = [
+        field for field in CustomerType.__strawberry_definition__._fields if field.name != "new_field"
+    ]
+    fastapi_app_graphql.register_graphql()
+
+
+def get_customers_query(
+    first: int = 1,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+    override_fields: bool = False,
+) -> bytes:
+    query = f"""
+query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  customers(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
+      customerId
+      fullname
+      shortcode
+      { "newField" if override_fields else ""}
+    }}
+  }}
+}}
+    """
+    return json.dumps(
+        {
+            "operationName": "CustomerQuery",
+            "query": query,
+            "variables": {
+                "first": first,
+                "after": after,
+                "sortBy": sort_by if sort_by else [],
+                "filterBy": filter_by if filter_by else [],
+            },
+        }
+    ).encode("utf-8")
+
+
+def get_subscriptions_customer_query(
+    first: int = 1,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+    override_fields: bool = False,
+) -> bytes:
+    query = f"""
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
+      customer {{
+        customerId
+        fullname
+        shortcode
+        { "newField" if override_fields else ""}
+      }}
+    }}
+  }}
+}}
+    """
+    return json.dumps(
+        {
+            "operationName": "SubscriptionQuery",
+            "query": query,
+            "variables": {
+                "first": first,
+                "after": after,
+                "sortBy": sort_by if sort_by else [],
+                "filterBy": filter_by if filter_by else [],
+            },
+        }
+    ).encode("utf-8")
+
+
+def get_subscriptions_detail_customer_query(
+    first: int = 1,
+    after: int = 0,
+    filter_by: Union[list[str], None] = None,
+    sort_by: Union[list[dict[str, str]], None] = None,
+    override_fields: bool = False,
+) -> bytes:
+    query = f"""
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
+      ... on ProductSubOneSubscription {{
+        customer {{
+          customerId
+          fullname
+          shortcode
+          { "newField" if override_fields else ""}
+        }}
+      }}
+    }}
+  }}
+}}
+    """
+    return json.dumps(
+        {
+            "operationName": "SubscriptionQuery",
+            "query": query,
+            "variables": {
+                "first": first,
+                "after": after,
+                "sortBy": sort_by if sort_by else [],
+                "filterBy": filter_by if filter_by else [],
+            },
+        }
+    ).encode("utf-8")
+
+
+def test_customers(fastapi_app_graphql, test_client):
+    # when
+    response = test_client.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["customers"]["page"][0]
+    assert customer_data == {
+        "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+    }
+
+
+def test_customers_overriden(override_class_app_graphql, test_client):
+    # when
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_customers_query(override_fields=True), headers=GRAPHQL_HEADERS
+    )
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["customers"]["page"][0]
+    assert customer_data == {
+        "customerId": "overriden",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+        "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+    }
+
+
+def test_subscription_customer(fastapi_app_graphql, test_client):
+    # when
+    response = test_client.post(GRAPHQL_ENDPOINT, content=get_subscriptions_customer_query(), headers=GRAPHQL_HEADERS)
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    assert customer_data == {
+        "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+    }
+
+
+def test_subscription_customer_overriden(override_class_app_graphql, test_client):
+    # when
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_subscriptions_customer_query(override_fields=True), headers=GRAPHQL_HEADERS
+    )
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    assert customer_data == {
+        "customerId": "overriden",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+        "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+    }
+
+
+def test_subscription_detail_customer(fastapi_app_graphql, test_client):
+    # when
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_subscriptions_detail_customer_query(), headers=GRAPHQL_HEADERS
+    )
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    assert customer_data == {
+        "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+    }
+
+
+def test_subscription_detail_customer_overriden(override_class_app_graphql, test_client):
+    # when
+    response = test_client.post(
+        GRAPHQL_ENDPOINT, content=get_subscriptions_detail_customer_query(override_fields=True), headers=GRAPHQL_HEADERS
+    )
+
+    # then
+    assert HTTPStatus.OK == response.status_code
+    result = response.json()
+    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+
+    assert customer_data == {
+        "customerId": "overriden",
+        "fullname": "Default::Orchestrator-Core Customer",
+        "shortcode": "default-cust",
+        "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+    }

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -58,18 +58,20 @@ def get_customers_query(
     sort_by: Union[list[dict[str, str]], None] = None,
     override_fields: bool = False,
 ) -> bytes:
-    query = f"""
-query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
-  customers(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
-    page {{
+    query = """
+query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
+  customers(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
+    page {
       customerId
       fullname
       shortcode
-      { "newField" if override_fields else ""}
-    }}
-  }}
-}}
-    """
+        %s
+    }
+  }
+}
+    """ % (
+        "newField" if override_fields else "",
+    )
     return json.dumps(
         {
             "operationName": "CustomerQuery",
@@ -91,20 +93,22 @@ def get_subscriptions_customer_query(
     sort_by: Union[list[dict[str, str]], None] = None,
     override_fields: bool = False,
 ) -> bytes:
-    query = f"""
-query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
-  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
-    page {{
-      customer {{
+    query = """
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
+    page {
+      customer {
         customerId
         fullname
         shortcode
-        { "newField" if override_fields else ""}
-      }}
-    }}
-  }}
-}}
-    """
+        %s
+      }
+    }
+  }
+}
+    """ % (
+        "newField" if override_fields else "",
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -126,22 +130,24 @@ def get_subscriptions_detail_customer_query(
     sort_by: Union[list[dict[str, str]], None] = None,
     override_fields: bool = False,
 ) -> bytes:
-    query = f"""
-query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
-  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
-    page {{
-      ... on ProductSubOneSubscription {{
-        customer {{
+    query = """
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
+    page {
+      ... on ProductSubOneSubscription {
+        customer {
           customerId
           fullname
           shortcode
-          { "newField" if override_fields else ""}
-        }}
-      }}
-    }}
-  }}
-}}
-    """
+          %s
+        }
+      }
+    }
+  }
+}
+    """ % (
+        "newField" if override_fields else "",
+    )
     return json.dumps(
         {
             "operationName": "SubscriptionQuery",
@@ -189,9 +195,15 @@ def test_customers_overriden(override_class_app_graphql, test_client):
     }
 
 
-def test_subscription_customer(fastapi_app_graphql, test_client):
+def test_subscription_customer(fastapi_app_graphql, test_client, sub_one_subscription_1):
     # when
-    response = test_client.post(GRAPHQL_ENDPOINT, content=get_subscriptions_customer_query(), headers=GRAPHQL_HEADERS)
+    response = test_client.post(
+        GRAPHQL_ENDPOINT,
+        content=get_subscriptions_customer_query(
+            filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}]
+        ),
+        headers=GRAPHQL_HEADERS,
+    )
 
     # then
     assert HTTPStatus.OK == response.status_code
@@ -206,10 +218,15 @@ def test_subscription_customer(fastapi_app_graphql, test_client):
     }
 
 
-def test_subscription_customer_overriden(override_class_app_graphql, test_client):
+def test_subscription_customer_overriden(override_class_app_graphql, test_client, sub_one_subscription_1):
     # when
     response = test_client.post(
-        GRAPHQL_ENDPOINT, content=get_subscriptions_customer_query(override_fields=True), headers=GRAPHQL_HEADERS
+        GRAPHQL_ENDPOINT,
+        content=get_subscriptions_customer_query(
+            filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}],
+            override_fields=True,
+        ),
+        headers=GRAPHQL_HEADERS,
     )
 
     # then
@@ -227,10 +244,14 @@ def test_subscription_customer_overriden(override_class_app_graphql, test_client
     }
 
 
-def test_subscription_detail_customer(fastapi_app_graphql, test_client):
+def test_subscription_detail_customer(fastapi_app_graphql, test_client, sub_one_subscription_1):
     # when
     response = test_client.post(
-        GRAPHQL_ENDPOINT, content=get_subscriptions_detail_customer_query(), headers=GRAPHQL_HEADERS
+        GRAPHQL_ENDPOINT,
+        content=get_subscriptions_detail_customer_query(
+            filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}]
+        ),
+        headers=GRAPHQL_HEADERS,
     )
 
     # then
@@ -246,10 +267,15 @@ def test_subscription_detail_customer(fastapi_app_graphql, test_client):
     }
 
 
-def test_subscription_detail_customer_overriden(override_class_app_graphql, test_client):
+def test_subscription_detail_customer_overriden(override_class_app_graphql, test_client, sub_one_subscription_1):
     # when
     response = test_client.post(
-        GRAPHQL_ENDPOINT, content=get_subscriptions_detail_customer_query(override_fields=True), headers=GRAPHQL_HEADERS
+        GRAPHQL_ENDPOINT,
+        content=get_subscriptions_detail_customer_query(
+            filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}],
+            override_fields=True,
+        ),
+        headers=GRAPHQL_HEADERS,
     )
 
     # then

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -196,11 +196,13 @@ def test_subscription_customer(fastapi_app_graphql, test_client):
     # then
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    customer_data = result["data"]["subscriptions"]["page"][0]
     assert customer_data == {
-        "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
-        "fullname": "Default::Orchestrator-Core Customer",
-        "shortcode": "default-cust",
+        "customer": {
+            "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+            "fullname": "Default::Orchestrator-Core Customer",
+            "shortcode": "default-cust",
+        }
     }
 
 
@@ -213,12 +215,15 @@ def test_subscription_customer_overriden(override_class_app_graphql, test_client
     # then
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    customer_data = result["data"]["subscriptions"]["page"][0]
+
     assert customer_data == {
-        "customerId": "overriden",
-        "fullname": "Default::Orchestrator-Core Customer",
-        "shortcode": "default-cust",
-        "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        "customer": {
+            "customerId": "overriden",
+            "fullname": "Default::Orchestrator-Core Customer",
+            "shortcode": "default-cust",
+            "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        }
     }
 
 
@@ -231,11 +236,13 @@ def test_subscription_detail_customer(fastapi_app_graphql, test_client):
     # then
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    customer_data = result["data"]["subscriptions"]["page"][0]
     assert customer_data == {
-        "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
-        "fullname": "Default::Orchestrator-Core Customer",
-        "shortcode": "default-cust",
+        "customer": {
+            "customerId": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+            "fullname": "Default::Orchestrator-Core Customer",
+            "shortcode": "default-cust",
+        }
     }
 
 
@@ -248,11 +255,13 @@ def test_subscription_detail_customer_overriden(override_class_app_graphql, test
     # then
     assert HTTPStatus.OK == response.status_code
     result = response.json()
-    customer_data = result["data"]["subscriptions"]["page"][0]["customer"]
+    customer_data = result["data"]["subscriptions"]["page"][0]
 
     assert customer_data == {
-        "customerId": "overriden",
-        "fullname": "Default::Orchestrator-Core Customer",
-        "shortcode": "default-cust",
-        "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        "customer": {
+            "customerId": "overriden",
+            "fullname": "Default::Orchestrator-Core Customer",
+            "shortcode": "default-cust",
+            "newField": "59289a57-70fb-4ff5-9c93-10fe67b12434",
+        }
     }


### PR DESCRIPTION
- Change `register_graphql` to re-create autogenerated models and update the graphql router schema.
- add strawberry class override to change field resolvers of existing classes.
- add unit tests for override_class function and add test that overrides `Query`.
- move register_domain_models to create_graphql_router.
- change register_domain_models to take existing models with a parameter instead of a global dict.
- move `StrawberryPydanticModel`, `StrawberryModelType` and `GRAPHQL_MODELS` to graphql.schemas init.
- create default `Subscription` inside the create_graphql_router to recreate it when interface is updated.

Fixes: #393, #310
Both fixed by the ability to update schema with running `app.register_graphql` multiple times.