### PR TITLE
Fix search_query. Only apply camel_casing to key-term

### DIFF
--- a/orchestrator/api/helpers.py
+++ b/orchestrator/api/helpers.py
@@ -27,7 +27,6 @@ from starlette.responses import Response
 from structlog import get_logger
 
 from orchestrator.api.error_handling import raise_status
-from orchestrator.cli.generator.generator.helpers import camel_to_snake
 from orchestrator.db import ProcessTable, ProductTable, SubscriptionTable, db
 from orchestrator.db.models import SubscriptionSearchView
 from orchestrator.db.range.range import Selectable, apply_range_to_statement
@@ -164,7 +163,7 @@ def add_subscription_search_query_filter(stmt: Select, search_query: str) -> Sel
     if len(search_query) > MAX_QUERY_STRING_LENGTH:
         raise_status(HTTPStatus.BAD_REQUEST, f"Max query length of {MAX_QUERY_STRING_LENGTH} characters exceeded.")
 
-    ts_query = create_ts_query_string(camel_to_snake(search_query))
+    ts_query = create_ts_query_string(search_query)
     return stmt.join(SubscriptionSearchView).filter(
         func.to_tsquery("simple", ts_query).op("@@")(SubscriptionSearchView.tsv)
     )

--- a/orchestrator/cli/generator/generator/helpers.py
+++ b/orchestrator/cli/generator/generator/helpers.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import re
 from collections.abc import Generator
 from pathlib import Path
 
@@ -18,17 +17,9 @@ import structlog
 from more_itertools import first, one
 
 from orchestrator.cli.generator.generator.settings import product_generator_settings as settings
+from orchestrator.utils.helpers import camel_to_snake
 
 logger = structlog.getLogger(__name__)
-
-
-def snake_to_camel(s: str) -> str:
-    return "".join(x.title() for x in s.split("_"))
-
-
-def camel_to_snake(s: str) -> str:
-    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
 
 
 def get_workflow(config: dict, workflow_name: str) -> dict:

--- a/orchestrator/cli/generator/generator/product_block.py
+++ b/orchestrator/cli/generator/generator/product_block.py
@@ -25,10 +25,10 @@ from orchestrator.cli.generator.generator.helpers import (
     create_dunder_init_files,
     get_product_block_file_name,
     path_to_module,
-    snake_to_camel,
 )
 from orchestrator.cli.generator.generator.settings import product_generator_settings as settings
 from orchestrator.domain.base import ProductBlockModel
+from orchestrator.utils.helpers import snake_to_camel
 
 logger = structlog.getLogger(__name__)
 

--- a/orchestrator/utils/helpers.py
+++ b/orchestrator/utils/helpers.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Any, Callable, TypeVar, Union
 
@@ -93,3 +94,12 @@ def to_snake(s: str) -> str:
 
 def is_ipaddress_type(v: Any) -> bool:
     return isinstance(v, (IPv4Address, IPv6Address, IPv4Network, IPv6Network))
+
+
+def snake_to_camel(s: str) -> str:
+    return "".join(x.title() for x in s.split("_"))
+
+
+def camel_to_snake(s: str) -> str:
+    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -97,6 +97,11 @@ class Lexer:
         yield Token.END,
 
 
+def camel_to_snake(s: str) -> str:
+    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
+
+
 Node = tuple[str, Any]
 
 
@@ -274,6 +279,9 @@ class TSQueryVisitor:
         key_node, value_node = node[1]
 
         # Re-use visit_term
+        if key_node[0] == "Word":
+            # Camel case key term
+            key_node = ["Word", camel_to_snake(key_node[1])]
         TSQueryVisitor.visit_term(key_node, acc)
         acc.append(" <-> ")
 

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import MappedColumn
 
 from orchestrator.db.database import BaseModel
+from orchestrator.utils.helpers import camel_to_snake
 
 logger = structlog.getLogger(__name__)
 
@@ -95,11 +96,6 @@ class Lexer:
                 yield Token.WORD, word
 
         yield Token.END,
-
-
-def camel_to_snake(s: str) -> str:
-    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
 
 
 Node = tuple[str, Any]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,6 @@ junit_suite_name = orchestrator
 filterwarnings=
 	; TODO #427 ProductBlockModel.name being used as both a ClassVar and a pydantic Field
 	ignore:Field name "name" shadows an attribute in parent.*:UserWarning:pydantic
-	; TODO #386 finish sqlalchemy v2 migration
-	ignore:The Query\.(get|with_parent)\(\) method is considered legacy:sqlalchemy.exc.LegacyAPIWarning:
 
 markers=
 	workflow: Test that runs a complete workflow (Slow)

--- a/test/unit_tests/utils/test_search_query.py
+++ b/test/unit_tests/utils/test_search_query.py
@@ -96,3 +96,9 @@ def test_query_with_underscores():
         tsquery
         == "word <-> with <-> underscores & prefix <-> word:* & key <-> value <-> term <-> 1 & key <-> value2 <-> (val <-> 1 | val <-> 2 | val <-> 3:*)"
     )
+
+
+def test_query_kv_camelcasing():
+    q = "productTag:myTag"
+    q2 = "product_tag:myTag"
+    assert _parse_tree_and_tsquery(q)[1] == _parse_tree_and_tsquery(q2)[1]


### PR DESCRIPTION
Selectively applies camel_case conversion to key-terms in tsv search queries.

This allows searching for `productType:X` instead of `product_type:X`, but prevents arbitrary conversion of e.g. `L2V` to `l2_v`.