### PR TITLE
Drop support for Python 3.9 and 3.10 and add 3.12

### DIFF
--- a/.github/workflows/run-linting-tests.yml
+++ b/.github/workflows/run-linting-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12']
       fail-fast: false
 
     steps:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12']
       fail-fast: false
     container: python:${{ matrix.python-version }}-slim
     services:

--- a/docs/architecture/application/cli.md
+++ b/docs/architecture/application/cli.md
@@ -2,11 +2,11 @@
 
 Top level options:
 
---install-completion [bash|zsh|fish|powershell|pwsh]  
+--install-completion [bash|zsh|fish|powershell|pwsh]
 
 Install completion for the specified shell. [default: None]
 
---show-completion [bash|zsh|fish|powershell|pwsh]  
+--show-completion [bash|zsh|fish|powershell|pwsh]
 
 Show completion for the specified shell, to copy it or customize the
 installation. [default: None]
@@ -35,7 +35,7 @@ chronological order.
 
 Options
 
---verbose - Verbose output  
+--verbose - Verbose output
 --current - Indicate current revision
 
 ### init
@@ -46,11 +46,11 @@ directories.
 
 ### merge
 
-The `main.py db merge` command merges database revisions.                     
+The `main.py db merge` command merges database revisions.
 
 Arguments
 
-revisions - Add the revision you would like to merge to this command 
+revisions - Add the revision you would like to merge to this command
 [default: None]
 
 Options
@@ -61,7 +61,7 @@ Options
 
 The `main.py db migrate-domain-models` command creates a revision based on the
 difference between domain models in the source code and those that are defined
-in the database.  
+in the database.
 
 Arguments
 
@@ -69,11 +69,11 @@ message - Migration name [default: None] [required]
 
 Options
 
---test | --no-test - Optional boolean if you don't want to generate a 
-migration file [default: no-test]  
---inputs -  stringified dict to prefill inputs [default: {}]  
---updates - stringified dict to map updates instead of 
-using inputs [default: {}]  
+--test | --no-test - Optional boolean if you don't want to generate a
+migration file [default: no-test]
+--inputs -  stringified dict to prefill inputs [default: {}]
+--updates - stringified dict to map updates instead of
+using inputs [default: {}]
 
 The `python main.py db migrate-domain-model` CLI command is used to
 automatically generate the data migrations that you'll need when you add or
@@ -425,7 +425,7 @@ If you are running with `--test`, the SQL file will not be generated.
 
 The `main.py db migrate-workflows` command creates a migration file based on
 the difference between de worfklows code and the workflows that are registered
-in the database.     
+in the database.
 
 Arguments
 
@@ -433,7 +433,7 @@ message - Migration name [default: None] [required]
 
 Options
 
---test | --no-test - Optional boolean if you don't want to generate a 
+--test | --no-test - Optional boolean if you don't want to generate a
 migration file [default: no-test]
 
 ### revision
@@ -442,12 +442,12 @@ The `main.py db revision` command creates a new Alembic revision file.
 
 Arguments
 
---message - The revision message [default: None]  
---version-path - Specify specific path from config for version file 
-[default: None]  
---autogenerate | --no-autogenerate - Detect schema changes and add 
-migrations [default: no-autogenerate]  
---head - Determine the head you need to add your migration to. [default: None]  
+--message - The revision message [default: None]
+--version-path - Specify specific path from config for version file
+[default: None]
+--autogenerate | --no-autogenerate - Detect schema changes and add
+migrations [default: no-autogenerate]
+--head - Determine the head you need to add your migration to. [default: None]
 
 ### upgrade
 
@@ -557,7 +557,7 @@ A fixed input has a `name` and a `type` field. If the type is a primitive type
 (for example: str, bool, int, UUID), then this is sufficient. In the case of
 `node_vendor` we use an enum type, so we add additional fields to describe the
 enumeration type and its possible values.
- 
+
 **`product_blocks` section**
 
 In this section we define the product blocks that are part of this product.
@@ -621,8 +621,8 @@ configuration file.
 
 Options
 
---config-file - The configuration file [default: None]  
---python-version - Python version for generated code [default: 3.9]  
+--config-file - The configuration file [default: None]
+--python-version - Python version for generated code [default: 3.11]
 
 ### product
 
@@ -631,10 +631,10 @@ from a configuration file.
 
 Options
 
---config-file - The configuration file [default: None]  
---dryrun | --no-dryrun - Dry run [default: dryrun]  
---force - Force overwrite of existing files  
---python-version - Python version for generated code [default: 3.9]  
+--config-file - The configuration file [default: None]
+--dryrun | --no-dryrun - Dry run [default: dryrun]
+--force - Force overwrite of existing files
+--python-version - Python version for generated code [default: 3.11]
 --folder-prefix - Folder prefix, e.g. <folder-prefix>/workflows [default: None]
 
 ### product-blocks
@@ -644,10 +644,10 @@ domain models from a configuration file.
 
 Options
 
---config-file - The configuration file [default: None]  
---dryrun | --no-dryrun - Dry run [default: dryrun]  
---force - Force overwrite of existing files  
---python-version - Python version for generated code [default: 3.9]  
+--config-file - The configuration file [default: None]
+--dryrun | --no-dryrun - Dry run [default: dryrun]
+--force - Force overwrite of existing files
+--python-version - Python version for generated code [default: 3.11]
 --folder-prefix - Folder prefix, e.g. <folder-prefix>/workflows [default: None]
 
 ### unit-tests
@@ -657,10 +657,10 @@ configuration file.
 
 Options
 
---config-file - The configuration file [default: None]  
---dryrun | --no-dryrun - Dry run [default: dryrun]  
---force - Force overwrite of existing files  
---python-version - Python version for generated code [default: 3.9]  
+--config-file - The configuration file [default: None]
+--dryrun | --no-dryrun - Dry run [default: dryrun]
+--force - Force overwrite of existing files
+--python-version - Python version for generated code [default: 3.11]
 --tdd - Force test driven development with failing asserts [default: True]
 
 ### workflows
@@ -673,13 +673,13 @@ steps to the create, modify and terminate workflows.
 
 Options
 
---config-file - The configuration file [default: None]  
---dryrun | --no-dryrun - Dry run [default: dryrun]  
---force - Force overwrite of existing files  
---python-version - Python version for generated code [default: 3.9]  
---folder-prefix - Folder prefix, e.g. <folder-prefix>/workflows [default: 
-None]  
---custom-templates - Custom templates folder [default: None]  
+--config-file - The configuration file [default: None]
+--dryrun | --no-dryrun - Dry run [default: dryrun]
+--force - Force overwrite of existing files
+--python-version - Python version for generated code [default: 3.11]
+--folder-prefix - Folder prefix, e.g. <folder-prefix>/workflows [default:
+None]
+--custom-templates - Custom templates folder [default: None]
 
 ## scheduler
 

--- a/docs/workshops/beginner/debian.md
+++ b/docs/workshops/beginner/debian.md
@@ -1,7 +1,7 @@
 # Debian 11 (bullseye) installation instructions
 
-How to manually install the orchestrator-core and orchestrator-core-gui on 
-Debian 11 
+How to manually install the orchestrator-core and orchestrator-core-gui on
+Debian 11
 (Bullseye) is described in the following steps.
 
 ### Step 1 - Install dependencies
@@ -33,7 +33,7 @@ sudo -u postgres createuser -sP nwa
 sudo -u postgres createdb orchestrator-core -O nwa
 ```
 
-For debug purposes, interact directly with the database by starting the 
+For debug purposes, interact directly with the database by starting the
 PostgresSQL interactive terminal:
 
 ``` shell
@@ -42,14 +42,14 @@ sudo -u postgres psql orchestrator-core
 
 ### Step 3 - Install orchestrator
 
-The minimal version of Python is 3.9. Before the orchestrator core and all its
+The minimal version of Python is 3.11. Before the orchestrator core and all its
 dependencies are installed, a Python virtual environment is created:
 
 ```shell
 mkdir example-orchestrator
 cd example-orchestrator
 source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-mkvirtualenv --python python3.9 example-orchestrator
+mkvirtualenv --python python3.11 example-orchestrator
 ```
 
 Make sure that the just created Python virtual environment is active before
@@ -104,7 +104,7 @@ PYTHONPATH=. python main.py db upgrade heads
 
 ### Step 5 - Install orchestrator client
 
-Install the orchestrator client in the parent directory of the 
+Install the orchestrator client in the parent directory of the
 example-orchestrator:
 
 ```shell
@@ -112,7 +112,7 @@ cd ..
 git clone https://github.com/workfloworchestrator/orchestrator-core-gui.git
 ```
 
-Install the Yarn package manager and use it to install the orchestrator 
+Install the Yarn package manager and use it to install the orchestrator
 client dependencies:
 
 ```shell

--- a/docs/workshops/beginner/explore.md
+++ b/docs/workshops/beginner/explore.md
@@ -14,7 +14,7 @@ cd example-orchestrator-beginner
 echo 'drop database "orchestrator-core";' | psql postgres
 createdb orchestrator-core -O nwa
 source virtualenvwrapper.sh
-workon example-orchestrator || mkvirtualenv --python python3.9 example-orchestrator
+workon example-orchestrator || mkvirtualenv --python python3.11 example-orchestrator
 pip install orchestrator-core
 PYTHONPATH=. python main.py db init
 cp -av examples/*add_user_and_usergroup* migrations/versions/schema

--- a/docs/workshops/beginner/macos.md
+++ b/docs/workshops/beginner/macos.md
@@ -1,6 +1,6 @@
 # MacOS version 12 (Monterey) installation instructions
 
-How to manually install the orchestrator-core and orchestrator-core-gui on 
+How to manually install the orchestrator-core and orchestrator-core-gui on
 MacOS version
 12 (Monterey) is described in the following steps.
 
@@ -9,15 +9,15 @@ MacOS version
 This installation instruction assumes the use of [Homebrew](https://brew.sh/).
 The following software dependencies need to be installed:
 
-* Python 3.9
+* Python 3.11
 * PostgreSQL (version >=11)
-* virtualenvwrapper (or use any other tool to create virtual Python 
+* virtualenvwrapper (or use any other tool to create virtual Python
   environments)
 * Node.js (version 14)
 * yarn
 
 ``` shell
-brew install python@3.9 postgresql@13 virtualenvwrapper node@14 yarn
+brew install python@3.11 postgresql@13 virtualenvwrapper node@14 yarn
 ```
 
 ### Step 2 - Database setup
@@ -40,14 +40,14 @@ psql orchestrator-core
 
 ### Step 3 - Install orchestrator
 
-The minimal version of Python is 3.9. Before the orchestrator core and all its
+The minimal version of Python is 3.11. Before the orchestrator core and all its
 dependencies are installed, a Python virtual environment is created:
 
 ```shell
 mkdir example-orchestrator
 cd example-orchestrator
 source virtualenvwrapper.sh
-mkvirtualenv --python python3.9 example-orchestrator
+mkvirtualenv --python python3.11 example-orchestrator
 ```
 
 Make sure that the just created Python virtual environment is active before
@@ -102,7 +102,7 @@ PYTHONPATH=. python main.py db upgrade heads
 
 ### Step 5 - Install orchestrator client
 
-Install the orchestrator client in the parent directory of the 
+Install the orchestrator client in the parent directory of the
 example-orchestrator:
 
 ```shell

--- a/orchestrator/api/api_v1/endpoints/fixed_input.py
+++ b/orchestrator/api/api_v1/endpoints/fixed_input.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Any, Dict
+from typing import Any
 
 import structlog
 from fastapi.routing import APIRouter
@@ -29,7 +29,7 @@ logger = structlog.get_logger(__name__)
 
 
 @router.get("/configuration", response_model=FixedInputConfigurationSchema)
-def fi_configuration() -> Dict[str, Any]:  # noqa: C901
+def fi_configuration() -> dict[str, Any]:  # noqa: C901
     product_tags = products.get_tags()
 
     data: dict = {"fixed_inputs": [], "by_tag": {}}

--- a/orchestrator/api/api_v1/endpoints/product_blocks.py
+++ b/orchestrator/api/api_v1/endpoints/product_blocks.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from http import HTTPStatus
-from typing import List
 from uuid import UUID
 
 from fastapi.param_functions import Body
@@ -29,8 +28,8 @@ from orchestrator.schemas import ProductBlockEnrichedSchema as ProductBlockSchem
 router = APIRouter()
 
 
-@router.get("/", response_model=List[ProductBlockSchema])
-def fetch() -> List[ProductBlockTable]:
+@router.get("/", response_model=list[ProductBlockSchema])
+def fetch() -> list[ProductBlockTable]:
     stmt = select(ProductBlockTable).options(joinedload(ProductBlockTable.resource_types))
     return list(db.session.scalars(stmt).unique())
 

--- a/orchestrator/api/api_v1/endpoints/products.py
+++ b/orchestrator/api/api_v1/endpoints/products.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from http import HTTPStatus
-from typing import List, Optional
 from uuid import UUID
 
 from fastapi.param_functions import Body
@@ -30,8 +29,8 @@ from orchestrator.services.products import get_tags, get_types
 router = APIRouter()
 
 
-@router.get("/", response_model=List[ProductSchema])
-def fetch(tag: Optional[str] = None, product_type: Optional[str] = None) -> List[ProductSchema]:
+@router.get("/", response_model=list[ProductSchema])
+def fetch(tag: str | None = None, product_type: str | None = None) -> list[ProductSchema]:
     stmt = select(ProductTable).options(
         selectinload(ProductTable.workflows),
         selectinload(ProductTable.fixed_inputs),
@@ -82,16 +81,16 @@ def delete_product(product_id: UUID) -> None:
     return delete(ProductTable, product_id)
 
 
-@router.get("/tags/all", response_model=List[str])
-def tags() -> List[str]:
+@router.get("/tags/all", response_model=list[str])
+def tags() -> list[str]:
     return get_tags()
 
 
-@router.get("/types/all", response_model=List[str])
-def types() -> List[str]:
+@router.get("/types/all", response_model=list[str])
+def types() -> list[str]:
     return get_types()
 
 
-@router.get("/statuses/all", response_model=List[ProductLifecycle])
-def statuses() -> List[ProductLifecycle]:
+@router.get("/statuses/all", response_model=list[ProductLifecycle])
+def statuses() -> list[ProductLifecycle]:
     return ProductLifecycle.values()

--- a/orchestrator/api/api_v1/endpoints/resource_types.py
+++ b/orchestrator/api/api_v1/endpoints/resource_types.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from http import HTTPStatus
-from typing import List
 from uuid import UUID
 
 from fastapi.param_functions import Body
@@ -28,8 +27,8 @@ from orchestrator.services.resource_types import get_resource_types
 router = APIRouter()
 
 
-@router.get("/", response_model=List[ResourceTypeSchema])
-def fetch() -> List[ResourceTypeTable]:
+@router.get("/", response_model=list[ResourceTypeSchema])
+def fetch() -> list[ResourceTypeTable]:
     return get_resource_types()
 
 

--- a/orchestrator/api/api_v1/endpoints/settings.py
+++ b/orchestrator/api/api_v1/endpoints/settings.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from http import HTTPStatus
-from typing import Optional, Union
 
 import structlog
 from fastapi import Query, WebSocket
@@ -39,7 +38,7 @@ CACHE_FLUSH_OPTIONS: dict[str, str] = {
 
 
 @router.delete("/cache/{name}")
-async def clear_cache(name: str) -> Union[int, None]:
+async def clear_cache(name: str) -> int | None:
     cache: AIORedis = AIORedis.from_url(str(app_settings.CACHE_URI))
     if name not in CACHE_FLUSH_OPTIONS:
         raise_status(HTTPStatus.BAD_REQUEST, "Invalid cache name")
@@ -60,7 +59,7 @@ async def reset_search_index() -> None:
 
 @router.put("/status", response_model=EngineSettingsSchema)
 async def set_global_status(
-    body: EngineSettingsBaseSchema, user: Optional[OIDCUserModel] = Depends(oidc_user)
+    body: EngineSettingsBaseSchema, user: OIDCUserModel | None = Depends(oidc_user)
 ) -> EngineSettingsSchema:
     """Update the global status of the engine to a new state.
 

--- a/orchestrator/api/api_v1/endpoints/user.py
+++ b/orchestrator/api/api_v1/endpoints/user.py
@@ -13,7 +13,7 @@
 
 """Module that implements user (e.g. miscellaneous) related API endpoints."""
 
-from typing import Any, Dict
+from typing import Any
 
 import structlog
 from fastapi.param_functions import Body
@@ -27,14 +27,14 @@ logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 
-@router.post("/error", response_model=Dict)
-def log_error(data: Dict[Any, Any] = Body(...)) -> Dict:
+@router.post("/error", response_model=dict)
+def log_error(data: dict[Any, Any] = Body(...)) -> dict:
     logger.error("Client reported an error", data=data, frontend_error=True)
     return {}
 
 
-@router.post("/log/{user_name}", response_model=Dict)
-def log_user_info(user_name: str, message: Dict = Body(...)) -> Dict:
+@router.post("/log/{user_name}", response_model=dict)
+def log_user_info(user_name: str, message: dict = Body(...)) -> dict:
     """Log frontend messages that are related to user actions.
 
     When the frontend finalizes the setup of a login session it will do a HTTP POST to this endpoint. The frontend

--- a/orchestrator/api/api_v1/endpoints/workflows.py
+++ b/orchestrator/api/api_v1/endpoints/workflows.py
@@ -13,7 +13,6 @@
 
 """Module that implements workflows related API endpoints."""
 
-from typing import List, Optional
 
 from fastapi.routing import APIRouter
 from sqlalchemy import select
@@ -25,14 +24,14 @@ from orchestrator.services.workflows import get_workflows
 router = APIRouter()
 
 
-@router.get("/", response_model=List[WorkflowSchema])
-def get_all(target: Optional[str] = None, include_steps: bool = False) -> List[WorkflowSchema]:
+@router.get("/", response_model=list[WorkflowSchema])
+def get_all(target: str | None = None, include_steps: bool = False) -> list[WorkflowSchema]:
     filters = {"target": target} if target else None
     return list(get_workflows(filters=filters, include_steps=include_steps))
 
 
-@router.get("/with_product_tags", response_model=List[WorkflowWithProductTagsSchema])
-def get_all_with_product_tags() -> List[WorkflowWithProductTagsSchema]:
+@router.get("/with_product_tags", response_model=list[WorkflowWithProductTagsSchema])
+def get_all_with_product_tags() -> list[WorkflowWithProductTagsSchema]:
     all_workflows = get_workflows()
 
     def add_product_tags(wf: WorkflowSchema) -> WorkflowWithProductTagsSchema:

--- a/orchestrator/api/error_handling.py
+++ b/orchestrator/api/error_handling.py
@@ -13,7 +13,7 @@
 
 
 from http import HTTPStatus
-from typing import Any, Dict, NoReturn, Optional, Union
+from typing import Any, NoReturn
 
 from fastapi.exceptions import HTTPException
 from starlette.datastructures import MutableHeaders
@@ -23,10 +23,10 @@ class ProblemDetailException(HTTPException):
     def __init__(
         self,
         status: int,
-        title: Optional[str] = None,
+        title: str | None = None,
         detail: Any = None,
-        headers: Optional[dict] = None,
-        error_type: Optional[str] = None,
+        headers: dict | None = None,
+        error_type: str | None = None,
     ) -> None:
         if headers is None:
             headers = {}
@@ -36,7 +36,7 @@ class ProblemDetailException(HTTPException):
         self.type = error_type
 
 
-def raise_status(status: int, detail: Any = None, headers: Optional[Union[MutableHeaders, Dict]] = None) -> NoReturn:
+def raise_status(status: int, detail: Any = None, headers: MutableHeaders | dict | None = None) -> NoReturn:
     status = HTTPStatus(status)
     if isinstance(headers, MutableHeaders):
         headers = dict(**headers)

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -25,6 +25,7 @@ from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from sentry_sdk.integrations.strawberry import StrawberryIntegration
 from sentry_sdk.integrations.threading import ThreadingIntegration
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -144,6 +145,9 @@ class OrchestratorCore(FastAPI):
             from sentry_sdk.integrations.celery import CeleryIntegration
 
             sentry_integrations.append(CeleryIntegration())
+
+        if self.graphql_router:
+            sentry_integrations.append(StrawberryIntegration(async_execution=True))
 
         sentry_sdk.init(
             dsn=sentry_dsn,

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Dict, List, Optional, Type
+from collections.abc import Callable
+from typing import Any
 
 import sentry_sdk
 import structlog
@@ -52,7 +53,7 @@ from pydantic_forms.exceptions import FormException
 
 logger = structlog.get_logger(__name__)
 
-sentry_integrations: List[Integration] = [
+sentry_integrations: list[Integration] = [
     SqlalchemyIntegration(),
     RedisIntegration(),
     FastApiIntegration(),
@@ -62,7 +63,7 @@ sentry_integrations: List[Integration] = [
 
 
 class OrchestratorCore(FastAPI):
-    graphql_router: Optional[Any] = None
+    graphql_router: Any | None = None
 
     def __init__(
         self,
@@ -72,7 +73,7 @@ class OrchestratorCore(FastAPI):
         docs_url: str = "/api/docs",
         redoc_url: str = "/api/redoc",
         version: str = __version__,
-        default_response_class: Type[Response] = JSONResponse,
+        default_response_class: type[Response] = JSONResponse,
         base_settings: AppSettings = app_settings,
         **kwargs: Any,
     ) -> None:
@@ -138,7 +139,7 @@ class OrchestratorCore(FastAPI):
         trace_sample_rate: float,
         server_name: str,
         environment: str,
-        release: Optional[str] = GIT_COMMIT_HASH,
+        release: str | None = GIT_COMMIT_HASH,
     ) -> None:
         logger.info("Adding Sentry middleware to app", app=self.title)
         if self.base_settings.EXECUTOR == ExecutorType.WORKER:
@@ -161,7 +162,7 @@ class OrchestratorCore(FastAPI):
         )
 
     @staticmethod
-    def register_subscription_models(product_to_subscription_model_mapping: Dict[str, Type[SubscriptionModel]]) -> None:
+    def register_subscription_models(product_to_subscription_model_mapping: dict[str, type[SubscriptionModel]]) -> None:
         """Register your subscription models.
 
         This method is needed to register your subscription models inside the orchestrator core.

--- a/orchestrator/cli/database.py
+++ b/orchestrator/cli/database.py
@@ -14,7 +14,6 @@
 import json
 import os
 from shutil import copyfile
-from typing import List, Optional, Tuple, Union
 
 import jinja2
 import typer
@@ -199,10 +198,10 @@ def history(
 @app.command(help="Create revision based on diff_product_in_database.")
 def migrate_domain_models(
     message: str = typer.Argument(..., help="Migration name"),
-    test: Optional[bool] = typer.Option(False, help="Optional boolean if you don't want to generate a migration file"),
-    inputs: Optional[str] = typer.Option("{}", help="stringified dict to prefill inputs"),
-    updates: Optional[str] = typer.Option("{}", help="stringified dict to map updates instead of using inputs"),
-) -> Union[Tuple[List[str], List[str]], None]:
+    test: bool | None = typer.Option(False, help="Optional boolean if you don't want to generate a migration file"),
+    inputs: str | None = typer.Option("{}", help="stringified dict to prefill inputs"),
+    updates: str | None = typer.Option("{}", help="stringified dict to map updates instead of using inputs"),
+) -> tuple[list[str], list[str]] | None:
     """Create migration file based on SubscriptionModel.diff_product_in_database. BACKUP DATABASE BEFORE USING THE MIGRATION!.
 
     You will be prompted with inputs for new models and resource type updates.
@@ -268,8 +267,8 @@ def migrate_domain_models(
 @app.command(help="Create migration file based on diff workflows in db")
 def migrate_workflows(
     message: str = typer.Argument(..., help="Migration name"),
-    test: Optional[bool] = typer.Option(False, help="Optional boolean if you don't want to generate a migration file"),
-) -> Union[Tuple[List[dict], List[dict]], None]:
+    test: bool | None = typer.Option(False, help="Optional boolean if you don't want to generate a migration file"),
+) -> tuple[list[dict], list[dict]] | None:
     """Create a migration file based on the difference between workflows in the database and registered WorkflowInstances. BACKUP DATABASE BEFORE USING THE MIGRATION!.
 
     You will be prompted with inputs for new models and resource type updates.

--- a/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/fixed_input_helpers.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Set, Union
-
 from more_itertools import flatten
 from sqlalchemy import select
 from sqlalchemy.sql.expression import Delete, Insert, Update
@@ -13,7 +11,7 @@ from orchestrator.db import db
 from orchestrator.db.models import FixedInputTable
 
 
-def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Dict[str, str]]:
+def map_update_fixed_inputs(product_diffs: dict[str, dict[str, set[str]]]) -> dict[str, dict[str, str]]:
     """Map fixed inputs to update.
 
     Args:
@@ -31,7 +29,7 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
     """
     print_fmt("\nUpdate fixed inputs", flags=[COLOR.BOLD, COLOR.UNDERLINE])
 
-    def rename_map(product_name: str, product_diff: Dict[str, Set[str]]) -> Dict[str, str]:
+    def rename_map(product_name: str, product_diff: dict[str, set[str]]) -> dict[str, str]:
         db_props = list(product_diff.get("missing_fixed_inputs_in_model", []))
         model_props = list(product_diff.get("missing_fixed_inputs_in_db", []))
 
@@ -62,8 +60,8 @@ def map_update_fixed_inputs(product_diffs: Dict[str, Dict[str, Set[str]]]) -> Di
 
 
 def generate_create_fixed_inputs_sql(
-    fixed_inputs: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]], revert: bool = False
-) -> List[str]:
+    fixed_inputs: dict[str, set[str]], inputs: dict[str, dict[str, str]], revert: bool = False
+) -> list[str]:
     """Generate SQL to create fixed inputs.
 
     Args:
@@ -82,7 +80,7 @@ def generate_create_fixed_inputs_sql(
     print_fmt("\nCreate fixed inputs", flags=[COLOR.BOLD, COLOR.UNDERLINE])
 
     def create_fixed_input(fixed_input: str, product_names: set[str]) -> str:
-        def create_product_insert_dict(product_name: str) -> dict[str, Union[str, ScalarSelect]]:
+        def create_product_insert_dict(product_name: str) -> dict[str, str | ScalarSelect]:
             product_id_sql = get_product_id(product_name)
 
             if revert:
@@ -110,7 +108,7 @@ def generate_create_fixed_inputs_sql(
     return [create_fixed_input(*item) for item in fixed_inputs.items()]
 
 
-def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[str]:
+def generate_delete_fixed_inputs_sql(fixed_inputs: dict[str, set[str]]) -> list[str]:
     """Generate SQL to delete fixed inputs.
 
     Args:
@@ -121,7 +119,7 @@ def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[
     Returns: List of SQL strings to delete fixed inputs.
     """
 
-    def delete_fixed_input(fixed_input: str, product_names: Set[str]) -> str:
+    def delete_fixed_input(fixed_input: str, product_names: set[str]) -> str:
         product_ids_sql = get_product_ids(product_names)
         return str(
             sql_compile(
@@ -135,7 +133,7 @@ def generate_delete_fixed_inputs_sql(fixed_inputs: Dict[str, Set[str]]) -> List[
     return [delete_fixed_input(*item) for item in fixed_inputs.items()]
 
 
-def generate_update_fixed_inputs_sql(product_fixed_inputs: Dict[str, Dict[str, str]]) -> List[str]:
+def generate_update_fixed_inputs_sql(product_fixed_inputs: dict[str, dict[str, str]]) -> list[str]:
     """Generate SQL to update fixed inputs.
 
     Args:
@@ -146,7 +144,7 @@ def generate_update_fixed_inputs_sql(product_fixed_inputs: Dict[str, Dict[str, s
     Returns: List of SQL strings to update fixed inputs.
     """
 
-    def update_fixed_inputs(product_name: str, fixed_inputs: Dict[str, str]) -> List[str]:
+    def update_fixed_inputs(product_name: str, fixed_inputs: dict[str, str]) -> list[str]:
         product_id_sql = get_product_id(product_name)
 
         def update_fixed_input(old_name: str, new_name: str) -> str:

--- a/orchestrator/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/helpers.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from itertools import groupby
-from typing import Dict, Iterable, Set, Type
 
 import structlog
 from sqlalchemy.dialects import postgresql
@@ -17,7 +17,7 @@ def sql_compile(sql: UpdateBase) -> str:
     return sql_string
 
 
-def generic_mapper(prop_name: str, model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def generic_mapper(prop_name: str, model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     model_by_resource = [
         (prop_name_value, model_name)
         for model_name, diff in model_diffs.items()
@@ -27,29 +27,29 @@ def generic_mapper(prop_name: str, model_diffs: Dict[str, Dict[str, Set[str]]]) 
     return {k: {val[1] for val in v} for k, v in grouped}
 
 
-def map_create_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_create_fixed_inputs(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_fixed_inputs_in_db", model_diffs)
 
 
-def map_delete_fixed_inputs(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_delete_fixed_inputs(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_fixed_inputs_in_model", model_diffs)
 
 
-def map_create_resource_type_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_create_resource_type_relations(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_resource_types_in_db", model_diffs)
 
 
-def map_delete_resource_type_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_delete_resource_type_relations(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_resource_types_in_model", model_diffs)
 
 
-def map_create_product_block_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_create_product_block_relations(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_product_blocks_in_db", model_diffs)
 
 
-def map_delete_product_block_relations(model_diffs: Dict[str, Dict[str, Set[str]]]) -> Dict[str, Set[str]]:
+def map_delete_product_block_relations(model_diffs: dict[str, dict[str, set[str]]]) -> dict[str, set[str]]:
     return generic_mapper("missing_product_blocks_in_model", model_diffs)
 
 
-def get_product_block_names(pbs: list[Type[ProductBlockModel]]) -> Iterable[str]:
+def get_product_block_names(pbs: list[type[ProductBlockModel]]) -> Iterable[str]:
     return filter(None, (pb.name for pb in pbs))

--- a/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_block_helpers.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from itertools import chain
-from typing import Any, Dict, Generator, List, Set, Type, Union
+from typing import Any
 
 from more_itertools import flatten
 from sqlalchemy import select
@@ -24,7 +25,7 @@ def get_product_block_id(block_name: str) -> ScalarSelect:
     return get_product_block_ids([block_name])
 
 
-def get_product_block_ids(block_names: Union[List[str], Set[str]]) -> ScalarSelect:
+def get_product_block_ids(block_names: list[str] | set[str]) -> ScalarSelect:
     return select(ProductBlockTable.product_block_id).where(ProductBlockTable.name.in_(block_names)).scalar_subquery()
 
 
@@ -40,7 +41,7 @@ def get_subscription_instance(subscription_id: str, product_block_id: ScalarSele
     )
 
 
-def map_create_product_blocks(product_blocks: dict[str, Type[ProductBlockModel]]) -> dict[str, Type[ProductBlockModel]]:
+def map_create_product_blocks(product_blocks: dict[str, type[ProductBlockModel]]) -> dict[str, type[ProductBlockModel]]:
     """Map product blocks to create.
 
     Args:
@@ -55,7 +56,7 @@ def map_create_product_blocks(product_blocks: dict[str, Type[ProductBlockModel]]
     }
 
 
-def map_delete_product_blocks(product_blocks: Dict[str, Type[ProductBlockModel]]) -> Set[str]:
+def map_delete_product_blocks(product_blocks: dict[str, type[ProductBlockModel]]) -> set[str]:
     """Map product blocks to delete.
 
     Args:
@@ -90,8 +91,8 @@ def map_product_block_additional_relations(changes: DomainModelChanges) -> Domai
 
 
 def generate_create_product_blocks_sql(
-    create_product_blocks: Dict[str, Any], inputs: Dict[str, Dict[str, str]]
-) -> List[str]:
+    create_product_blocks: dict[str, Any], inputs: dict[str, dict[str, str]]
+) -> list[str]:
     """Generate SQL to create product blocks.
 
     Args:
@@ -125,7 +126,7 @@ def generate_create_product_blocks_sql(
     return [create_product_block(name) for name in create_product_blocks]
 
 
-def generate_delete_product_blocks_sql(delete_product_blocks: Set[str]) -> List[str]:
+def generate_delete_product_blocks_sql(delete_product_blocks: set[str]) -> list[str]:
     """Generate SQL to delete product blocks.
 
     Args:
@@ -146,7 +147,7 @@ def generate_delete_product_blocks_sql(delete_product_blocks: Set[str]) -> List[
     ]
 
 
-def generate_create_product_block_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+def generate_create_product_block_relations_sql(create_block_relations: dict[str, set[str]]) -> list[str]:
     """Generate SQL to create product block to product block relations.
 
     Args:
@@ -157,10 +158,10 @@ def generate_create_product_block_relations_sql(create_block_relations: Dict[str
     Returns: List of SQL to create relation between product blocks.
     """
 
-    def create_block_relation(depends_block_name: str, block_names: Set[str]) -> str:
+    def create_block_relation(depends_block_name: str, block_names: set[str]) -> str:
         depends_block_id_sql = get_product_block_id(depends_block_name)
 
-        def create_block_relation_dict(block_name: str) -> Dict[str, ScalarSelect]:
+        def create_block_relation_dict(block_name: str) -> dict[str, ScalarSelect]:
             block_id_sql = get_product_block_id(block_name)
             return {"in_use_by_id": block_id_sql, "depends_on_id": depends_block_id_sql}
 
@@ -170,7 +171,7 @@ def generate_create_product_block_relations_sql(create_block_relations: Dict[str
     return [create_block_relation(*item) for item in create_block_relations.items()]
 
 
-def generate_create_product_block_instance_relations_sql(product_block_relations: Dict[str, Set[str]]) -> List[str]:
+def generate_create_product_block_instance_relations_sql(product_block_relations: dict[str, set[str]]) -> list[str]:
     """Generate SQL to create resource type instance values for existing instances.
 
     Args:
@@ -182,11 +183,11 @@ def generate_create_product_block_instance_relations_sql(product_block_relations
     """
 
     def create_subscription_instance_relations(
-        depends_block_name: str, block_names: Set[str]
+        depends_block_name: str, block_names: set[str]
     ) -> Generator[str, None, None]:
         depends_block_id_sql = get_product_block_id(depends_block_name)
 
-        def map_subscription_instances(block_name: str) -> dict[str, list[dict[str, Union[str, ScalarSelect]]]]:
+        def map_subscription_instances(block_name: str) -> dict[str, list[dict[str, str | ScalarSelect]]]:
             in_use_by_id_sql = get_product_block_id(block_name)
             stmt = select(
                 SubscriptionInstanceTable.subscription_instance_id, SubscriptionInstanceTable.subscription_id
@@ -227,7 +228,7 @@ def generate_create_product_block_instance_relations_sql(product_block_relations
     )
 
 
-def generate_delete_product_block_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+def generate_delete_product_block_relations_sql(delete_block_relations: dict[str, set[str]]) -> list[str]:
     """Generate SQL to delete product block to product blocks relations.
 
     Args:
@@ -238,7 +239,7 @@ def generate_delete_product_block_relations_sql(delete_block_relations: Dict[str
     Returns: List of SQL to delete relations between product blocks.
     """
 
-    def delete_block_relation(delete_block_name: str, block_names: Set[str]) -> str:
+    def delete_block_relation(delete_block_name: str, block_names: set[str]) -> str:
         in_use_by_ids_sql = get_product_block_ids(block_names)
         delete_block_id_sql = get_product_block_id(delete_block_name)
 

--- a/orchestrator/cli/domain_gen_helpers/product_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/product_helpers.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from itertools import chain
-from typing import Dict, Generator, List, Set, Type, Union
 
 from sqlalchemy import select
 from sqlalchemy.sql.expression import Delete, Insert
@@ -26,7 +26,7 @@ def get_product_id(product_name: str) -> ScalarSelect:
     return get_product_ids([product_name])
 
 
-def get_product_ids(product_names: Union[list[str], set[str]]) -> ScalarSelect:
+def get_product_ids(product_names: list[str] | set[str]) -> ScalarSelect:
     return select(ProductTable.product_id).where(ProductTable.name.in_(product_names)).scalar_subquery()
 
 
@@ -53,8 +53,8 @@ def map_product_additional_relations(changes: DomainModelChanges) -> DomainModel
 
 
 def generate_create_products_sql(
-    create_products: Dict[str, Type[SubscriptionModel]], inputs: Dict[str, Dict[str, str]]
-) -> List[str]:
+    create_products: dict[str, type[SubscriptionModel]], inputs: dict[str, dict[str, str]]
+) -> list[str]:
     """Generate SQL to create products.
 
     Args:
@@ -127,7 +127,7 @@ def generate_delete_products_sql(delete_products: set[str]) -> list[str]:
             sql_compile(Delete(SubscriptionTable).where(SubscriptionTable.product_id.in_(product_ids))),
         ]
 
-    def delete_products_sql(product_names: Set[str]) -> str:
+    def delete_products_sql(product_names: set[str]) -> str:
         return sql_compile(Delete(ProductTable).where(ProductTable.name.in_(product_names)))
 
     sql_deletes = delete_product_relations_sql(delete_products)
@@ -135,7 +135,7 @@ def generate_delete_products_sql(delete_products: set[str]) -> list[str]:
     return sql_deletes
 
 
-def generate_create_product_relations_sql(create_block_relations: Dict[str, Set[str]]) -> List[str]:
+def generate_create_product_relations_sql(create_block_relations: dict[str, set[str]]) -> list[str]:
     """Generate SQL to create product relations to product blocks.
 
     Args:
@@ -146,10 +146,10 @@ def generate_create_product_relations_sql(create_block_relations: Dict[str, Set[
     Returns: List of SQL strings to create subscription instances.
     """
 
-    def create_block_relation(block_name: str, product_names: Set[str]) -> str:
+    def create_block_relation(block_name: str, product_names: set[str]) -> str:
         block_id_sql = get_product_block_id(block_name)
 
-        def create_block_relation_dict(product_name: str) -> Dict[str, ScalarSelect]:
+        def create_block_relation_dict(product_name: str) -> dict[str, ScalarSelect]:
             product_id_sql = get_product_id(product_name)
             return {"product_block_id": block_id_sql, "product_id": product_id_sql}
 
@@ -177,7 +177,7 @@ def generate_create_product_instance_relations_sql(product_to_block_relations: d
 
         def map_subscription_instance_relations(
             product_name: str,
-        ) -> Generator[Dict[str, Union[str, ScalarSelect]], None, None]:
+        ) -> Generator[dict[str, str | ScalarSelect], None, None]:
             product_id_sql = get_product_id(product_name)
             subscription_ids_stmt = select(SubscriptionTable.subscription_id).where(
                 SubscriptionTable.product_id.in_(product_id_sql)
@@ -200,7 +200,7 @@ def generate_create_product_instance_relations_sql(product_to_block_relations: d
     )
 
 
-def generate_delete_product_relations_sql(delete_block_relations: Dict[str, Set[str]]) -> List[str]:
+def generate_delete_product_relations_sql(delete_block_relations: dict[str, set[str]]) -> list[str]:
     """Generate SQL to delete product to product blocks relations.
 
     Args:
@@ -211,7 +211,7 @@ def generate_delete_product_relations_sql(delete_block_relations: Dict[str, Set[
     Returns: List of SQL strings to delete relations between product and product block.
     """
 
-    def delete_block_relation(delete_block_name: str, product_names: Set[str]) -> str:
+    def delete_block_relation(delete_block_name: str, product_names: set[str]) -> str:
         product_ids_sql = get_product_ids(product_names)
         block_id_sql = get_product_block_id(delete_block_name)
         return sql_compile(

--- a/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
+++ b/orchestrator/cli/domain_gen_helpers/resource_type_helpers.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple, Type, Union
 from uuid import UUID
 
 import structlog
@@ -32,7 +31,7 @@ def get_resource_type(resource_type: str) -> ScalarSelect:
     return get_resource_types([resource_type])
 
 
-def get_resource_types(resource_types: Union[List[str], Set[str]]) -> ScalarSelect:
+def get_resource_types(resource_types: list[str] | set[str]) -> ScalarSelect:
     return (
         select(ResourceTypeTable.resource_type_id)
         .where(ResourceTypeTable.resource_type.in_(resource_types))
@@ -59,8 +58,8 @@ def map_create_resource_types(resource_type_names: set[str], updated_resource_ty
 
 
 def find_resource_within_blocks(
-    resource_type_names: List[str], product_blocks: Dict[str, Type[ProductBlockModel]]
-) -> Set[str]:
+    resource_type_names: list[str], product_blocks: dict[str, type[ProductBlockModel]]
+) -> set[str]:
     """Find resource types within product blocks.
 
     Args:
@@ -74,9 +73,9 @@ def find_resource_within_blocks(
 
 
 def rename_resource_type_inputs(
-    resource_type_choices: Dict[str, Set[str]],
-    renamed_resource_types: Dict[str, str],
-) -> Tuple[Optional[str], Optional[str]]:
+    resource_type_choices: dict[str, set[str]],
+    renamed_resource_types: dict[str, str],
+) -> tuple[str | None, str | None]:
     old_resource_types = set(resource_type_choices.keys())
     noqa_print("Which resource type would you want to rename?")
     old_rt = _prompt_user_menu(
@@ -97,7 +96,7 @@ def rename_resource_type_inputs(
 
 def map_rename_resource_types(
     block_diffs: dict[str, dict[str, set[str]]],
-    product_blocks: dict[str, Type[ProductBlockModel]],
+    product_blocks: dict[str, type[ProductBlockModel]],
 ) -> dict[str, str]:
     """Map resource types to rename.
 
@@ -154,8 +153,8 @@ def map_rename_resource_types(
 
 
 def update_block_resource_type_input(
-    old_props: List[str], new_props: List[str], block_name: str
-) -> Tuple[Optional[str], Optional[str]]:
+    old_props: list[str], new_props: list[str], block_name: str
+) -> tuple[str | None, str | None]:
     noqa_print(f"Which resource type would you want to update in {block_name} Block?")
     old_rt = _prompt_user_menu(
         [*[(p, p) for p in old_props], ("continue", None)],
@@ -173,9 +172,9 @@ def update_block_resource_type_input(
 
 
 def map_update_product_block_resource_types(
-    block_diffs: Dict[str, Dict[str, Set[str]]],
-    renamed_resource_types: Dict[str, str],
-) -> Dict[str, Dict[str, str]]:
+    block_diffs: dict[str, dict[str, set[str]]],
+    renamed_resource_types: dict[str, str],
+) -> dict[str, dict[str, str]]:
     """Map resource types to update per product block.
 
     Args:
@@ -215,10 +214,10 @@ def map_update_product_block_resource_types(
 
 
 def map_delete_resource_types(
-    resource_types: Dict[str, Set[str]],
-    updated_resource_types: List[str],
-    product_blocks: Dict[str, Type[ProductBlockModel]],
-) -> Set[str]:
+    resource_types: dict[str, set[str]],
+    updated_resource_types: list[str],
+    product_blocks: dict[str, type[ProductBlockModel]],
+) -> set[str]:
     """Map resource types to delete.
 
     Args:
@@ -259,11 +258,11 @@ def get_block_instance_count(product_block_id: UUID) -> int:
 
 def _has_product_existing_instances(product_name: str) -> bool:
     stmt = select(ProductTable).where(ProductTable.name == product_name)
-    product: Optional[ProductTable] = db.session.scalars(stmt).first()
+    product: ProductTable | None = db.session.scalars(stmt).first()
     return bool(product and get_product_instance_count(product.product_id))
 
 
-def _find_new_relations(block_name: str, relations: Dict[str, Set[str]]) -> Set[str]:
+def _find_new_relations(block_name: str, relations: dict[str, set[str]]) -> set[str]:
     return set(flatten((list(v) for k, v in relations.items() if block_name in k)))
 
 
@@ -282,7 +281,7 @@ def map_create_resource_type_instances(changes: DomainModelChanges) -> dict[str,
 
     def _has_existing_instances(block_name: str) -> bool:
         stmt = select(ProductBlockTable).where(ProductBlockTable.name == block_name)
-        block: Optional[ProductBlockTable] = db.session.scalars(stmt).first()
+        block: ProductBlockTable | None = db.session.scalars(stmt).first()
         if block and get_block_instance_count(block.product_block_id):
             return True
 
@@ -300,8 +299,8 @@ def map_create_resource_type_instances(changes: DomainModelChanges) -> dict[str,
 
 
 def generate_create_resource_types_sql(
-    resource_types: Set[str], inputs: Dict[str, Dict[str, str]], revert: bool = False
-) -> List[str]:
+    resource_types: set[str], inputs: dict[str, dict[str, str]], revert: bool = False
+) -> list[str]:
     """Generate SQL to create resource types.
 
     Args:
@@ -333,7 +332,7 @@ def generate_create_resource_types_sql(
     return [create_resource_type(resource_type) for resource_type in resource_types]
 
 
-def generate_rename_resource_types_sql(resource_types: Dict[str, str]) -> List[str]:
+def generate_rename_resource_types_sql(resource_types: dict[str, str]) -> list[str]:
     """Generate SQL to update resource types.
 
     Args:
@@ -354,7 +353,7 @@ def generate_rename_resource_types_sql(resource_types: Dict[str, str]) -> List[s
     return [update_resource_type(*item) for item in resource_types.items()]
 
 
-def generate_delete_resource_types_sql(resource_types: Set[str]) -> List[str]:
+def generate_delete_resource_types_sql(resource_types: set[str]) -> list[str]:
     """Generate SQL to delete resource types.
 
     Args:
@@ -374,7 +373,7 @@ def generate_delete_resource_types_sql(resource_types: Set[str]) -> List[str]:
     ]
 
 
-def generate_create_resource_type_relations_sql(resource_types: Dict[str, Set[str]]) -> List[str]:
+def generate_create_resource_type_relations_sql(resource_types: dict[str, set[str]]) -> list[str]:
     """Generate SQL to create resource type relations.
 
     Args:
@@ -385,10 +384,10 @@ def generate_create_resource_type_relations_sql(resource_types: Dict[str, Set[st
     Returns: List of SQL strings to create relation between product blocks and resource type.
     """
 
-    def create_resource_type_relation(resource_type: str, block_names: Set[str]) -> str:
+    def create_resource_type_relation(resource_type: str, block_names: set[str]) -> str:
         resource_type_id_sql = get_resource_type(resource_type)
 
-        def create_block_relation_dict(block_name: str) -> Dict[str, Union[str, ScalarSelect]]:
+        def create_block_relation_dict(block_name: str) -> dict[str, str | ScalarSelect]:
             block_id_sql = get_product_block_id(block_name)
             return {"resource_type_id": resource_type_id_sql, "product_block_id": block_id_sql}
 
@@ -399,8 +398,8 @@ def generate_create_resource_type_relations_sql(resource_types: Dict[str, Set[st
 
 
 def generate_create_resource_type_instance_values_sql(
-    resource_types: Dict[str, Set[str]], inputs: Dict[str, Dict[str, str]]
-) -> List[str]:
+    resource_types: dict[str, set[str]], inputs: dict[str, dict[str, str]]
+) -> list[str]:
     """Generate SQL to create resource type instance values for existing instances.
 
     Args:
@@ -456,7 +455,7 @@ def generate_create_resource_type_instance_values_sql(
     ]
 
 
-def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str, Set[str]]) -> List[str]:
+def generate_delete_resource_type_relations_sql(delete_resource_types: dict[str, set[str]]) -> list[str]:
     """Generate SQL to delete resource type relations and its instance values.
 
     Args:
@@ -467,7 +466,7 @@ def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str,
     Returns: List of SQL strings to delete relations between product blocks and resource type.
     """
 
-    def delete_resource_type_relation(resource_type: str, block_names: Set[str]) -> List[str]:
+    def delete_resource_type_relation(resource_type: str, block_names: set[str]) -> list[str]:
         block_ids_sql = get_product_block_ids(block_names)
         resource_type_id_sql = get_resource_type(resource_type)
         subscription_instance_id_sql = (
@@ -493,7 +492,7 @@ def generate_delete_resource_type_relations_sql(delete_resource_types: Dict[str,
     return list(flatten([delete_resource_type_relation(*item) for item in delete_resource_types.items()]))
 
 
-def generate_update_resource_type_block_relations_sql(block_rt_updates: Dict[str, Dict[str, str]]) -> List[str]:
+def generate_update_resource_type_block_relations_sql(block_rt_updates: dict[str, dict[str, str]]) -> list[str]:
     """Generate SQL to update resource type block relations.
 
     Args:
@@ -506,7 +505,7 @@ def generate_update_resource_type_block_relations_sql(block_rt_updates: Dict[str
     Returns: List of SQL strings to update resource types.
     """
 
-    def update_block_resource_types(block_name: str, rt_updates: Dict[str, str]) -> List[str]:
+    def update_block_resource_types(block_name: str, rt_updates: dict[str, str]) -> list[str]:
         block_id_sql = get_product_block_id(block_name)
 
         def update_block_relation(old_rt_name: str, new_rt_name: str) -> str:
@@ -526,7 +525,7 @@ def generate_update_resource_type_block_relations_sql(block_rt_updates: Dict[str
     return list(flatten([update_block_resource_types(*item) for item in block_rt_updates.items()]))
 
 
-def generate_update_resource_type_instance_values_sql(block_rt_updates: Dict[str, Dict[str, str]]) -> List[str]:
+def generate_update_resource_type_instance_values_sql(block_rt_updates: dict[str, dict[str, str]]) -> list[str]:
     """Generate SQL to update resource type instance values.
 
     Args:

--- a/orchestrator/cli/domain_gen_helpers/types.py
+++ b/orchestrator/cli/domain_gen_helpers/types.py
@@ -1,29 +1,27 @@
-from typing import Dict, Set, Type
-
 from pydantic import BaseModel
 
 from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
 
 
 class DomainModelChanges(BaseModel):
-    create_products: Dict[str, Type[SubscriptionModel]] = {}
-    delete_products: Set[str] = set()
-    create_product_to_block_relations: Dict[str, Set[str]] = {}
-    delete_product_to_block_relations: Dict[str, Set[str]] = {}
-    create_product_blocks: Dict[str, Type[ProductBlockModel]] = {}
-    delete_product_blocks: Set[str] = set()
-    create_product_block_relations: Dict[str, Set[str]] = {}
-    delete_product_block_relations: Dict[str, Set[str]] = {}
-    create_product_fixed_inputs: Dict[str, Set[str]] = {}
-    update_product_fixed_inputs: Dict[str, Dict[str, str]] = {}
-    delete_product_fixed_inputs: Dict[str, Set[str]] = {}
-    create_resource_types: Set[str] = set()
-    rename_resource_types: Dict[str, str] = {}
-    update_block_resource_types: Dict[str, Dict[str, str]] = {}
-    delete_resource_types: Set[str] = set()
-    create_resource_type_relations: Dict[str, Set[str]] = {}
-    create_resource_type_instance_relations: Dict[str, Set[str]] = {}
-    delete_resource_type_relations: Dict[str, Set[str]] = {}
+    create_products: dict[str, type[SubscriptionModel]] = {}
+    delete_products: set[str] = set()
+    create_product_to_block_relations: dict[str, set[str]] = {}
+    delete_product_to_block_relations: dict[str, set[str]] = {}
+    create_product_blocks: dict[str, type[ProductBlockModel]] = {}
+    delete_product_blocks: set[str] = set()
+    create_product_block_relations: dict[str, set[str]] = {}
+    delete_product_block_relations: dict[str, set[str]] = {}
+    create_product_fixed_inputs: dict[str, set[str]] = {}
+    update_product_fixed_inputs: dict[str, dict[str, str]] = {}
+    delete_product_fixed_inputs: dict[str, set[str]] = {}
+    create_resource_types: set[str] = set()
+    rename_resource_types: dict[str, str] = {}
+    update_block_resource_types: dict[str, dict[str, str]] = {}
+    delete_resource_types: set[str] = set()
+    create_resource_type_relations: dict[str, set[str]] = {}
+    create_resource_type_instance_relations: dict[str, set[str]] = {}
+    delete_resource_type_relations: dict[str, set[str]] = {}
 
 
 class DuplicateError(Exception):
@@ -31,6 +29,6 @@ class DuplicateError(Exception):
 
 
 class ModelUpdates(BaseModel):
-    fixed_inputs: Dict[str, Dict[str, str]] = {}
-    resource_types: Dict[str, str] = {}
-    block_resource_types: Dict[str, Dict[str, str]] = {}
+    fixed_inputs: dict[str, dict[str, str]] = {}
+    resource_types: dict[str, str] = {}
+    block_resource_types: dict[str, dict[str, str]] = {}

--- a/orchestrator/cli/generate.py
+++ b/orchestrator/cli/generate.py
@@ -98,7 +98,7 @@ ConfigFile = typer.Option(..., "--config-file", "-cf", help="The configuration f
 DryRun = typer.Option(True, help="Dry run")
 TestDrivenDevelopment = typer.Option(True, "--tdd", help="Force test driven development with failing asserts")
 Force = typer.Option(False, "--force", "-f", help="Force overwrite of existing files")
-PythonVersion = typer.Option("3.9", "--python-version", "-p", help="Python version for generated code")
+PythonVersion = typer.Option("3.11", "--python-version", "-p", help="Python version for generated code")
 FolderPrefix = typer.Option("", "--folder-prefix", "-fp", help="Folder prefix, e.g. <folder-prefix>/workflows")
 CustomTemplates = typer.Option("", "--custom-templates", "-ct", help="Custom templates folder")
 

--- a/orchestrator/cli/generate.py
+++ b/orchestrator/cli/generate.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
-from typing import Dict, Optional
 
 import structlog
 import typer
@@ -31,7 +30,7 @@ logger = structlog.getLogger(__name__)
 app: typer.Typer = typer.Typer()
 
 
-def read_config(config_file: Path) -> Dict:
+def read_config(config_file: Path) -> dict:
     try:
         with open(config_file) as stream:
             try:
@@ -63,9 +62,7 @@ def write_file(path: Path, content: str, append: bool, force: bool) -> None:
         logger.info("wrote file", path=str(path), append=append, force=force)
 
 
-def create_context(
-    config_file: Path, dryrun: bool, force: bool, python_version: str, tdd: Optional[bool] = False
-) -> Dict:
+def create_context(config_file: Path, dryrun: bool, force: bool, python_version: str, tdd: bool | None = False) -> dict:
     def writer(path: Path, content: str, append: bool = False) -> None:
         if dryrun:
             logger.info("preview file", path=str(path), append=append, force=force, dryrun=dryrun)

--- a/orchestrator/cli/generator/generator/product_block.py
+++ b/orchestrator/cli/generator/generator/product_block.py
@@ -17,7 +17,7 @@ from collections.abc import Generator
 from importlib import import_module
 from os import listdir, path
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -86,7 +86,7 @@ def get_fields(product_block: dict) -> list[dict]:
 
 
 def get_lists_to_generate(fields: list[dict]) -> list[dict]:
-    def should_generate(type: str, list_type: Optional[str] = None, **kwargs: Any) -> bool:
+    def should_generate(type: str, list_type: str | None = None, **kwargs: Any) -> bool:
         return type == "list" and list_type not in ["str", "int", "bool", "UUID"]
 
     return [field for field in fields if should_generate(**field)]

--- a/orchestrator/cli/generator/generator/workflow.py
+++ b/orchestrator/cli/generator/generator/workflow.py
@@ -14,7 +14,7 @@
 from collections.abc import Callable
 from functools import partial, wraps
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 from jinja2 import Environment
@@ -63,7 +63,7 @@ def insert_lazy_workflow_instances(environment: Environment, config: dict, write
     if not path.exists():
         writer(path, "from orchestrator.workflows import LazyWorkflowInstance\n\n")
     if path.exists():  # if dryrun then path was not created above
-        with open(path, "r") as fp:
+        with open(path) as fp:
             if f"workflows.{variable}.create_{variable}" in fp.read():
                 logger.warning("not re-adding lazy workflows", product=variable)
             else:
@@ -130,7 +130,7 @@ def generate_shared_workflow_files(environment: Environment, config: dict, write
     writer(path, content)
 
 
-def generate_workflow(f: Optional[Callable] = None, workflow: Optional[str] = None) -> Callable:
+def generate_workflow(f: Callable | None = None, workflow: str | None = None) -> Callable:
     if f is None:
         return partial(generate_workflow, workflow=workflow)
 

--- a/orchestrator/cli/helpers/input_helpers.py
+++ b/orchestrator/cli/helpers/input_helpers.py
@@ -1,4 +1,5 @@
-from typing import Iterable, List, Optional, Set, Tuple, TypeVar, Union
+from collections.abc import Iterable
+from typing import TypeVar
 
 import structlog
 
@@ -18,13 +19,11 @@ def get_user_input(text: str, default: str = "", optional: bool = False) -> str:
             return default
 
 
-def _enumerate_menu_keys(items: Union[List, Set]) -> List[str]:
+def _enumerate_menu_keys(items: list | set) -> list[str]:
     return [str(i + 1) for i in range(len(items))]
 
 
-def _prompt_user_menu(
-    options: Iterable[Tuple[str, T]], keys: Optional[List[str]] = None, repeat: bool = True
-) -> Optional[T]:
+def _prompt_user_menu(options: Iterable[tuple[str, T]], keys: list[str] | None = None, repeat: bool = True) -> T | None:
     options_list = list(options)
     keys = keys or _enumerate_menu_keys(options_list)
     done = False

--- a/orchestrator/cli/helpers/print_helpers.py
+++ b/orchestrator/cli/helpers/print_helpers.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Iterable
+from collections.abc import Callable, Iterable
+from typing import Any
 
 from orchestrator.types import strEnum
 

--- a/orchestrator/cli/migrate_workflows.py
+++ b/orchestrator/cli/migrate_workflows.py
@@ -1,6 +1,7 @@
 import itertools
 import operator
-from typing import Dict, Iterable, List, Tuple, TypeVar
+from collections.abc import Iterable
+from typing import TypeVar
 
 import structlog
 from sqlalchemy import select
@@ -29,7 +30,7 @@ logger = structlog.get_logger(__name__)
 T = TypeVar("T")
 
 
-def _print_workflows_table(workflows: List[WorkflowTable]) -> None:
+def _print_workflows_table(workflows: list[WorkflowTable]) -> None:
     items = [(wf.name, wf.target, wf.description, wf.products[0].product_type) for wf in workflows if wf.products]
     print_fmt(
         tabulate(
@@ -41,7 +42,7 @@ def _print_workflows_table(workflows: List[WorkflowTable]) -> None:
     )
 
 
-def _add_workflow(workflows: Dict[str, LazyWorkflowInstance], state: dict) -> dict:
+def _add_workflow(workflows: dict[str, LazyWorkflowInstance], state: dict) -> dict:
     print_fmt("\nAdd new workflow\n", flags=[COLOR.UNDERLINE])
 
     if not workflows:
@@ -139,7 +140,7 @@ def _show_state(state: dict) -> dict:
     return state
 
 
-def delete_dangling_workflows(workflows: List[WorkflowTable], state: dict) -> dict:
+def delete_dangling_workflows(workflows: list[WorkflowTable], state: dict) -> dict:
     if not workflows:
         noqa_print("No dangling workflows found.")
         return state
@@ -173,7 +174,7 @@ def delete_dangling_workflows(workflows: List[WorkflowTable], state: dict) -> di
     return {**state, "workflows_to_delete": [*state["workflows_to_delete"], *items]}
 
 
-def create_workflows_migration_wizard() -> Tuple[List[dict], List[dict]]:
+def create_workflows_migration_wizard() -> tuple[list[dict], list[dict]]:
     """Create tuple with lists for workflows to add and delete.
 
     Returns tuple:

--- a/orchestrator/db/__init__.py
+++ b/orchestrator/db/__init__.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from structlog import get_logger
 
@@ -40,7 +40,7 @@ logger = get_logger(__name__)
 
 
 class WrappedDatabase:
-    def __init__(self, wrappee: Optional[Database] = None) -> None:
+    def __init__(self, wrappee: Database | None = None) -> None:
         self.wrapped_database = wrappee
 
     def update(self, wrappee: Database) -> None:

--- a/orchestrator/db/database.py
+++ b/orchestrator/db/database.py
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Callable, ClassVar, Dict, Generator, Iterator, List, Optional, Set, cast
+from typing import Any, ClassVar, cast
 from uuid import uuid4
 
 import structlog
@@ -62,10 +63,10 @@ class _Base:
 
     __abstract__ = True
 
-    _json_include: List = []
-    _json_exclude: List = []
+    _json_include: list = []
+    _json_exclude: list = []
 
-    def __json__(self, excluded_keys: Set = set()) -> Dict:  # noqa: B006
+    def __json__(self, excluded_keys: set = set()) -> dict:  # noqa: B006
         ins: Any = sa_inspect(self)
 
         columns = set(ins.mapper.column_attrs.keys())
@@ -193,7 +194,7 @@ class Database:
         self.scoped_session = scoped_session(self.session_factory, self._scopefunc)
         BaseModel.set_query(cast(SearchQuery, self.scoped_session.query_property()))
 
-    def _scopefunc(self) -> Optional[str]:
+    def _scopefunc(self) -> str | None:
         return self.request_context.get()
 
     @property

--- a/orchestrator/db/filters/filters.py
+++ b/orchestrator/db/filters/filters.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Iterator, Protocol
+from collections.abc import Callable, Iterator
+from typing import Any, Protocol
 
 from more_itertools import partition
 from pydantic import BaseModel

--- a/orchestrator/db/filters/generic_filters/bool_filter.py
+++ b/orchestrator/db/filters/generic_filters/bool_filter.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import ColumnClause
 

--- a/orchestrator/db/filters/generic_filters/is_like_filter.py
+++ b/orchestrator/db/filters/generic_filters/is_like_filter.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import ColumnClause, String, cast
 

--- a/orchestrator/db/filters/generic_filters/range_filter.py
+++ b/orchestrator/db/filters/generic_filters/range_filter.py
@@ -10,9 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Callable
 from datetime import datetime
 from functools import partial
-from typing import Callable, Optional
 
 import pytz
 from dateutil.parser import parse
@@ -68,7 +68,7 @@ def generic_range_filter(range_type_fn: Callable, field: ColumnClause) -> Callab
 
 
 def generic_range_filters(
-    column: ColumnClause, column_alias: Optional[str] = None
+    column: ColumnClause, column_alias: str | None = None
 ) -> dict[str, Callable[[QueryType, str], QueryType]]:
     column_name = to_camel(column_alias or column.name)
 

--- a/orchestrator/db/filters/generic_filters/values_in_column_filter.py
+++ b/orchestrator/db/filters/generic_filters/values_in_column_filter.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import ColumnClause, func
 

--- a/orchestrator/db/filters/process.py
+++ b/orchestrator/db/filters/process.py
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from http import HTTPStatus
-from typing import Callable
 from uuid import UUID
 
 import structlog

--- a/orchestrator/db/filters/product.py
+++ b/orchestrator/db/filters/product.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from sqlalchemy import BinaryExpression

--- a/orchestrator/db/filters/product_block.py
+++ b/orchestrator/db/filters/product_block.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from sqlalchemy import BinaryExpression

--- a/orchestrator/db/filters/resource_type.py
+++ b/orchestrator/db/filters/resource_type.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from sqlalchemy import BinaryExpression, inspect

--- a/orchestrator/db/filters/search_filters/__init__.py
+++ b/orchestrator/db/filters/search_filters/__init__.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from sqlalchemy import inspect
 
 from orchestrator.db.database import BaseModel
@@ -11,7 +9,7 @@ from orchestrator.utils.helpers import to_camel
 from orchestrator.utils.search_query import WhereCondGenerator
 
 
-def default_inferred_column_clauses(table: Type[BaseModel]) -> dict[str, WhereCondGenerator]:
+def default_inferred_column_clauses(table: type[BaseModel]) -> dict[str, WhereCondGenerator]:
     return {
         k: inferred_filter(column)
         for key, column in getattr(inspect(table), "columns", {}).items()

--- a/orchestrator/db/filters/search_filters/inferred_filter.py
+++ b/orchestrator/db/filters/search_filters/inferred_filter.py
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import uuid
+from collections.abc import Callable
 from datetime import datetime
-from typing import Callable
 
 from sqlalchemy import BinaryExpression, Cast, ColumnClause, ColumnElement, String, cast
 from sqlalchemy.sql.functions import coalesce

--- a/orchestrator/db/filters/subscription.py
+++ b/orchestrator/db/filters/subscription.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from sqlalchemy import func

--- a/orchestrator/db/filters/workflow.py
+++ b/orchestrator/db/filters/workflow.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from sqlalchemy import BinaryExpression

--- a/orchestrator/db/sorting/process.py
+++ b/orchestrator/db/sorting/process.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import Column, Select
 from sqlalchemy.inspection import inspect

--- a/orchestrator/db/sorting/sorting.py
+++ b/orchestrator/db/sorting/sorting.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable, Iterator
 from enum import Enum
-from typing import Callable, Iterator, TypeVar, Union
+from typing import TypeVar, Union
 
 import strawberry
 from more_itertools import partition

--- a/orchestrator/db/sorting/subscription.py
+++ b/orchestrator/db/sorting/subscription.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from sqlalchemy import Column
 from sqlalchemy.inspection import inspect

--- a/orchestrator/devtools/populator.py
+++ b/orchestrator/devtools/populator.py
@@ -14,9 +14,10 @@
 
 import copy
 import os
+from collections.abc import Iterable
 from http import HTTPStatus
 from time import sleep
-from typing import Any, Iterable, TypedDict, Union
+from typing import Any, TypedDict, Union
 from uuid import UUID
 
 import jsonref
@@ -96,7 +97,7 @@ def get_input_field_types(input_field: JSONSchema) -> Iterable[str]:
         ['foo', 'bar']
     """
 
-    def yield_type(v: Union[dict, JSONSchema]) -> Iterable[str]:
+    def yield_type(v: dict | JSONSchema) -> Iterable[str]:
         if "type" in v:
             yield v["type"]
 
@@ -354,9 +355,7 @@ class Populator:
         product_id = self._product.get("product_id")
         return self._start_workflow(self.create_workflow, product=product_id, **kwargs)
 
-    def start_modify_workflow(
-        self, workflow_name: str, subscription_id: Union[UUIDstr, UUID], **kwargs: Any
-    ) -> UUIDstr:
+    def start_modify_workflow(self, workflow_name: str, subscription_id: UUIDstr | UUID, **kwargs: Any) -> UUIDstr:
         """Start a modify workflow for the provided name and subscription_id.
 
         Args:
@@ -372,13 +371,13 @@ class Populator:
         self.log.info("Started modify workflow")
         return self._start_workflow(workflow_name, subscription_id=subscription_id, **kwargs)
 
-    def start_verify_workflow(self, workflow_name: str, subscription_id: Union[UUIDstr, UUID]) -> UUIDstr:
+    def start_verify_workflow(self, workflow_name: str, subscription_id: UUIDstr | UUID) -> UUIDstr:
         subscription_id = str(subscription_id)
         self.log = self.log.bind(subscription_id=subscription_id)
         self.log.info("Started verify workflow")
         return self._start_workflow(workflow_name, subscription_id=subscription_id)
 
-    def start_terminate_workflow(self, subscription_id: Union[UUIDstr, UUID], **kwargs: Any) -> UUIDstr:
+    def start_terminate_workflow(self, subscription_id: UUIDstr | UUID, **kwargs: Any) -> UUIDstr:
         """Start a terminate workflow for the provided subscription_id.
 
         Args:
@@ -427,11 +426,11 @@ class Populator:
         self.log.error("Cowardly quitting due to unknown status", status=self.last_state["status"])
         raise Exception(f"Unknown status: {status}")
 
-    def get_current_form(self) -> Union[JSONSchema, None]:
+    def get_current_form(self) -> JSONSchema | None:
         self.log.info("Current form.", form=self.last_state.get("form"))
         return copy.deepcopy(self.last_state.get("form"))
 
-    def provide_user_input(self, method: str, url: URL, form: Union[JSONSchema, None] = None) -> requests.Response:
+    def provide_user_input(self, method: str, url: URL, form: JSONSchema | None = None) -> requests.Response:
         """Provide input for steps that normally require a user."""
         self.log.info("Providing user input.")
 

--- a/orchestrator/distlock/__init__.py
+++ b/orchestrator/distlock/__init__.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 from structlog import get_logger
 
@@ -20,12 +20,12 @@ from orchestrator.settings import AppSettings
 logger = get_logger(__name__)
 
 
-async def empty_fn(*args: tuple, **kwargs: Dict[str, Any]) -> None:
+async def empty_fn(*args: tuple, **kwargs: dict[str, Any]) -> None:
     return
 
 
 class WrappedDistLockManager:
-    def __init__(self, wrappee: Optional[DistLockManager] = None) -> None:
+    def __init__(self, wrappee: DistLockManager | None = None) -> None:
         self.wrapped_distlock_manager = wrappee
 
     def update(self, wrappee: DistLockManager) -> None:

--- a/orchestrator/distlock/distlock_manager.py
+++ b/orchestrator/distlock/distlock_manager.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Union
+from typing import Union
 
 from pydantic import RedisDsn
 
@@ -33,9 +33,9 @@ class DistLockManager:
     implementation must release it.
     """
 
-    _backend: Union[MemoryDistLockManager, RedisDistLockManager]
+    _backend: MemoryDistLockManager | RedisDistLockManager
 
-    def __init__(self, enabled: bool, backend: Optional[str] = None, redis_dsn: Optional[RedisDsn] = None):
+    def __init__(self, enabled: bool, backend: str | None = None, redis_dsn: RedisDsn | None = None):
         self.enabled = enabled
         self.connected = False
         if backend == "redis" and redis_dsn:
@@ -53,7 +53,7 @@ class DistLockManager:
             await self._backend.disconnect_redis()
             self.connected = False
 
-    async def get_lock(self, resource: str, expiration_seconds: int) -> Optional[DistLock]:
+    async def get_lock(self, resource: str, expiration_seconds: int) -> DistLock | None:
         return await self._backend.get_lock(resource, expiration_seconds)
 
     async def release_lock(self, resource: DistLock) -> None:

--- a/orchestrator/distlock/managers/memory_distlock_manager.py
+++ b/orchestrator/distlock/managers/memory_distlock_manager.py
@@ -13,7 +13,7 @@
 import asyncio
 from threading import Lock, Thread
 from time import sleep, time
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from structlog import get_logger
 
@@ -30,7 +30,7 @@ class MemoryDistLockManager(Thread):
     """
 
     manager_lock: Lock = Lock()
-    locks: Dict[str, Tuple[Lock, float]] = {}
+    locks: dict[str, tuple[Lock, float]] = {}
 
     def __init__(self) -> None:
         super().__init__()
@@ -44,7 +44,9 @@ class MemoryDistLockManager(Thread):
     async def disconnect_redis(self) -> None:
         pass
 
-    async def get_lock(self, resource: str, expiration_seconds: int) -> Optional[Lock]:
+    async def get_lock(
+        self, resource: str, expiration_seconds: int
+    ) -> Optional[Lock]:  # https://github.com/python/cpython/issues/114315
         with self.manager_lock:
             resource_lock, expire_at = self.locks.get(resource, (Lock(), time() + expiration_seconds))
             if not resource_lock.acquire(blocking=False):

--- a/orchestrator/distlock/managers/redis_distlock_manager.py
+++ b/orchestrator/distlock/managers/redis_distlock_manager.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from pydantic import RedisDsn
 from redis import Redis
@@ -34,7 +33,7 @@ class RedisDistLockManager:
     namespace = "orchestrator:distlock"
 
     def __init__(self, redis_address: RedisDsn):
-        self.redis_conn: Optional[AIORedis] = None
+        self.redis_conn: AIORedis | None = None
         self.redis_address = redis_address
 
     async def connect_redis(self) -> None:
@@ -44,7 +43,7 @@ class RedisDistLockManager:
         if self.redis_conn:
             await self.redis_conn.close()
 
-    async def get_lock(self, resource: str, expiration_seconds: int) -> Optional[Lock]:
+    async def get_lock(self, resource: str, expiration_seconds: int) -> Lock | None:
         if not self.redis_conn:
             return None
 
@@ -77,7 +76,7 @@ class RedisDistLockManager:
 
     # https://github.com/aio-libs/aioredis-py/issues/1273
     def release_sync(self, lock: Lock) -> None:
-        redis_conn: Optional[Redis] = None
+        redis_conn: Redis | None = None
         try:
             redis_conn = Redis.from_url(str(app_settings.CACHE_URI))
             sync_lock: SyncLock = SyncLock(

--- a/orchestrator/domain/__init__.py
+++ b/orchestrator/domain/__init__.py
@@ -11,12 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Type
 
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.utils.docs import make_product_type_index_doc
 
-SUBSCRIPTION_MODEL_REGISTRY: Dict[str, Type[SubscriptionModel]] = {}
+SUBSCRIPTION_MODEL_REGISTRY: dict[str, type[SubscriptionModel]] = {}
 
 __doc__ = make_product_type_index_doc(SUBSCRIPTION_MODEL_REGISTRY)
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -11,10 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
-import sys
 import warnings
 from collections import defaultdict
 from datetime import datetime
+from inspect import get_annotations
 from itertools import groupby, zip_longest
 from operator import attrgetter
 from typing import (
@@ -169,19 +169,6 @@ class DomainModel(BaseModel):
         """Make and store a list of resource_type fields and product block fields."""
         cls._non_product_block_fields_ = {}
         cls._product_block_fields_ = {}
-
-        if sys.version_info >= (3, 10):
-            from inspect import get_annotations
-        else:
-            # python 3.9 compatibility
-            def get_annotations(obj: Any) -> dict:
-                if hasattr(obj, "__annotations__"):
-                    return obj.__annotations__
-
-                if isinstance(obj, type) and "__annotations__" in obj.__dict__:
-                    return obj.__dict__["__annotations__"]
-
-                raise Exception(f"Cannot resolve type annotations for object {obj!r}")
 
         annotations = get_annotations(cls)
 

--- a/orchestrator/domain/helpers.py
+++ b/orchestrator/domain/helpers.py
@@ -1,9 +1,9 @@
-from typing import Iterable, Tuple, Union
+from collections.abc import Iterable
 
 from orchestrator.types import filter_nonetype, get_origin_and_args, is_union_type
 
 
-def _to_product_block_field_type_iterable(product_block_field_type: Union[type, Tuple[type]]) -> Iterable[type]:
+def _to_product_block_field_type_iterable(product_block_field_type: type | tuple[type]) -> Iterable[type]:
     """Return an iterable of types in the given product block field.
 
     Notes:

--- a/orchestrator/domain/lifecycle.py
+++ b/orchestrator/domain/lifecycle.py
@@ -11,12 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import strawberry
 import structlog
 
 from orchestrator.types import SubscriptionLifecycle, strEnum
+
+if TYPE_CHECKING:
+    from orchestrator.domain.base import DomainModel
 
 logger = structlog.get_logger(__name__)
 
@@ -29,31 +32,34 @@ class ProductLifecycle(strEnum):
     END_OF_LIFE = "end of life"
 
 
-_sub_type_per_lifecycle: Dict[Tuple[Type, Optional[SubscriptionLifecycle]], Type] = {}
+_sub_type_per_lifecycle: dict[tuple[type["DomainModel"], SubscriptionLifecycle | None], type] = {}
 
 
-def register_specialized_type(cls: Type, lifecycle: Optional[List[SubscriptionLifecycle]] = None) -> None:
+def register_specialized_type(cls: type["DomainModel"], lifecycle: list[SubscriptionLifecycle] | None = None) -> None:
+    if not (base_type := cls.__base_type__):
+        raise ValueError("Cannot register a type that has no __base_type__")
+
     if lifecycle:
         for lifecycle_state in lifecycle:
-            _sub_type_per_lifecycle[(cls.__base_type__, lifecycle_state)] = cls
+            _sub_type_per_lifecycle[(base_type, lifecycle_state)] = cls
     else:
-        _sub_type_per_lifecycle[(cls.__base_type__, None)] = cls
+        _sub_type_per_lifecycle[(base_type, None)] = cls
 
 
-def lookup_specialized_type(block: Type, lifecycle: Optional[SubscriptionLifecycle]) -> Type:
-    if not hasattr(block, "__base_type__"):
-        raise ValueError("Cannot instantiate a class that has no __base_type__ attribute")
+def lookup_specialized_type(cls: type["DomainModel"], lifecycle: SubscriptionLifecycle | None) -> type:
+    if not (base_type := cls.__base_type__):
+        raise ValueError("Cannot instantiate a class that has no __base_type__")
 
-    specialized_block = _sub_type_per_lifecycle.get((block.__base_type__, lifecycle), None)
+    specialized_block = _sub_type_per_lifecycle.get((base_type, lifecycle), None)
     if specialized_block is None:
-        specialized_block = _sub_type_per_lifecycle.get((block.__base_type__, None), None)
+        specialized_block = _sub_type_per_lifecycle.get((base_type, None), None)
     if specialized_block is None:
-        specialized_block = block
+        specialized_block = cls
     return specialized_block
 
 
 def validate_lifecycle_status(
-    product_block_field_name: str, product_block_field_type: Type, lifecycle_status: SubscriptionLifecycle
+    product_block_field_name: str, product_block_field_type: type, lifecycle_status: SubscriptionLifecycle
 ) -> None:
     specialized_type = lookup_specialized_type(product_block_field_type, lifecycle_status)
     if not issubclass(product_block_field_type, specialized_type):
@@ -65,7 +71,7 @@ def validate_lifecycle_status(
 
 
 if TYPE_CHECKING:
-    from orchestrator.domain.base import SubscriptionModel
+    from orchestrator.domain.base import DomainModel, SubscriptionModel
 else:
     SubscriptionModel = None
     DomainModel = None

--- a/orchestrator/forms/network_type_validators.py
+++ b/orchestrator/forms/network_type_validators.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 
 
-from typing import Any, Optional
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_serializer, model_validator
-from typing_extensions import Annotated
 
 
 class BFD(BaseModel):
@@ -23,8 +22,8 @@ class BFD(BaseModel):
 
     # order matters, this should be first
     enabled: bool
-    minimum_interval: Optional[Annotated[int, Field(ge=1, le=255000)]] = 900
-    multiplier: Optional[Annotated[int, Field(ge=1, le=255)]] = 3
+    minimum_interval: Annotated[int, Field(ge=1, le=255000)] | None = 900
+    multiplier: Annotated[int, Field(ge=1, le=255)] | None = 3
 
     @model_validator(mode="after")
     def check_optional_fields(self) -> "BFD":

--- a/orchestrator/forms/validators.py
+++ b/orchestrator/forms/validators.py
@@ -10,8 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Sequence
 from functools import partial
-from typing import Annotated, Any, List, Optional, Sequence, Type
+from typing import Annotated, Any
 from uuid import UUID
 
 import structlog
@@ -97,7 +98,7 @@ def _validate_in_products(product_ids: set[UUID], id_: UUID) -> UUID:
 ProductId = Annotated[UUID, AfterValidator(_validate_is_product), Field(json_schema_extra={"format": "productId"})]
 
 
-def product_id(product_ids: Optional[List[UUID]] = None) -> Type[ProductId]:
+def product_id(product_ids: list[UUID] | None = None) -> type[ProductId]:
     schema = {"uniforms": {"productIds": product_ids}} if product_ids else {}
     return Annotated[  # type: ignore[return-value]
         ProductId,

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -13,7 +13,7 @@
 
 import inspect
 from enum import Enum, EnumMeta
-from typing import Any, Type, Union
+from typing import Any
 
 import strawberry
 import structlog
@@ -43,7 +43,7 @@ def is_enum(field: Any) -> bool:
     return inspect.isclass(field) and issubclass(field, Enum)
 
 
-def create_strawberry_enums(model: Type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:
+def create_strawberry_enums(model: type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:
     enums = {
         key: create_strawberry_enum(field)
         for key, field in model._non_product_block_fields_.items()
@@ -63,8 +63,8 @@ def graphql_subscription_name(name: str) -> str:
 
 def create_block_strawberry_type(
     strawberry_name: str,
-    model: Type[DomainModel],
-) -> Type[StrawberryTypeFromPydantic[DomainModel]]:
+    model: type[DomainModel],
+) -> type[StrawberryTypeFromPydantic[DomainModel]]:
     from strawberry.federation.schema_directives import Key
     from strawberry.unset import UNSET
 
@@ -80,7 +80,7 @@ def create_block_strawberry_type(
     return strawberry_wrapper(new_type)
 
 
-def create_subscription_strawberry_type(strawberry_name: str, model: Type[DomainModel], interface: Type) -> Type:
+def create_subscription_strawberry_type(strawberry_name: str, model: type[DomainModel], interface: type) -> type:
     base_type = type(strawberry_name, (interface,), {})
     directives = [Key(fields="subscriptionId", resolvable=UNSET)]
 
@@ -92,10 +92,10 @@ def create_subscription_strawberry_type(strawberry_name: str, model: Type[Domain
 
 def add_class_to_strawberry(
     model_name: str,
-    model: Type[DomainModel],
+    model: type[DomainModel],
     strawberry_models: StrawberryModelType,
     strawberry_enums: EnumDict,
-    interface: Union[Type, None] = None,
+    interface: type | None = None,
 ) -> None:
     if model_name in strawberry_models:
         logger.debug("Skip already registered strawberry model", model=repr(model), strawberry_name=model_name)
@@ -118,7 +118,7 @@ def add_class_to_strawberry(
 
 
 def register_domain_models(
-    interface: Union[Type, None], existing_models: Union[StrawberryModelType, None] = None
+    interface: type | None, existing_models: StrawberryModelType | None = None
 ) -> StrawberryModelType:
     strawberry_models = existing_models if existing_models else {}
     strawberry_enums: EnumDict = {}

--- a/orchestrator/graphql/extensions/deprecation_checker_extension.py
+++ b/orchestrator/graphql/extensions/deprecation_checker_extension.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Type, Union
+from typing import Any
 
 import structlog
 from graphql import GraphQLField, GraphQLResolveInfo
@@ -39,7 +39,7 @@ def get_root_path(path: Path) -> Path:
     return path
 
 
-def get_field_deprecation(info: GraphQLResolveInfo) -> Union[str, None]:
+def get_field_deprecation(info: GraphQLResolveInfo) -> str | None:
     field = info.parent_type.fields.get(info.field_name)
     if isinstance(field, GraphQLField):
         return field.deprecation_reason
@@ -94,10 +94,10 @@ def get_deprecated_paths(type_definition: TypeDefinition) -> DeprecatedPaths:
 
 
 def make_deprecation_checker_extension(
-    query: Union[Type, None] = None, mutation: Union[Type, None] = None
+    query: type | None = None, mutation: type | None = None
 ) -> type[DeprecationCheckerExtension]:
-    def deprecations_for(_type: Union[Type, None]) -> DeprecatedPaths:
-        type_def: Union[TypeDefinition, None] = getattr(_type, "__strawberry_definition__", None) if _type else None
+    def deprecations_for(_type: type | None) -> DeprecatedPaths:
+        type_def: TypeDefinition | None = getattr(_type, "__strawberry_definition__", None) if _type else None
         if not type_def:
             return {}
         return get_deprecated_paths(type_def) if type_def else {}

--- a/orchestrator/graphql/extensions/error_collector_extension.py
+++ b/orchestrator/graphql/extensions/error_collector_extension.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 from collections.abc import Generator
 from contextvars import ContextVar
-from typing import Optional
 
 import structlog
 from graphql import GraphQLError
@@ -20,7 +19,7 @@ from strawberry.extensions import SchemaExtension
 
 logger = structlog.get_logger(__name__)
 
-error_bucket: ContextVar[Optional[list[GraphQLError]]] = ContextVar("error_bucket", default=None)
+error_bucket: ContextVar[list[GraphQLError] | None] = ContextVar("error_bucket", default=None)
 
 
 class ErrorCollectorExtension(SchemaExtension):

--- a/orchestrator/graphql/pagination.py
+++ b/orchestrator/graphql/pagination.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Generic, List, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
 import strawberry
 
@@ -46,11 +46,11 @@ class PageInfo:
 
     has_next_page: bool
     has_previous_page: bool
-    start_cursor: Union[int, None]
-    end_cursor: Union[int, None]
-    total_items: Union[int, None]
-    sort_fields: List[str]
-    filter_fields: List[str]
+    start_cursor: int | None
+    end_cursor: int | None
+    total_items: int | None
+    sort_fields: list[str]
+    filter_fields: list[str]
 
 
 @strawberry.type(description="An edge may contain additional information of the relationship")

--- a/orchestrator/graphql/resolvers/customer.py
+++ b/orchestrator/graphql/resolvers/customer.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from orchestrator.graphql.pagination import Connection
 from orchestrator.graphql.schemas.customer import CustomerType
 from orchestrator.graphql.types import GraphqlFilter, GraphqlSort, OrchestratorInfo
@@ -9,8 +7,8 @@ from orchestrator.settings import app_settings
 
 async def resolve_customer(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 1,
     after: int = 0,
 ) -> Connection[CustomerType]:

--- a/orchestrator/graphql/resolvers/helpers.py
+++ b/orchestrator/graphql/resolvers/helpers.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Type, Union
+from collections.abc import Sequence
 
 from sqlalchemy import CompoundSelect, Select, select
 
@@ -6,9 +6,7 @@ from orchestrator.db import db
 from orchestrator.db.database import BaseModel
 
 
-def rows_from_statement(
-    stmt: Union[Select, CompoundSelect], base_table: Type[BaseModel], unique: bool = False
-) -> Sequence:
+def rows_from_statement(stmt: Select | CompoundSelect, base_table: type[BaseModel], unique: bool = False) -> Sequence:
     """Helper function to handle some tricky cases with sqlalchemy types."""
     # Tell SQLAlchemy that the rows must be objects of type `base_table`for CompoundSelect
     rewritten_stmt = select(base_table).from_statement(stmt) if isinstance(stmt, CompoundSelect) else stmt

--- a/orchestrator/graphql/resolvers/process.py
+++ b/orchestrator/graphql/resolvers/process.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import structlog
 from pydantic.alias_generators import to_camel as to_lower_camel
@@ -56,11 +55,11 @@ def _enrich_process(process: ProcessTable, with_details: bool = False) -> Proces
 
 async def resolve_processes(
     info: OrchestratorInfo,
-    filter_by: Optional[list[GraphqlFilter]] = None,
-    sort_by: Optional[list[GraphqlSort]] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[ProcessType]:
     _error_handler = create_resolver_error_handler(info)
     pydantic_filter_by: list[Filter] = [item.to_pydantic() for item in filter_by] if filter_by else []

--- a/orchestrator/graphql/resolvers/product.py
+++ b/orchestrator/graphql/resolvers/product.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import structlog
 from sqlalchemy import func, select
 
@@ -22,11 +20,11 @@ logger = structlog.get_logger(__name__)
 
 async def resolve_products(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[ProductType]:
     _error_handler = create_resolver_error_handler(info)
 

--- a/orchestrator/graphql/resolvers/product_block.py
+++ b/orchestrator/graphql/resolvers/product_block.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import structlog
 from sqlalchemy import func, select
 
@@ -26,11 +24,11 @@ logger = structlog.get_logger(__name__)
 
 async def resolve_product_blocks(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[ProductBlock]:
     _error_handler = create_resolver_error_handler(info)
 

--- a/orchestrator/graphql/resolvers/resource_type.py
+++ b/orchestrator/graphql/resolvers/resource_type.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import structlog
 from sqlalchemy import func, select
 
@@ -26,11 +24,11 @@ logger = structlog.get_logger(__name__)
 
 async def resolve_resource_types(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[ResourceType]:
     _error_handler = create_resolver_error_handler(info)
 

--- a/orchestrator/graphql/resolvers/settings.py
+++ b/orchestrator/graphql/resolvers/settings.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import strawberry
 import structlog
 from redis.asyncio import Redis as AIORedis
@@ -58,7 +56,7 @@ def resolve_settings(info: OrchestratorInfo) -> StatusType:
 
 
 # Mutations
-async def clear_cache(info: OrchestratorInfo, name: str) -> Union[CacheClearSuccess, Error]:
+async def clear_cache(info: OrchestratorInfo, name: str) -> CacheClearSuccess | Error:
     cache: AIORedis = AIORedis.from_url(str(app_settings.CACHE_URI))
     if name not in CACHE_FLUSH_OPTIONS:
         return Error(message="Invalid cache name")
@@ -68,7 +66,7 @@ async def clear_cache(info: OrchestratorInfo, name: str) -> Union[CacheClearSucc
     return CacheClearSuccess(deleted=deleted)
 
 
-async def set_status(info: OrchestratorInfo, global_lock: bool) -> Union[Error, EngineSettingsType]:
+async def set_status(info: OrchestratorInfo, global_lock: bool) -> Error | EngineSettingsType:
     engine_settings = get_engine_settings_for_update()
 
     result = marshall_processes(engine_settings, global_lock)

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, cast
+from typing import cast
 
 import structlog
 from pydantic.alias_generators import to_camel as to_lower_camel
@@ -74,11 +74,11 @@ def format_base_subscription(subscription: SubscriptionTable) -> SubscriptionInt
 
 async def resolve_subscriptions(
     info: OrchestratorInfo,
-    filter_by: Optional[list[GraphqlFilter]] = None,
-    sort_by: Optional[list[GraphqlSort]] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[SubscriptionInterface]:
     _error_handler = create_resolver_error_handler(info)
 

--- a/orchestrator/graphql/resolvers/workflow.py
+++ b/orchestrator/graphql/resolvers/workflow.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import structlog
 from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload
@@ -23,11 +21,11 @@ logger = structlog.get_logger(__name__)
 
 async def resolve_workflows(
     info: OrchestratorInfo,
-    filter_by: Union[list[GraphqlFilter], None] = None,
-    sort_by: Union[list[GraphqlSort], None] = None,
+    filter_by: list[GraphqlFilter] | None = None,
+    sort_by: list[GraphqlSort] | None = None,
     first: int = 10,
     after: int = 0,
-    query: Optional[str] = None,
+    query: str | None = None,
 ) -> Connection[Workflow]:
     _error_handler = create_resolver_error_handler(info)
 

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -10,8 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, Callable, Type, Union
+from typing import Any
 
 import strawberry
 import structlog
@@ -119,7 +120,7 @@ class OrchestratorSchema(strawberry.federation.Schema):
     def process_errors(
         self,
         errors: list[GraphQLError],
-        execution_context: Union[ExecutionContext, None] = None,
+        execution_context: ExecutionContext | None = None,
     ) -> None:
         """Override error processing to reduce verbosity of the logging.
 
@@ -154,7 +155,7 @@ def create_graphql_router(
     query: Any = Query,
     mutation: Any = Mutation,
     register_models: bool = True,
-    subscription_interface: Union[Type, None] = SubscriptionInterface,
+    subscription_interface: type | None = SubscriptionInterface,
 ) -> OrchestratorGraphqlRouter:
     @strawberry.experimental.pydantic.type(
         model=SubscriptionModel, all_fields=True, directives=federation_key_directives

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Annotated, Optional, Union
+from typing import TYPE_CHECKING, Annotated
 from uuid import UUID
 
 import strawberry
@@ -31,7 +31,7 @@ class ProcessFormType:
     additionalProperties: strawberry.auto
     required: strawberry.auto
     properties: JSON
-    definitions: Union[JSON, None]
+    definitions: JSON | None
 
 
 @strawberry.experimental.pydantic.type(model=ProcessStepSchema)
@@ -42,14 +42,14 @@ class ProcessStepType:
     created_by: strawberry.auto
     executed: strawberry.auto
     commit_hash: strawberry.auto
-    state: Union[JSON, None]
-    state_delta: Union[JSON, None]
+    state: JSON | None
+    state_delta: JSON | None
 
     @authenticated_field(
         description="Returns step id",
         deprecation_reason="Changed to 'stepId' from version 1.2.3, will be removed in 1.4",
     )  # type: ignore
-    def stepid(self) -> Optional[UUID]:
+    def stepid(self) -> UUID | None:
         return self.step_id
 
 
@@ -72,7 +72,7 @@ class ProcessType:
     is_task: strawberry.auto
     steps: strawberry.auto
     form: strawberry.auto
-    current_state: Union[JSON, None]
+    current_state: JSON | None
 
     @authenticated_field(
         description="Returns process id",
@@ -117,7 +117,7 @@ class ProcessType:
         return self.last_modified_at
 
     @authenticated_field(description="Returns the associated product")  # type: ignore
-    def product(self) -> Optional[ProductType]:
+    def product(self) -> ProductType | None:
         if self.product_id and (product := db.session.get(ProductTable, self.product_id)):
             return ProductType.from_pydantic(product)
         return None
@@ -134,8 +134,8 @@ class ProcessType:
     async def subscriptions(
         self,
         info: OrchestratorInfo,
-        filter_by: Union[list[GraphqlFilter], None] = None,
-        sort_by: Union[list[GraphqlSort], None] = None,
+        filter_by: list[GraphqlFilter] | None = None,
+        sort_by: list[GraphqlSort] | None = None,
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionInterface", strawberry.lazy(".subscription")]]:

--- a/orchestrator/graphql/schemas/product.py
+++ b/orchestrator/graphql/schemas/product.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Annotated, Union
+from typing import TYPE_CHECKING, Annotated
 
 import strawberry
 from strawberry.federation.schema_directives import Key
@@ -38,8 +38,8 @@ class ProductType:
     async def subscriptions(
         self,
         info: OrchestratorInfo,
-        filter_by: Union[list[GraphqlFilter], None] = None,
-        sort_by: Union[list[GraphqlSort], None] = None,
+        filter_by: list[GraphqlFilter] | None = None,
+        sort_by: list[GraphqlSort] | None = None,
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionInterface", strawberry.lazy(".subscription")]]:

--- a/orchestrator/graphql/schemas/resource_type.py
+++ b/orchestrator/graphql/schemas/resource_type.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Annotated, List
+from typing import TYPE_CHECKING, Annotated
 
 import strawberry
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 @strawberry.experimental.pydantic.type(model=ResourceTypeSchema, all_fields=True)
 class ResourceType:
     @strawberry.field(description="Return all product blocks that make use of this resource type")  # type: ignore
-    async def product_blocks(self) -> List[Annotated["ProductBlock", strawberry.lazy(".product_block")]]:
+    async def product_blocks(self) -> list[Annotated["ProductBlock", strawberry.lazy(".product_block")]]:
         from orchestrator.graphql.schemas.product_block import ProductBlock
 
         return [ProductBlock.from_pydantic(product_block) for product_block in self._original_model.product_blocks]  # type: ignore

--- a/orchestrator/graphql/schemas/settings.py
+++ b/orchestrator/graphql/schemas/settings.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional, Union
+from typing import Annotated, Union
 
 import strawberry
 from strawberry.scalars import JSON
@@ -22,9 +22,9 @@ class EngineSettingsType:
 
 @strawberry.type
 class StatusType:
-    engine_settings: Optional[EngineSettingsType]
-    worker_status: Optional[WorkerStatusType]
-    cache_names: Optional[JSON]
+    engine_settings: EngineSettingsType | None
+    worker_status: WorkerStatusType | None
+    cache_names: JSON | None
 
 
 # Responses

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Optional, Type, Union
+from typing import Annotated
 from uuid import UUID
 
 import strawberry
@@ -30,7 +30,7 @@ from orchestrator.types import SubscriptionLifecycle
 
 federation_key_directives = [Key(fields="subscriptionId", resolvable=UNSET)]
 
-MetadataDict: dict[str, Optional[Type[BaseModel]]] = {"metadata": None}
+MetadataDict: dict[str, type[BaseModel] | None] = {"metadata": None}
 static_metadata_schema = {"title": "SubscriptionMetadata", "type": "object", "properties": {}, "definitions": {}}
 
 
@@ -40,11 +40,11 @@ class SubscriptionInterface:
     customer_id: str
     product: ProductModelGraphql
     description: str
-    start_date: Optional[datetime]
-    end_date: Optional[datetime]
+    start_date: datetime | None
+    end_date: datetime | None
     status: SubscriptionLifecycle
     insync: bool
-    note: Optional[str]
+    note: str | None
 
     @strawberry.field(name="_schema", description="Return all products block instances of a subscription as JSON Schema")  # type: ignore
     async def schema(self) -> dict:
@@ -62,13 +62,13 @@ class SubscriptionInterface:
 
     @strawberry.field(description="Return all products block instances of a subscription")  # type: ignore
     async def product_block_instances(
-        self, tags: Optional[list[str]] = None, resource_types: Optional[list[str]] = None
+        self, tags: list[str] | None = None, resource_types: list[str] | None = None
     ) -> list[ProductBlockInstance]:
         return await get_subscription_product_blocks(self.subscription_id, tags, resource_types)
 
     @strawberry.field(description="Return all products blocks that are part of a subscription", deprecation_reason="changed to product_block_instances")  # type: ignore
     async def product_blocks(
-        self, tags: Optional[list[str]] = None, resource_types: Optional[list[str]] = None
+        self, tags: list[str] | None = None, resource_types: list[str] | None = None
     ) -> list[ProductBlockInstance]:
         return await get_subscription_product_blocks(self.subscription_id, tags, resource_types)
 
@@ -81,8 +81,8 @@ class SubscriptionInterface:
     async def processes(
         self,
         info: OrchestratorInfo,
-        filter_by: Union[list[GraphqlFilter], None] = None,
-        sort_by: Union[list[GraphqlSort], None] = None,
+        filter_by: list[GraphqlFilter] | None = None,
+        sort_by: list[GraphqlSort] | None = None,
         first: int = 10,
         after: int = 0,
     ) -> Connection[ProcessType]:
@@ -95,8 +95,8 @@ class SubscriptionInterface:
     async def in_use_by_subscriptions(
         self,
         info: OrchestratorInfo,
-        filter_by: Union[list[GraphqlFilter], None] = None,
-        sort_by: Union[list[GraphqlSort], None] = None,
+        filter_by: list[GraphqlFilter] | None = None,
+        sort_by: list[GraphqlSort] | None = None,
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionInterface", strawberry.lazy(".subscription")]]:
@@ -117,8 +117,8 @@ class SubscriptionInterface:
     async def depends_on_subscriptions(
         self,
         info: OrchestratorInfo,
-        filter_by: Union[list[GraphqlFilter], None] = None,
-        sort_by: Union[list[GraphqlSort], None] = None,
+        filter_by: list[GraphqlFilter] | None = None,
+        sort_by: list[GraphqlSort] | None = None,
         first: int = 10,
         after: int = 0,
     ) -> Connection[Annotated["SubscriptionInterface", strawberry.lazy(".subscription")]]:

--- a/orchestrator/graphql/schemas/workflow.py
+++ b/orchestrator/graphql/schemas/workflow.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Annotated, List, Optional
+from typing import TYPE_CHECKING, Annotated
 
 import strawberry
 
@@ -12,17 +12,17 @@ if TYPE_CHECKING:
 
 @strawberry.experimental.pydantic.type(model=StepSchema, all_fields=True)
 class Step:
-    assignee: Optional[Assignee]
+    assignee: Assignee | None
 
 
 @strawberry.experimental.pydantic.type(model=WorkflowSchema, all_fields=True)
 class Workflow:
     @strawberry.field(description="Return all products that can use this workflow")  # type: ignore
-    async def products(self) -> List[Annotated["ProductType", strawberry.lazy(".product")]]:
+    async def products(self) -> list[Annotated["ProductType", strawberry.lazy(".product")]]:
         from orchestrator.graphql.schemas.product import ProductType
 
         return [ProductType.from_pydantic(product) for product in self._original_model.products]  # type: ignore
 
     @strawberry.field(description="Return all steps for this workflow")  # type: ignore
-    def steps(self) -> List[Step]:
+    def steps(self) -> list[Step]:
         return [Step(name=step.name, assignee=step.assignee) for step in get_workflow(self.name).steps]  # type: ignore

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -11,11 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface
 
 # Map some Orchestrator types to scalars
-from typing import Any, Callable, List, NewType, Tuple, Union
+from typing import Any, NewType
 
 import strawberry
 from graphql import GraphQLError
@@ -36,7 +36,7 @@ def serialize_to_string(value: Any) -> str:
     return str(value)
 
 
-def serialize_vlan(vlan: VlanRanges) -> List[Tuple[int, int]]:
+def serialize_vlan(vlan: VlanRanges) -> list[tuple[int, int]]:
     return vlan.to_list_of_tuples()
 
 
@@ -44,7 +44,7 @@ class OrchestratorContext(OauthContext):
     def __init__(
         self,
         get_current_user: Callable[[Request], Awaitable[OIDCUserModel]],
-        get_opa_decision: Callable[[str, OIDCUserModel], Awaitable[Union[bool, None]]],
+        get_opa_decision: Callable[[str, OIDCUserModel], Awaitable[bool | None]],
     ):
         self.errors: list[GraphQLError] = []
         super().__init__(get_current_user, get_opa_decision)
@@ -107,7 +107,7 @@ IntType = strawberry.scalar(
     parse_value=lambda v: v,
 )
 
-SCALAR_OVERRIDES: dict[object, Union[Any, ScalarWrapper, ScalarDefinition]] = {
+SCALAR_OVERRIDES: dict[object, Any | ScalarWrapper | ScalarDefinition] = {
     dict: JSON,
     VlanRanges: VlanRangesType,
     IPv4Address: IPv4AddressType,

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from itertools import count
-from typing import Any, Generator, Optional
+from typing import Any
 from uuid import UUID
 
 import strawberry
@@ -13,7 +14,7 @@ from orchestrator.services.subscriptions import build_extended_domain_model
 @strawberry.type
 class ProductBlockInstance:
     id: int
-    parent: Optional[int]
+    parent: int | None
     subscription_instance_id: UUID
     owner_subscription_id: UUID
     in_use_by_relations: list[JSON]
@@ -32,7 +33,7 @@ def is_product_block(candidate: Any) -> bool:
     return False
 
 
-def get_all_product_blocks(subscription: dict[str, Any], _tags: Optional[list[str]]) -> list[dict[str, Any]]:
+def get_all_product_blocks(subscription: dict[str, Any], _tags: list[str] | None) -> list[dict[str, Any]]:
     gen_id = count()
 
     def locate_product_block(candidate: dict[str, Any]) -> Generator:
@@ -56,7 +57,7 @@ pb_instance_property_keys = ("id", "parent", "owner_subscription_id", "subscript
 
 
 async def get_subscription_product_blocks(
-    subscription_id: UUID, tags: Optional[list[str]] = None, product_block_instance_values: Optional[list[str]] = None
+    subscription_id: UUID, tags: list[str] | None = None, product_block_instance_values: list[str] | None = None
 ) -> list[ProductBlockInstance]:
     subscription_model = SubscriptionModel.from_subscription(subscription_id)
     subscription = build_extended_domain_model(subscription_model)

--- a/orchestrator/graphql/utils/is_query_detailed.py
+++ b/orchestrator/graphql/utils/is_query_detailed.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from more_itertools import flatten, one
 from strawberry.types.nodes import FragmentSpread, InlineFragment, SelectedField, Selection
@@ -14,9 +14,7 @@ def get_selected_field_selections(selected_field: Selection, name: str) -> list[
     return one(page_field).selections if page_field else []
 
 
-def is_query_detailed(
-    basic_fields: tuple, type_conditions: Optional[tuple] = None
-) -> Callable[[OrchestratorInfo], bool]:
+def is_query_detailed(basic_fields: tuple, type_conditions: tuple | None = None) -> Callable[[OrchestratorInfo], bool]:
     """Function wrapper that validates GraphQL queries against provided basic_fields.
 
     Args:

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,9 +1,7 @@
-from typing import Type
-
 from strawberry.field import StrawberryField
 
 
-def override_class(strawberry_class: Type, fields: list[StrawberryField]) -> Type:
+def override_class(strawberry_class: type, fields: list[StrawberryField]) -> type:
     """Override fields or add fields to a existing strawberry class.
 
     Usefull for overriding orchestrator core strawberry classes.
@@ -18,6 +16,9 @@ def override_class(strawberry_class: Type, fields: list[StrawberryField]) -> Typ
     if not fields:
         return strawberry_class
 
+    if (definition := getattr(strawberry_class, "__strawberry_definition__", None)) is None:
+        raise TypeError("Cannot override fields for a class without __strawberry_definition__")
+
     fields_map = {field.name: field for field in fields}
 
     def override_fn(field: StrawberryField) -> StrawberryField:
@@ -26,10 +27,10 @@ def override_class(strawberry_class: Type, fields: list[StrawberryField]) -> Typ
             return field
         return field
 
-    default_class_field_names = [field.name for field in strawberry_class.__strawberry_definition__._fields]
+    default_class_field_names = [field.name for field in definition._fields]
 
-    new_field_list = [override_fn(field) for field in strawberry_class.__strawberry_definition__._fields]
+    new_field_list = [override_fn(field) for field in definition._fields]
     new_field_list.extend([field for field in fields if field.name not in default_class_field_names])
 
-    strawberry_class.__strawberry_definition__._fields = new_field_list
+    definition._fields = new_field_list
     return strawberry_class

--- a/orchestrator/graphql/utils/to_graphql_result_page.py
+++ b/orchestrator/graphql/utils/to_graphql_result_page.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from orchestrator.graphql.pagination import Connection, PageInfo
 
@@ -7,9 +7,9 @@ def to_graphql_result_page(
     items: list[Any],
     first: int,
     after: int,
-    total: Optional[int],
-    sort_fields: Union[List[str], None] = None,
-    filter_fields: Union[List[str], None] = None,
+    total: int | None,
+    sort_fields: list[str] | None = None,
+    filter_fields: list[str] | None = None,
 ) -> Connection:
     has_next_page = len(items) > first
 

--- a/orchestrator/migrations/helpers.py
+++ b/orchestrator/migrations/helpers.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Iterable, List, Sequence, Union
+from collections.abc import Iterable, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -46,12 +46,12 @@ def get_product_id_by_name(conn: sa.engine.Connection, name: str) -> UUID:
     return [x for (x,) in result.fetchall()][0]
 
 
-def get_product_name_by_id(conn: sa.engine.Connection, id: Union[UUID, UUIDstr]) -> str:
+def get_product_name_by_id(conn: sa.engine.Connection, id: UUID | UUIDstr) -> str:
     result = conn.execute(sa.text("SELECT name FROM products WHERE product_id=:id"), {"id": id})
     return [x for (x,) in result.fetchall()][0]
 
 
-def get_product_by_id(conn: sa.engine.Connection, id: Union[UUID, UUIDstr]) -> dict:
+def get_product_by_id(conn: sa.engine.Connection, id: UUID | UUIDstr) -> dict:
     result = conn.execute(sa.text("SELECT * FROM products WHERE product_id=:id"), {"id": id})
 
     return dict(result.mappings().one())
@@ -66,7 +66,7 @@ def get_product_ids_by_product_type(conn: sa.engine.Connection, product_type: st
     return [x for (x,) in result.fetchall()]
 
 
-def get_fixed_inputs_by_product_id(conn: sa.engine.Connection, id: Union[UUID, UUIDstr]) -> Sequence:
+def get_fixed_inputs_by_product_id(conn: sa.engine.Connection, id: UUID | UUIDstr) -> Sequence:
     result = conn.execute(sa.text("SELECT * FROM fixed_inputs WHERE product_id=:id"), {"id": id})
     return result.fetchall()
 
@@ -85,7 +85,7 @@ def insert_resource_type(conn: sa.engine.Connection, resource_type: str, descrip
     )
 
 
-def get_all_active_products_and_ids(conn: sa.engine.Connection) -> List[Dict[str, Union[UUID, UUIDstr, str]]]:
+def get_all_active_products_and_ids(conn: sa.engine.Connection) -> list[dict[str, UUID | UUIDstr | str]]:
     """Return a list, with dicts containing keys `product_id` and `name` of active products."""
     result = conn.execute(sa.text("SELECT product_id, name  FROM products WHERE status='active'"))
     return [{"product_id": row[0], "name": row[1]} for row in result.fetchall()]
@@ -116,7 +116,7 @@ def ensure_default_workflows(conn: sa.engine.Connection) -> None:
     )
 
 
-def create_workflow(conn: sa.engine.Connection, workflow: Dict) -> None:
+def create_workflow(conn: sa.engine.Connection, workflow: dict) -> None:
     """Create a new workflow for a product.
 
     Args:
@@ -160,7 +160,7 @@ def create_workflow(conn: sa.engine.Connection, workflow: Dict) -> None:
     )
 
 
-def create_workflows(conn: sa.engine.Connection, new: Dict) -> None:
+def create_workflows(conn: sa.engine.Connection, new: dict) -> None:
     """Create new workflows.
 
     Args:
@@ -202,7 +202,7 @@ def create_workflows(conn: sa.engine.Connection, new: Dict) -> None:
         )
 
 
-def create_fixed_inputs(conn: sa.engine.Connection, product_id: Union[UUID, UUIDstr], new: Dict) -> Dict[str, str]:
+def create_fixed_inputs(conn: sa.engine.Connection, product_id: UUID | UUIDstr, new: dict) -> dict[str, str]:
     """Create fixed inputs for a given product.
 
     Args:
@@ -255,7 +255,7 @@ def create_fixed_inputs(conn: sa.engine.Connection, product_id: Union[UUID, UUID
     return uuids
 
 
-def create_products(conn: sa.engine.Connection, new: Dict) -> Dict[str, UUIDstr]:
+def create_products(conn: sa.engine.Connection, new: dict) -> dict[str, UUIDstr]:
     """Create new products with their fixed inputs.
 
     Args:
@@ -316,7 +316,7 @@ def create_products(conn: sa.engine.Connection, new: Dict) -> Dict[str, UUIDstr]
     return uuids
 
 
-def create_product_blocks(conn: sa.engine.Connection, new: Dict) -> Dict[str, UUIDstr]:
+def create_product_blocks(conn: sa.engine.Connection, new: dict) -> dict[str, UUIDstr]:
     """Create new product blocks.
 
     Args:
@@ -375,7 +375,7 @@ def create_product_blocks(conn: sa.engine.Connection, new: Dict) -> Dict[str, UU
     return uuids
 
 
-def create_resource_types_for_product_blocks(conn: sa.engine.Connection, new: Dict) -> List[UUID]:
+def create_resource_types_for_product_blocks(conn: sa.engine.Connection, new: dict) -> list[UUID]:
     """Create new resource types and link them to existing product_blocks by product_block name.
 
     Note: If the resource type already exists it will still add the resource type to the provided Product Blocks.
@@ -474,7 +474,7 @@ def create_resource_types_for_product_blocks(conn: sa.engine.Connection, new: Di
     return resource_type_ids
 
 
-def create(conn: sa.engine.Connection, new: Dict) -> None:  # noqa: C901
+def create(conn: sa.engine.Connection, new: dict) -> None:  # noqa: C901
     """Call other functions in this file based on the schema.
 
     Args:
@@ -672,7 +672,7 @@ def remove_products_from_workflow_by_product_tag(
 
 
 def add_product_block_relation_between_products_by_id(
-    conn: sa.engine.Connection, in_use_by_id: Union[UUID, UUIDstr], depends_on_id: Union[UUID, UUIDstr]
+    conn: sa.engine.Connection, in_use_by_id: UUID | UUIDstr, depends_on_id: UUID | UUIDstr
 ) -> None:
     """Add product block relation by product block id.
 
@@ -704,7 +704,7 @@ def add_product_block_relation_between_products_by_id(
 
 
 def remove_product_block_relation_between_products_by_id(
-    conn: sa.engine.Connection, in_use_by_id: Union[UUID, UUIDstr], depends_on_id: Union[UUID, UUIDstr]
+    conn: sa.engine.Connection, in_use_by_id: UUID | UUIDstr, depends_on_id: UUID | UUIDstr
 ) -> None:
     """Remove product block relation by id.
 
@@ -735,7 +735,7 @@ def remove_product_block_relation_between_products_by_id(
     )
 
 
-def delete_resource_type_by_id(conn: sa.engine.Connection, id: Union[UUID, UUIDstr]) -> None:
+def delete_resource_type_by_id(conn: sa.engine.Connection, id: UUID | UUIDstr) -> None:
     """Delete resource type by resource type id.
 
     Args:
@@ -751,7 +751,7 @@ def delete_resource_type_by_id(conn: sa.engine.Connection, id: Union[UUID, UUIDs
     conn.execute(sa.text("DELETE FROM resource_types WHERE resource_type_id=:id"), {"id": id})
 
 
-def delete_resource_types_from_product_blocks(conn: sa.engine.Connection, delete: Dict) -> None:
+def delete_resource_types_from_product_blocks(conn: sa.engine.Connection, delete: dict) -> None:
     """Delete resource type from product blocks.
 
     Note: the resource_type itself will not be deleted.
@@ -931,7 +931,7 @@ def delete_resource_type(conn: sa.engine.Connection, resource_type: str) -> None
     )
 
 
-def delete(conn: sa.engine.Connection, obsolete: Dict) -> None:
+def delete(conn: sa.engine.Connection, obsolete: dict) -> None:
     """Delete multiple products, product_blocks, resources, and workflows.
 
     Args:
@@ -981,7 +981,7 @@ def delete(conn: sa.engine.Connection, obsolete: Dict) -> None:
 
 
 def convert_resource_type_relations_to_instance_relations(
-    conn: sa.engine.Connection, resource_type_id: Union[UUID, UUIDstr], domain_model_attr: str, cleanup: bool = True
+    conn: sa.engine.Connection, resource_type_id: UUID | UUIDstr, domain_model_attr: str, cleanup: bool = True
 ) -> None:
     """Move resouce type relations to instance type relations using resource type id.
 
@@ -1034,7 +1034,7 @@ def convert_resource_type_relations_to_instance_relations(
 
 
 def convert_instance_relations_to_resource_type_relations_by_domain_model_attr(
-    conn: sa.engine.Connection, domain_model_attr: str, resource_type_id: Union[UUID, UUIDstr], cleanup: bool = True
+    conn: sa.engine.Connection, domain_model_attr: str, resource_type_id: UUID | UUIDstr, cleanup: bool = True
 ) -> None:
     """Move instance type relations to resouce type relations by domain model attribute.
 

--- a/orchestrator/schedules/__init__.py
+++ b/orchestrator/schedules/__init__.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 from orchestrator.schedules.resume_workflows import run_resume_workflows
 from orchestrator.schedules.scheduling import SchedulingFunction
@@ -19,7 +18,7 @@ from orchestrator.schedules.task_vacuum import vacuum_tasks
 from orchestrator.schedules.validate_products import validate_products
 from orchestrator.schedules.validate_subscriptions import validate_subscriptions
 
-ALL_SCHEDULERS: List[SchedulingFunction] = [
+ALL_SCHEDULERS: list[SchedulingFunction] = [
     run_resume_workflows,
     vacuum_tasks,
     validate_subscriptions,

--- a/orchestrator/schedules/scheduling.py
+++ b/orchestrator/schedules/scheduling.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Protocol, cast
+from collections.abc import Callable
+from typing import Protocol, cast
 
 from schedule import CancelJob
 
@@ -20,16 +21,16 @@ class SchedulingFunction(Protocol):
     __name__: str
     name: str
     time_unit: str
-    period: Optional[int]
-    at: Optional[str]
+    period: int | None
+    at: str | None
 
-    def __call__(self) -> Optional[CancelJob]:
+    def __call__(self) -> CancelJob | None:
         ...
 
 
 def scheduler(
-    name: str, time_unit: str, period: int = 1, at: Optional[str] = None
-) -> Callable[[Callable[[], Optional[CancelJob]]], SchedulingFunction]:
+    name: str, time_unit: str, period: int = 1, at: str | None = None
+) -> Callable[[Callable[[], CancelJob | None]], SchedulingFunction]:
     """Create schedule.
 
     Either specify the period or the at. Examples:
@@ -37,7 +38,7 @@ def scheduler(
     time_unit = "day", at="01:00" -> will run every day at 1 o'clock
     """
 
-    def _scheduler(f: Callable[[], Optional[CancelJob]]) -> SchedulingFunction:
+    def _scheduler(f: Callable[[], CancelJob | None]) -> SchedulingFunction:
         schedule = cast(SchedulingFunction, f)
         schedule.name = name
         schedule.time_unit = time_unit

--- a/orchestrator/schemas/engine_settings.py
+++ b/orchestrator/schemas/engine_settings.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import strawberry
 from pydantic import ConfigDict
@@ -39,6 +38,6 @@ class WorkerStatus(OrchestratorBaseModel):
 
 
 class EngineSettingsSchema(EngineSettingsBaseSchema):
-    global_status: Optional[GlobalStatusEnum] = None
+    global_status: GlobalStatusEnum | None = None
     running_processes: int
     model_config = ConfigDict(from_attributes=True)

--- a/orchestrator/schemas/fixed_input.py
+++ b/orchestrator/schemas/fixed_input.py
@@ -12,21 +12,20 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Dict, List, Optional
 from uuid import UUID
 
 from pydantic import ConfigDict
 
 from orchestrator.schemas.base import OrchestratorBaseModel
 
-TagConfig = Dict[str, List[Dict[str, bool]]]
+TagConfig = dict[str, list[dict[str, bool]]]
 
 
 class FixedInputBaseSchema(OrchestratorBaseModel):
-    fixed_input_id: Optional[UUID] = None
+    fixed_input_id: UUID | None = None
     name: str
     value: str
-    product_id: Optional[UUID] = None
+    product_id: UUID | None = None
 
 
 class FixedInputSchema(FixedInputBaseSchema):
@@ -39,9 +38,9 @@ class FixedInputSchema(FixedInputBaseSchema):
 class FixedInputConfigurationItemSchema(OrchestratorBaseModel):
     name: str
     description: str
-    values: List[str]
+    values: list[str]
 
 
 class FixedInputConfigurationSchema(OrchestratorBaseModel):
-    fixed_inputs: List[FixedInputConfigurationItemSchema]
+    fixed_inputs: list[FixedInputConfigurationItemSchema]
     by_tag: TagConfig

--- a/orchestrator/schemas/problem_detail.py
+++ b/orchestrator/schemas/problem_detail.py
@@ -11,13 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 from orchestrator.schemas.base import OrchestratorBaseModel
 
 
 class ProblemDetailSchema(OrchestratorBaseModel):
-    detail: Optional[str] = None
-    status: Optional[int] = None
-    title: Optional[str] = None
-    type: Optional[str] = None
+    detail: str | None = None
+    status: int | None = None
+    title: str | None = None
+    type: str | None = None

--- a/orchestrator/schemas/process.py
+++ b/orchestrator/schemas/process.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any
 from uuid import UUID
 
 from pydantic import ConfigDict, Field, model_serializer
@@ -32,10 +32,10 @@ class ProcessIdSchema(OrchestratorBaseModel):
 class ProcessForm(OrchestratorBaseModel):
     title: str
     type: str
-    properties: Dict[str, Any]
+    properties: dict[str, Any]
     additionalProperties: bool  # noqa: N815
-    required: List[str] = []
-    definitions: Optional[Dict[str, Any]] = Field(None, validation_alias="$defs")
+    required: list[str] = []
+    definitions: dict[str, Any] | None = Field(None, validation_alias="$defs")
 
     @model_serializer(mode="wrap", when_used="json")
     def serialize_defs(self, handler: SerializerFunctionWrapHandler, _info: ValidationInfo) -> dict[str, Any]:
@@ -55,57 +55,57 @@ class ProcessBaseSchema(OrchestratorBaseModel):
     workflow_id: UUID
     workflow_name: str
     is_task: bool
-    created_by: Optional[str] = None
-    failed_reason: Optional[str] = None
+    created_by: str | None = None
+    failed_reason: str | None = None
     started_at: datetime
     last_status: ProcessStatus
-    last_step: Optional[str] = None
+    last_step: str | None = None
     assignee: Assignee
     last_modified_at: datetime
-    traceback: Optional[str] = None
+    traceback: str | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
 class ProcessStepSchema(OrchestratorBaseModel):
-    step_id: Optional[UUID] = None
+    step_id: UUID | None = None
     name: str
     status: str
-    created_by: Optional[str] = None
-    executed: Optional[datetime] = None
-    commit_hash: Optional[str] = None
-    state: Optional[Dict[str, Any]] = None
-    state_delta: Optional[Dict[str, Any]] = None
+    created_by: str | None = None
+    executed: datetime | None = None
+    commit_hash: str | None = None
+    state: dict[str, Any] | None = None
+    state_delta: dict[str, Any] | None = None
 
-    stepid: Optional[UUID] = None  # TODO: will be removed in 1.4
+    stepid: UUID | None = None  # TODO: will be removed in 1.4
 
 
 class ProcessSchema(ProcessBaseSchema):
-    product_id: Optional[UUID] = None
-    customer_id: Optional[str] = None
-    workflow_target: Optional[Target] = None
-    subscriptions: List[SubscriptionSchema]
-    current_state: Optional[Dict[str, Any]] = None
-    steps: Optional[List[ProcessStepSchema]] = None
-    form: Optional[ProcessForm] = None
+    product_id: UUID | None = None
+    customer_id: str | None = None
+    workflow_target: Target | None = None
+    subscriptions: list[SubscriptionSchema]
+    current_state: dict[str, Any] | None = None
+    steps: list[ProcessStepSchema] | None = None
+    form: ProcessForm | None = None
 
 
 class ProcessDeprecationsSchema(ProcessSchema):
-    id: Optional[UUID] = None  # TODO: will be removed in 1.4
-    pid: Optional[UUID] = None  # TODO: will be removed in 1.4
-    workflow: Optional[str] = None  # TODO: will be removed in 1.4
-    status: Optional[ProcessStatus] = None  # TODO: will be removed in 1.4
-    step: Optional[str] = None  # TODO: will be removed in 1.4
-    started: Optional[datetime] = None  # TODO: will be removed in 1.4
-    last_modified: Optional[datetime] = None  # TODO: will be removed in 1.4
-    product: Optional[UUID] = None  # TODO: will be removed in 1.4
-    customer: Optional[str] = None  # TODO: will be removed in 1.4
+    id: UUID | None = None  # TODO: will be removed in 1.4
+    pid: UUID | None = None  # TODO: will be removed in 1.4
+    workflow: str | None = None  # TODO: will be removed in 1.4
+    status: ProcessStatus | None = None  # TODO: will be removed in 1.4
+    step: str | None = None  # TODO: will be removed in 1.4
+    started: datetime | None = None  # TODO: will be removed in 1.4
+    last_modified: datetime | None = None  # TODO: will be removed in 1.4
+    product: UUID | None = None  # TODO: will be removed in 1.4
+    customer: str | None = None  # TODO: will be removed in 1.4
 
 
 class ProcessSubscriptionBaseSchema(OrchestratorBaseModel):
     id: UUID
     process_id: UUID
     subscription_id: UUID
-    workflow_target: Optional[Target] = None
+    workflow_target: Target | None = None
     created_at: datetime
 
     pid: UUID  # TODO: will be removed in 1.4
@@ -121,8 +121,8 @@ class ProcessResumeAllSchema(OrchestratorBaseModel):
 
 
 class ProcessStatusCounts(OrchestratorBaseModel):
-    process_counts: Dict[ProcessStatus, int]
-    task_counts: Dict[ProcessStatus, int]
+    process_counts: dict[ProcessStatus, int]
+    task_counts: dict[ProcessStatus, int]
 
 
 Reporter = Annotated[str, Field(max_length=100)]

--- a/orchestrator/schemas/product.py
+++ b/orchestrator/schemas/product.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import List, Optional
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -25,25 +24,25 @@ from orchestrator.schemas.workflow import WorkflowSchema
 
 
 class ProductBaseSchema(OrchestratorBaseModel):
-    product_id: Optional[UUID] = None
+    product_id: UUID | None = None
     name: str
     description: str
     product_type: str
     status: ProductLifecycle
     tag: str
-    created_at: Optional[datetime] = None
-    end_date: Optional[datetime] = None
+    created_at: datetime | None = None
+    end_date: datetime | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
 class ProductSchema(ProductBaseSchema):
     product_id: UUID
     created_at: datetime
-    product_blocks: List[ProductBlockSchema]
-    fixed_inputs: List[FixedInputSchema]
-    workflows: List[WorkflowSchema]
+    product_blocks: list[ProductBlockSchema]
+    fixed_inputs: list[FixedInputSchema]
+    workflows: list[WorkflowSchema]
 
 
 class ProductCRUDSchema(ProductBaseSchema):
-    product_blocks: Optional[List[ProductBlockBaseSchema]] = None
-    fixed_inputs: Optional[List[FixedInputBaseSchema]] = None
+    product_blocks: list[ProductBlockBaseSchema] | None = None
+    fixed_inputs: list[FixedInputBaseSchema] | None = None

--- a/orchestrator/schemas/product_block.py
+++ b/orchestrator/schemas/product_block.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import List, Optional
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -23,23 +22,23 @@ from orchestrator.schemas.resource_type import ResourceTypeBaseSchema, ResourceT
 
 
 class ProductBlockBaseSchema(OrchestratorBaseModel):
-    product_block_id: Optional[UUID] = None
+    product_block_id: UUID | None = None
     name: str
     description: str
-    tag: Optional[str] = None
-    status: Optional[ProductLifecycle] = None
-    resource_types: Optional[List[ResourceTypeBaseSchema]] = None
+    tag: str | None = None
+    status: ProductLifecycle | None = None
+    resource_types: list[ResourceTypeBaseSchema] | None = None
 
 
 class ProductBlockEnrichedSchema(OrchestratorBaseModel):
     product_block_id: UUID
     name: str
     description: str
-    tag: Optional[str] = None
+    tag: str | None = None
     status: ProductLifecycle
-    created_at: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    resource_types: Optional[List[ResourceTypeSchema]] = None
+    created_at: datetime | None = None
+    end_date: datetime | None = None
+    resource_types: list[ResourceTypeSchema] | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -47,6 +46,6 @@ class ProductBlockSchema(ProductBlockBaseSchema):
     product_block_id: UUID
     status: ProductLifecycle
     created_at: datetime
-    end_date: Optional[datetime] = None
-    resource_types: Optional[List[ResourceTypeSchema]] = None  # type: ignore
+    end_date: datetime | None = None
+    resource_types: list[ResourceTypeSchema] | None = None  # type: ignore
     model_config = ConfigDict(from_attributes=True)

--- a/orchestrator/schemas/resource_type.py
+++ b/orchestrator/schemas/resource_type.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -21,8 +20,8 @@ from orchestrator.schemas.base import OrchestratorBaseModel
 
 class ResourceTypeBaseSchema(OrchestratorBaseModel):
     resource_type: str
-    description: Optional[str] = None
-    resource_type_id: Optional[UUID] = None
+    description: str | None = None
+    resource_type_id: UUID | None = None
 
 
 class ResourceTypeSchema(ResourceTypeBaseSchema):

--- a/orchestrator/schemas/subscription.py
+++ b/orchestrator/schemas/subscription.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any
 from uuid import UUID
 
 from pydantic import ConfigDict, Field
@@ -34,7 +34,7 @@ class PortMode(strEnum):
 
 
 class SubscriptionRelationSchema(OrchestratorBaseModel):
-    domain_model_attr: Optional[str] = None
+    domain_model_attr: str | None = None
     parent_id: UUID
     child_id: UUID
     in_use_by_id: UUID
@@ -53,42 +53,42 @@ class SubscriptionInstanceValueBaseSchema(OrchestratorBaseModel):
 
 
 class SubscriptionInstanceBase(OrchestratorBaseModel):
-    label: Optional[str] = None
+    label: str | None = None
     subscription_id: UUID
     product_block_id: UUID
     subscription_instance_id: UUID
-    values: List[SubscriptionInstanceValueBaseSchema]
-    parent_relations: List[SubscriptionRelationSchema]
-    children_relations: List[SubscriptionRelationSchema]
-    in_use_by_block_relations: List[SubscriptionRelationSchema]
-    depends_on_block_relations: List[SubscriptionRelationSchema]
+    values: list[SubscriptionInstanceValueBaseSchema]
+    parent_relations: list[SubscriptionRelationSchema]
+    children_relations: list[SubscriptionRelationSchema]
+    in_use_by_block_relations: list[SubscriptionRelationSchema]
+    depends_on_block_relations: list[SubscriptionRelationSchema]
     product_block: ProductBlockSchema
     model_config = ConfigDict(from_attributes=True)
 
 
 class SubscriptionBaseSchema(OrchestratorBaseModel):
-    subscription_id: Optional[UUID] = None
-    start_date: Optional[datetime] = None
+    subscription_id: UUID | None = None
+    start_date: datetime | None = None
     description: str
     status: SubscriptionLifecycle
-    product_id: Optional[UUID] = None
+    product_id: UUID | None = None
     customer_id: str
     insync: bool
-    note: Optional[str] = None
+    note: str | None = None
 
 
 class SubscriptionSchema(SubscriptionBaseSchema):
-    name: Optional[str] = None
+    name: str | None = None
     subscription_id: UUID
-    end_date: Optional[datetime] = None
-    product: Optional[ProductBaseSchema] = None
-    customer_descriptions: Optional[List[SubscriptionDescriptionSchema]] = None
-    tag: Optional[str] = None
+    end_date: datetime | None = None
+    product: ProductBaseSchema | None = None
+    customer_descriptions: list[SubscriptionDescriptionSchema] | None = None
+    tag: str | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
 class SubscriptionWithMetadata(SubscriptionSchema):
-    metadata_: Optional[Any] = Field(..., alias="metadata")
+    metadata_: Any | None = Field(..., alias="metadata")
 
 
 class SubscriptionIdSchema(OrchestratorBaseModel):
@@ -96,6 +96,6 @@ class SubscriptionIdSchema(OrchestratorBaseModel):
 
 
 class SubscriptionDomainModelSchema(SubscriptionSchema):
-    customer_descriptions: List[Optional[SubscriptionDescriptionSchema]] = []  # type: ignore
+    customer_descriptions: list[SubscriptionDescriptionSchema | None] = []  # type: ignore
     product: ProductBaseSchema
     model_config = ConfigDict(extra="allow")

--- a/orchestrator/schemas/subscription_descriptions.py
+++ b/orchestrator/schemas/subscription_descriptions.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -28,5 +27,5 @@ class SubscriptionDescriptionBaseSchema(OrchestratorBaseModel):
 
 class SubscriptionDescriptionSchema(SubscriptionDescriptionBaseSchema):
     id: UUID
-    created_at: Optional[datetime] = None
+    created_at: datetime | None = None
     model_config = ConfigDict(from_attributes=True)

--- a/orchestrator/schemas/workflow.py
+++ b/orchestrator/schemas/workflow.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -24,8 +24,8 @@ from orchestrator.targets import Target
 class WorkflowBaseSchema(OrchestratorBaseModel):
     name: str
     target: Target
-    description: Optional[str] = None
-    created_at: Optional[datetime] = None
+    description: str | None = None
+    created_at: datetime | None = None
 
 
 class StepSchema(OrchestratorBaseModel):
@@ -35,31 +35,31 @@ class StepSchema(OrchestratorBaseModel):
 class WorkflowSchema(WorkflowBaseSchema):
     workflow_id: UUID
     created_at: datetime
-    steps: Optional[List[StepSchema]] = None
+    steps: list[StepSchema] | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class WorkflowWithProductTagsSchema(WorkflowBaseSchema):
-    product_tags: List[str]
+    product_tags: list[str]
 
 
 class WorkflowListItemSchema(OrchestratorBaseModel):
     name: str
-    description: Optional[str] = None
-    reason: Optional[str] = None
-    usable_when: Optional[List[Any]] = None
-    status: Optional[str] = None
-    action: Optional[str] = None
-    locked_relations: Optional[List[UUID]] = None
-    unterminated_parents: Optional[List[UUID]] = None
-    unterminated_in_use_by_subscriptions: Optional[List[UUID]] = None
+    description: str | None = None
+    reason: str | None = None
+    usable_when: list[Any] | None = None
+    status: str | None = None
+    action: str | None = None
+    locked_relations: list[UUID] | None = None
+    unterminated_parents: list[UUID] | None = None
+    unterminated_in_use_by_subscriptions: list[UUID] | None = None
 
 
 class SubscriptionWorkflowListsSchema(OrchestratorBaseModel):
-    reason: Optional[str] = None
-    locked_relations: Optional[List[UUID]] = None
-    create: List[WorkflowListItemSchema]
-    modify: List[WorkflowListItemSchema]
-    terminate: List[WorkflowListItemSchema]
-    system: List[WorkflowListItemSchema]
+    reason: str | None = None
+    locked_relations: list[UUID] | None = None
+    create: list[WorkflowListItemSchema]
+    modify: list[WorkflowListItemSchema]
+    terminate: list[WorkflowListItemSchema]
+    system: list[WorkflowListItemSchema]

--- a/orchestrator/services/celery.py
+++ b/orchestrator/services/celery.py
@@ -10,8 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any
 from uuid import UUID
 
 from orchestrator import app_settings
@@ -26,7 +27,7 @@ SYSTEM_USER = "SYSTEM"
 
 
 def _celery_start_process(
-    workflow_key: str, user_inputs: Optional[List[State]], user: str = SYSTEM_USER, **kwargs: Any
+    workflow_key: str, user_inputs: list[State] | None, user: str = SYSTEM_USER, **kwargs: Any
 ) -> UUID:
     """Client side call of Celery."""
     from orchestrator.services.tasks import NEW_TASK, NEW_WORKFLOW, get_celery_task
@@ -54,8 +55,8 @@ def _celery_start_process(
 def _celery_resume_process(
     process: ProcessTable,
     *,
-    user_inputs: Optional[List[State]],
-    user: Optional[str],
+    user_inputs: list[State] | None,
+    user: str | None,
     **kwargs: Any,
 ) -> UUID:
     """Client side call of Celery."""
@@ -94,11 +95,11 @@ def _celery_set_process_status_resumed(process: ProcessTable) -> None:
     db.session.commit()
 
 
-def _celery_validate(validation_workflow: str, json: Optional[List[State]]) -> None:
+def _celery_validate(validation_workflow: str, json: list[State] | None) -> None:
     _celery_start_process(validation_workflow, user_inputs=json)
 
 
-CELERY_EXECUTION_CONTEXT: Dict[str, Callable] = {
+CELERY_EXECUTION_CONTEXT: dict[str, Callable] = {
     "start": _celery_start_process,
     "resume": _celery_resume_process,
     "validate": _celery_validate,

--- a/orchestrator/services/fixed_inputs.py
+++ b/orchestrator/services/fixed_inputs.py
@@ -10,14 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from sqlalchemy import select
 
 from orchestrator.db import FixedInputTable, db
 
 
-def get_fixed_inputs(*, filters: Optional[list] = None) -> list[FixedInputTable]:
+def get_fixed_inputs(*, filters: list | None = None) -> list[FixedInputTable]:
     stmt = select(FixedInputTable)
     for clause in filters or []:
         stmt = stmt.where(clause)

--- a/orchestrator/services/products.py
+++ b/orchestrator/services/products.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 
-from typing import Optional, Union
 from uuid import UUID
 
 from sqlalchemy import select
@@ -22,14 +21,14 @@ from orchestrator.db import ProductTable, db
 from orchestrator.types import UUIDstr
 
 
-def get_products(*, filters: Optional[list] = None) -> list[ProductTable]:
+def get_products(*, filters: list | None = None) -> list[ProductTable]:
     stmt = select(ProductTable)
     for clause in filters or []:
         stmt = stmt.where(clause)
     return list(db.session.scalars(stmt))
 
 
-def get_product_by_id(product_id: Union[UUID, UUIDstr], join_fixed_inputs: bool = True) -> Optional[ProductTable]:
+def get_product_by_id(product_id: UUID | UUIDstr, join_fixed_inputs: bool = True) -> ProductTable | None:
     """Get product by id.
 
     Args:

--- a/orchestrator/services/resource_types.py
+++ b/orchestrator/services/resource_types.py
@@ -10,14 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from sqlalchemy import select
 
 from orchestrator.db import ResourceTypeTable, db
 
 
-def get_resource_types(*, filters: Optional[list] = None) -> list[ResourceTypeTable]:
+def get_resource_types(*, filters: list | None = None) -> list[ResourceTypeTable]:
     stmt = select(ResourceTypeTable)
     for clause in filters or []:
         stmt = stmt.where(clause)

--- a/orchestrator/services/translations.py
+++ b/orchestrator/services/translations.py
@@ -12,11 +12,11 @@
 # limitations under the License.
 import json
 from pathlib import Path
-from typing import Dict, Union
+from typing import Union
 
 from orchestrator.settings import app_settings
 
-Translations = Dict[str, Union[dict, str]]
+Translations = dict[str, Union[dict, str]]
 
 
 def _load_translations_file(language: str, translations_dir: Path) -> Translations:

--- a/orchestrator/services/workflows.py
+++ b/orchestrator/services/workflows.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 from sqlalchemy import Select, select
 
@@ -27,7 +27,7 @@ def _to_workflow_schema(workflow: WorkflowTable, include_steps: bool = False) ->
 
 
 def get_workflows(
-    filters: Optional[dict] = None, include_steps: bool = False, include_deleted: bool = False
+    filters: dict | None = None, include_steps: bool = False, include_deleted: bool = False
 ) -> Iterable[WorkflowSchema]:
     def _add_filter(stmt: Select) -> Select:
         for k, v in (filters or {}).items():
@@ -40,5 +40,5 @@ def get_workflows(
     return [_to_workflow_schema(wf, include_steps=include_steps) for wf in workflows]
 
 
-def get_workflow_by_name(workflow_name: str) -> Optional[WorkflowTable]:
+def get_workflow_by_name(workflow_name: str) -> WorkflowTable | None:
     return db.session.scalar(select(WorkflowTable).where(WorkflowTable.name == workflow_name))

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -14,7 +14,6 @@
 import secrets
 import string
 from pathlib import Path
-from typing import List, Optional
 
 from pydantic import PostgresDsn, RedisDsn
 from pydantic_settings import BaseSettings
@@ -32,9 +31,9 @@ class AppSettings(BaseSettings):
     TESTING: bool = True
     SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     CORS_ORIGINS: str = "*"
-    CORS_ALLOW_METHODS: List[str] = ["GET", "PUT", "PATCH", "POST", "DELETE", "OPTIONS", "HEAD"]
-    CORS_ALLOW_HEADERS: List[str] = ["If-None-Match", "Authorization", "If-Match", "Content-Type"]
-    CORS_EXPOSE_HEADERS: List[str] = [
+    CORS_ALLOW_METHODS: list[str] = ["GET", "PUT", "PATCH", "POST", "DELETE", "OPTIONS", "HEAD"]
+    CORS_ALLOW_HEADERS: list[str] = ["If-None-Match", "Authorization", "If-Match", "Content-Type"]
+    CORS_EXPOSE_HEADERS: list[str] = [
         "Cache-Control",
         "Content-Language",
         "Content-Length",
@@ -56,7 +55,7 @@ class AppSettings(BaseSettings):
     MAIL_STARTTLS: bool = False
     CACHE_URI: RedisDsn = "redis://localhost:6379/0"  # type: ignore
     CACHE_DOMAIN_MODELS: bool = False
-    CACHE_HMAC_SECRET: Optional[str] = None  # HMAC signing key, used when pickling results in the cache
+    CACHE_HMAC_SECRET: str | None = None  # HMAC signing key, used when pickling results in the cache
     ENABLE_DISTLOCK_MANAGER: bool = True
     DISTLOCK_BACKEND: str = "memory"
     CC_NOC: int = 0
@@ -67,12 +66,12 @@ class AppSettings(BaseSettings):
     SLACK_ENGINE_SETTINGS_HOOK_URL: str = ""
     TRACING_ENABLED: bool = False
     TRACE_HOST: str = "http://localhost:4317"
-    TRANSLATIONS_DIR: Optional[Path] = None
+    TRANSLATIONS_DIR: Path | None = None
     WEBSOCKET_BROADCASTER_URL: str = "memory://"
     ENABLE_WEBSOCKETS: bool = True
     DISABLE_INSYNC_CHECK: bool = False
-    DEFAULT_PRODUCT_WORKFLOWS: List[str] = ["modify_note"]
-    SKIP_MODEL_FOR_MIGRATION_DB_DIFF: List[str] = []
+    DEFAULT_PRODUCT_WORKFLOWS: list[str] = ["modify_note"]
+    SKIP_MODEL_FOR_MIGRATION_DB_DIFF: list[str] = []
     SERVE_GRAPHQL_UI: bool = True
     FEDEREATION_ENABLED: bool = False
     DEFAULT_CUSTOMER_FULLNAME: str = "Default::Orchestrator-Core Customer"

--- a/orchestrator/types.py
+++ b/orchestrator/types.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections.abc
-import sys
+import types
 import typing
 from enum import Enum  # noqa: F401 (doctest)
 from http import HTTPStatus
@@ -96,16 +96,9 @@ __all__ = [
 if TYPE_CHECKING:
     from orchestrator.domain.base import ProductBlockModel
 
-if sys.version_info < (3, 10):
 
-    def is_union(tp: Optional[Type[Any]]) -> bool:
-        return tp is Union  # type: ignore[comparison-overlap]
-
-else:
-    import types
-
-    def is_union(tp: Optional[Type[Any]]) -> bool:
-        return tp is Union or tp is types.UnionType  # type: ignore[comparison-overlap]
+def is_union(tp: Optional[Type[Any]]) -> bool:
+    return tp is Union or tp is types.UnionType  # type: ignore[comparison-overlap]
 
 
 # ErrorState is either a string containing an error message, a catched Exception or a tuple containing a message and

--- a/orchestrator/utils/crypt.py
+++ b/orchestrator/utils/crypt.py
@@ -22,10 +22,10 @@ class Cryptic:
     MAGIC = "$9$"
     MAGIC_SEARCH = r"\$9\$"
     FAMILY = ["QzF3n6/9CAtpu0O", "B1IREhcSyrleKvMW8LXx", "7N-dVbwsY2g4oaJZGUDj", "iHkq.mPf5T"]
-    EXTRA: Dict[str, int] = {}
+    EXTRA: dict[str, int] = {}
     VALID = ""
     NUM_ALPHA = ""
-    ALPHA_NUM: Dict[str, int] = {}
+    ALPHA_NUM: dict[str, int] = {}
     ENCODING = [[1, 4, 32], [1, 16, 32], [1, 8, 32], [1, 64], [1, 32], [1, 4, 16, 128], [1, 32, 64]]
 
     # ------------------------------------------------------------------------------
@@ -52,10 +52,10 @@ class Cryptic:
         return ret
 
     # ------------------------------------------------------------------------------
-    def _gap_encode(self, pc: str, prev: str, enc: List[int]) -> str:
+    def _gap_encode(self, pc: str, prev: str, enc: list[int]) -> str:
         literal_pc = ord(pc)
         crypt = ""
-        gaps: List[int] = []
+        gaps: list[int] = []
 
         for mod in reversed(enc):
             gaps.insert(0, int(literal_pc / mod))
@@ -70,7 +70,7 @@ class Cryptic:
         return crypt
 
     # ------------------------------------------------------------------------------
-    def encrypt(self, plain: str, salt: Optional[str] = None) -> str:
+    def encrypt(self, plain: str, salt: str | None = None) -> str:
         if salt is None:
             salt = self._randc(1)
         rand = self._randc(self.EXTRA[salt])
@@ -88,7 +88,7 @@ class Cryptic:
         return crypt
 
     # ------------------------------------------------------------------------------
-    def _nibble(self, cref: str, length: int) -> Tuple[str, str]:
+    def _nibble(self, cref: str, length: int) -> tuple[str, str]:
         nib = cref[0:length]
         cref = cref[length:]
 
@@ -99,7 +99,7 @@ class Cryptic:
         return ((self.ALPHA_NUM[c2] - self.ALPHA_NUM[c1]) % len(self.NUM_ALPHA)) - 1
 
     # ------------------------------------------------------------------------------
-    def _gap_decode(self, gaps: List[int], dec: List[int]) -> str:
+    def _gap_decode(self, gaps: list[int], dec: list[int]) -> str:
         num = 0
         assert len(gaps) == len(dec)
         for i in range(len(gaps)):
@@ -108,7 +108,7 @@ class Cryptic:
         return chr(num % 256)
 
     # ------------------------------------------------------------------------------
-    def decrypt(self, crypt: Optional[str]) -> Optional[str]:
+    def decrypt(self, crypt: str | None) -> str | None:
         if crypt is None or len(crypt) == 0:
             print("Invalid Crypt")
             return None

--- a/orchestrator/utils/docs.py
+++ b/orchestrator/utils/docs.py
@@ -25,7 +25,7 @@ WARNING2: Since we use the sphinx napoleon extension and the docstrings we gener
 """
 
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, get_origin
+from typing import TYPE_CHECKING, Any, get_origin
 from uuid import UUID
 
 from more_itertools import first
@@ -78,7 +78,7 @@ def make_field_doc(field_name: str, field_type: Any) -> str:
 
 
 def make_product_block_docstring(
-    block: Type["ProductBlockModel"], lifecycle: Optional[List[SubscriptionLifecycle]] = None
+    block: type["ProductBlockModel"], lifecycle: list[SubscriptionLifecycle] | None = None
 ) -> str:
     lifecycle_str = f"\n\nValid for statuses: {', '.join(lifecycle) if lifecycle else 'all others'}"
 
@@ -105,7 +105,7 @@ def make_product_block_docstring(
 
 
 def make_subscription_model_docstring(
-    model: Type["SubscriptionModel"], lifecycle: Optional[List[SubscriptionLifecycle]] = None
+    model: type["SubscriptionModel"], lifecycle: list[SubscriptionLifecycle] | None = None
 ) -> str:
     lifecycle_str = f"\n\nValid for statuses: {', '.join(lifecycle) if lifecycle else 'all others'}"
 
@@ -145,12 +145,12 @@ def make_workflow_doc(wf: "Workflow") -> str:
     return f"{(wf.__doc__ or '')}\n\nSteps:\n\n{steps_string}\n"
 
 
-def make_workflow_index_doc(all_workflows: Dict[str, "LazyWorkflowInstance"]) -> str:
+def make_workflow_index_doc(all_workflows: dict[str, "LazyWorkflowInstance"]) -> str:
     workflow_list_str = "\n".join(map(lambda wf: f"* :obj:`~{wf[1].package}.{wf[0]}`", all_workflows.items()))
     return f"\nWorkflows\n---------\n\n{workflow_list_str}\n"
 
 
-def make_product_type_index_doc(subscription_model_registry: Dict[str, Type["SubscriptionModel"]]) -> str:
+def make_product_type_index_doc(subscription_model_registry: dict[str, type["SubscriptionModel"]]) -> str:
     product_types_str = "\n".join(
         map(
             lambda product: f"* :class:`~{product.__module__}.{product.__qualname__}`",

--- a/orchestrator/utils/enrich_process.py
+++ b/orchestrator/utils/enrich_process.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 from more_itertools import first
 
@@ -48,11 +47,11 @@ def format_subscription(subscription: SubscriptionTable) -> dict:
 step_finish_statuses = [StepStatus.SUCCESS, StepStatus.SKIPPED, StepStatus.COMPLETE]
 
 
-def find_previous_step(steps: list[ProcessStepTable], index: int) -> Optional[ProcessStepTable]:
+def find_previous_step(steps: list[ProcessStepTable], index: int) -> ProcessStepTable | None:
     return first([step for step in reversed(steps[:index]) if step.status in step_finish_statuses], None)
 
 
-def enrich_step_details(step: ProcessStepTable, previous_step: Optional[ProcessStepTable]) -> dict:
+def enrich_step_details(step: ProcessStepTable, previous_step: ProcessStepTable | None) -> dict:
     state_delta = get_dict_updates(previous_step.state, step.state) if previous_step else step.state
 
     return {
@@ -86,7 +85,7 @@ def enrich_process_details(process: ProcessTable, p_stat: ProcessStat) -> dict:
     }
 
 
-def enrich_process(process: ProcessTable, p_stat: Optional[ProcessStat] = None) -> dict:
+def enrich_process(process: ProcessTable, p_stat: ProcessStat | None = None) -> dict:
     # process.subscriptions is a non JSON serializable AssociationProxy
     # So we need to build a list of Subscriptions here.
     subscriptions = [format_subscription(sub) for sub in process.subscriptions]

--- a/orchestrator/utils/errors.py
+++ b/orchestrator/utils/errors.py
@@ -13,7 +13,7 @@
 
 from functools import singledispatch
 from http import HTTPStatus
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 import structlog
 from deprecated import deprecated
@@ -31,14 +31,12 @@ class ApiException(Exception):  # noqa: N818
     This should conform to what is used in the api clients.
     """
 
-    status: Optional[HTTPStatus]
-    reason: Optional[str]
-    body: Optional[str]
-    headers: Dict[str, str]
+    status: HTTPStatus | None
+    reason: str | None
+    body: str | None
+    headers: dict[str, str]
 
-    def __init__(
-        self, status: Optional[HTTPStatus] = None, reason: Optional[str] = None, http_resp: Optional[object] = None
-    ):
+    def __init__(self, status: HTTPStatus | None = None, reason: str | None = None, http_resp: object | None = None):
         super().__init__(status, reason, http_resp)
         if http_resp:
             self.status = http_resp.status  # type:ignore

--- a/orchestrator/utils/functional.py
+++ b/orchestrator/utils/functional.py
@@ -13,7 +13,8 @@
 
 
 import itertools
-from typing import Callable, Iterable, List, Optional, Sequence, Set, TypeVar, Union
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeVar
 
 import more_itertools
 import structlog
@@ -76,7 +77,7 @@ def orig(func: Callable) -> Callable:
     return f
 
 
-def join_cs(*args: Union[Iterable[str], str]) -> str:
+def join_cs(*args: Iterable[str] | str) -> str:
     """Return comma separated string from one or more comma separated strings or iterables of strings.
 
     It deals with empty strings and properly inserting comma's.
@@ -91,7 +92,7 @@ def join_cs(*args: Union[Iterable[str], str]) -> str:
 
     """
 
-    def to_iterable(value: Union[Iterable[str], str]) -> Iterable[str]:
+    def to_iterable(value: Iterable[str] | str) -> Iterable[str]:
         if isinstance(value, str):
             return filter(None, value.split(","))
         return value
@@ -99,7 +100,7 @@ def join_cs(*args: Union[Iterable[str], str]) -> str:
     return ",".join(itertools.chain(*map(to_iterable, args)))
 
 
-def expand_ranges(ranges: Sequence[Sequence[int]], inclusive: bool = False) -> List[int]:
+def expand_ranges(ranges: Sequence[Sequence[int]], inclusive: bool = False) -> list[int]:
     """Expand sequence of range definitions into sorted and deduplicated list of individual values.
 
     A range definition is either a:
@@ -132,7 +133,7 @@ def expand_ranges(ranges: Sequence[Sequence[int]], inclusive: bool = False) -> L
         ValueError: if range definition is not a one or two element sequence.
 
     """
-    values: Set[int] = set()
+    values: set[int] = set()
     for r in ranges:
         if len(r) == 2:
             values.update(range(r[0], r[1] + (1 if inclusive else 0)))
@@ -146,7 +147,7 @@ def expand_ranges(ranges: Sequence[Sequence[int]], inclusive: bool = False) -> L
 T = TypeVar("T")
 
 
-def as_t(value: Optional[T]) -> T:
+def as_t(value: T | None) -> T:
     """Cast `value` to non-Optional.
 
     One often needs to assign a value that was typed as being `Optional` to a variable that is typed non-Optional. MyPy

--- a/orchestrator/utils/helpers.py
+++ b/orchestrator/utils/helpers.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from collections.abc import Callable
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, TypeVar
 
 import structlog
 
@@ -22,7 +23,7 @@ T = TypeVar("T")
 logger = structlog.get_logger(__name__)
 
 
-def create_filter_string(input: Union[list[str], None]) -> str:
+def create_filter_string(input: list[str] | None) -> str:
     return ",".join(input) if input else ""
 
 

--- a/orchestrator/utils/json.py
+++ b/orchestrator/utils/json.py
@@ -75,10 +75,11 @@ decoding functions differently then `default` and `object_hook` is that they are
 
 """
 import re
+from collections.abc import Sequence
 from contextlib import suppress
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Sequence, Set, Tuple, Union
+from typing import Any, Union
 from uuid import UUID
 
 import orjson as json
@@ -89,12 +90,12 @@ from pydantic import BaseModel
 from orchestrator.utils.datetime import isoformat
 from orchestrator.utils.helpers import is_ipaddress_type
 
-PY_JSON_TYPES = Union[Dict[str, Any], List, str, int, float, bool, None, object]  # pragma: no mutate
+PY_JSON_TYPES = Union[dict[str, Any], list, str, int, float, bool, None, object]  # pragma: no mutate
 
 logger = structlog.get_logger(__name__)
 
 
-def json_loads(s: Union[str, bytes, bytearray]) -> PY_JSON_TYPES:
+def json_loads(s: str | bytes | bytearray) -> PY_JSON_TYPES:
     o = json.loads(s)
     if isinstance(o, list):
         return [from_serializable(dikt) if isinstance(dikt, dict) else dikt for dikt in o]
@@ -144,7 +145,7 @@ def to_serializable(o: Any) -> Any:
         return o.to_dict()
     if isinstance(o, BaseModel):
         return o.model_dump()
-    if isinstance(o, Set):
+    if isinstance(o, set):
         return list(o)
     raise TypeError(f"Could not serialize object of type {o.__class__.__name__} to JSON")
 
@@ -153,7 +154,7 @@ ISO_FORMAT_STR_LEN = len("2019-05-18T15:17:00+00:00")  # assume 'seconds' precis
 UUID_PATTERN = re.compile(r"^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$", re.IGNORECASE)
 
 
-def from_serializable(dct: Dict[str, Any]) -> Dict[str, Any]:
+def from_serializable(dct: dict[str, Any]) -> dict[str, Any]:
     """Convert a serializable object into a more specific, custom, Python data type.
 
     Args:
@@ -174,7 +175,7 @@ def from_serializable(dct: Dict[str, Any]) -> Dict[str, Any]:
     return dct
 
 
-def non_none_dict(dikt: Sequence[Tuple[str, Any]]) -> Dict[Any, Any]:
+def non_none_dict(dikt: Sequence[tuple[str, Any]]) -> dict[Any, Any]:
     """Return no `None` values in a Dict.
 
     This function may be used in the `asdict()` method as dictionary factory.

--- a/orchestrator/utils/redis.py
+++ b/orchestrator/utils/redis.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 from os import getenv
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 from uuid import UUID
 
 from redis import Redis
@@ -34,7 +34,7 @@ def caching_models_enabled() -> bool:
     return getenv("AIOCACHE_DISABLE", "0") == "0" and app_settings.CACHE_DOMAIN_MODELS
 
 
-def to_redis(subscription: Dict[str, Any]) -> None:
+def to_redis(subscription: dict[str, Any]) -> None:
     if caching_models_enabled():
         logger.info("Setting cache for subscription", subscription=subscription["subscription_id"])
         etag = _generate_etag(subscription)
@@ -44,7 +44,7 @@ def to_redis(subscription: Dict[str, Any]) -> None:
         logger.warning("Caching disabled, not caching subscription", subscription=subscription["subscription_id"])
 
 
-def from_redis(subscription_id: UUID) -> Optional[Tuple[Any, str]]:
+def from_redis(subscription_id: UUID) -> tuple[Any, str] | None:
     log = logger.bind(subscription_id=subscription_id)
     if caching_models_enabled():
         log.debug("Try to retrieve subscription from cache")

--- a/orchestrator/utils/speed.py
+++ b/orchestrator/utils/speed.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 from math import floor, log
-from typing import Union
 
 
 def format_bandwidth(mbits: int, short: bool = False) -> str:
@@ -60,7 +59,7 @@ def format_bandwidth(mbits: int, short: bool = False) -> str:
     return f"{number}{separator}{units[unit_fmt][magnitude]}"
 
 
-def speed_humanize(bandwidth: Union[int, str], short: bool = False) -> str:
+def speed_humanize(bandwidth: int | str, short: bool = False) -> str:
     if isinstance(bandwidth, str) and "," in bandwidth:
         return ",".join(map(speed_humanize, bandwidth.split(",")))
     try:

--- a/orchestrator/utils/state.py
+++ b/orchestrator/utils/state.py
@@ -13,11 +13,10 @@
 
 
 import inspect
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, List, Optional, Tuple, Union, cast
+from typing import Any, cast, get_args
 from uuid import UUID
-
-from typing_extensions import get_args
 
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import State, StepFunc, is_list_type, is_optional_type
@@ -32,7 +31,7 @@ from pydantic_forms.types import (
 )
 
 
-def extract(keys: Tuple[str, ...], state: State) -> Tuple[Any, ...]:
+def extract(keys: tuple[str, ...], state: State) -> tuple[Any, ...]:
     """Extract multiple values from dictionary.
 
     Args:
@@ -46,7 +45,7 @@ def extract(keys: Tuple[str, ...], state: State) -> Tuple[Any, ...]:
     return tuple(state[k] for k in keys)
 
 
-def _get_sub_id(val: Any) -> Optional[UUID]:
+def _get_sub_id(val: Any) -> UUID | None:
     """Get the subscription_id for a domain model from a state like dict.
 
     The convention we use is that for a parameter specification of `light_path: Sn8LightPath` for a step function,
@@ -132,7 +131,7 @@ def _save_models(state: State) -> None:
             _save_models(value)
 
 
-def _build_arguments(func: Union[StepFunc, InputStepFunc], state: State) -> List:  # noqa: C901
+def _build_arguments(func: StepFunc | InputStepFunc, state: State) -> list:  # noqa: C901
     """Build actual arguments based on step function signature and state.
 
     What the step function requests in its function signature it what this function retrieves from the state or DB.
@@ -153,7 +152,7 @@ def _build_arguments(func: Union[StepFunc, InputStepFunc], state: State) -> List
 
     """
     sig = inspect.signature(func)
-    arguments: List[Any] = []
+    arguments: list[Any] = []
     if sig.parameters:
         for name, param in sig.parameters.items():
             # Ignore dynamic arguments. Mostly need to deal with `const`
@@ -323,7 +322,7 @@ def form_inject_args(func: InputStepFunc) -> StateInputStepFunc:
         simple_func = cast(SimpleInputFormGenerator, func)
 
         @wraps(simple_func)
-        def wrapper(state: State) -> Optional[InputForm]:
+        def wrapper(state: State) -> InputForm | None:
             args = _build_arguments(simple_func, state)
             return simple_func(*args)
 

--- a/orchestrator/version.py
+++ b/orchestrator/version.py
@@ -12,14 +12,13 @@
 # limitations under the License.
 
 from subprocess import check_output  # noqa: S404
-from typing import Optional
 
 import structlog
 
 logger = structlog.getLogger(__name__)
 
 
-def __getattr__(name: str) -> Optional[str]:
+def __getattr__(name: str) -> str | None:
     """Return the GIT_COMMIT_HASH.
 
     Usage::

--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from asyncio import new_event_loop
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -35,12 +35,12 @@ class WS_CHANNELS:
     ENGINE_SETTINGS = "engine-settings"
 
 
-async def empty_fn(*args: tuple, **kwargs: Dict[str, Any]) -> None:
+async def empty_fn(*args: tuple, **kwargs: dict[str, Any]) -> None:
     return
 
 
 class WrappedWebSocketManager:
-    def __init__(self, wrappee: Optional[WebSocketManager] = None) -> None:
+    def __init__(self, wrappee: WebSocketManager | None = None) -> None:
         self.wrapped_websocket_manager = wrappee
 
     def update(self, wrappee: WebSocketManager) -> None:
@@ -80,18 +80,18 @@ def init_websocket_manager(settings: AppSettings) -> WebSocketManager:
     return websocket_manager
 
 
-def create_process_websocket_data(process: ProcessTable, pStat: ProcessStat) -> Dict:
+def create_process_websocket_data(process: ProcessTable, pStat: ProcessStat) -> dict:
     return {"process": enrich_process(process, pStat)}
 
 
-def is_process_active(p: Dict) -> bool:
+def is_process_active(p: dict) -> bool:
     return p["status"] in [ProcessStatus.RUNNING, ProcessStatus.SUSPENDED, ProcessStatus.WAITING]
 
 
 def send_process_data_to_websocket(
     process_id: UUID,
-    data: Dict,
-    broadcast_func: Optional[BroadcastFunc] = None,
+    data: dict,
+    broadcast_func: BroadcastFunc | None = None,
 ) -> None:
     """Broadcast data of the current process to connected websocket clients."""
     if not websocket_manager.enabled:

--- a/orchestrator/websocket/managers/broadcast_websocket_manager.py
+++ b/orchestrator/websocket/managers/broadcast_websocket_manager.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union
 
 from broadcaster import Broadcast
 from fastapi import WebSocket, status
@@ -48,7 +47,7 @@ class BroadcastWebsocketManager:
         self.remove_ws_from_connected_list(websocket)
 
     async def disconnect(
-        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: Union[Dict, str, None] = None
+        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: dict | str | None = None
     ) -> None:
         if reason:
             await websocket.send_text(json_dumps(reason))
@@ -74,7 +73,7 @@ class BroadcastWebsocketManager:
                     await self.disconnect(websocket)
                     break
 
-    async def broadcast_data(self, channels: List[str], data: Dict) -> None:
+    async def broadcast_data(self, channels: list[str], data: dict) -> None:
         await self.pub_broadcast.connect()
         for channel in channels:
             await self.pub_broadcast.publish(channel, message=json_dumps(data))

--- a/orchestrator/websocket/managers/memory_websocket_manager.py
+++ b/orchestrator/websocket/managers/memory_websocket_manager.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union
 
 from fastapi import WebSocket, WebSocketDisconnect, status
 from starlette.websockets import WebSocketState
@@ -24,7 +23,7 @@ logger = get_logger(__name__)
 
 class MemoryWebsocketManager:
     def __init__(self) -> None:
-        self.connections_by_pid: Dict[str, List[WebSocket]] = {}
+        self.connections_by_pid: dict[str, list[WebSocket]] = {}
 
     async def connect(self, websocket: WebSocket, channel: str) -> None:
         if channel not in self.connections_by_pid:
@@ -43,7 +42,7 @@ class MemoryWebsocketManager:
         await self.remove_ws(websocket, channel)
 
     async def disconnect(
-        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: Union[Dict, str, None] = None
+        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: dict | str | None = None
     ) -> None:
         if reason:
             await websocket.send_text(json_dumps(reason))
@@ -54,7 +53,7 @@ class MemoryWebsocketManager:
             for websocket in self.connections_by_pid[channel]:
                 await self.remove_ws(websocket, channel)
 
-    async def broadcast_data(self, channels: List[str], data: Dict) -> None:
+    async def broadcast_data(self, channels: list[str], data: dict) -> None:
         try:
             for channel in channels:
                 if channel in self.connections_by_pid:

--- a/orchestrator/websocket/websocket_manager.py
+++ b/orchestrator/websocket/websocket_manager.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from fastapi import WebSocket, status
@@ -28,7 +27,7 @@ logger = get_logger(__name__)
 
 
 class WebSocketManager:
-    _backend: Union[MemoryWebsocketManager, BroadcastWebsocketManager]
+    _backend: MemoryWebsocketManager | BroadcastWebsocketManager
 
     def __init__(self, websockets_enabled: bool, broadcast_url: str):
         self.enabled = websockets_enabled
@@ -39,7 +38,7 @@ class WebSocketManager:
         else:
             self._backend = MemoryWebsocketManager()
 
-    async def authorize(self, websocket: WebSocket, token: str) -> Optional[Dict]:
+    async def authorize(self, websocket: WebSocket, token: str) -> dict | None:
         try:
             async with AsyncClient(verify=HTTPX_SSL_CONTEXT) as client:
                 user = await oidc_user(websocket, token=token)  # type: ignore
@@ -63,12 +62,12 @@ class WebSocketManager:
         await self._backend.connect(websocket, channel)
 
     async def disconnect(
-        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: Union[Dict, str, None] = None
+        self, websocket: WebSocket, code: int = status.WS_1000_NORMAL_CLOSURE, reason: dict | str | None = None
     ) -> None:
         await self._backend.disconnect(websocket, code, reason)
 
     async def disconnect_all(self) -> None:
         await self._backend.disconnect_all()
 
-    async def broadcast_data(self, channels: List[str], data: Dict) -> None:
+    async def broadcast_data(self, channels: list[str], data: dict) -> None:
         await self._backend.broadcast_data(channels, data)

--- a/orchestrator/workflows/__init__.py
+++ b/orchestrator/workflows/__init__.py
@@ -13,7 +13,6 @@
 
 
 from importlib import import_module
-from typing import Dict, Optional
 
 from orchestrator.utils.docs import make_workflow_index_doc
 from orchestrator.workflow import Workflow
@@ -21,7 +20,7 @@ from orchestrator.workflow import Workflow
 DEFAULT_PKG = "orchestrator.workflows"
 
 
-ALL_WORKFLOWS: Dict[str, "LazyWorkflowInstance"] = {}
+ALL_WORKFLOWS: dict[str, "LazyWorkflowInstance"] = {}
 
 
 class LazyWorkflowInstance:
@@ -95,7 +94,7 @@ class LazyWorkflowInstance:
         return f"LazyWorkflowInstance('{self.package}','{self.function}')"
 
 
-def get_workflow(name: str) -> Optional[Workflow]:
+def get_workflow(name: str) -> Workflow | None:
     wi = ALL_WORKFLOWS.get(name)
 
     if not wi:

--- a/orchestrator/workflows/tasks/resume_workflows.py
+++ b/orchestrator/workflows/tasks/resume_workflows.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import structlog
 from sqlalchemy import select
@@ -35,7 +34,7 @@ def find_waiting_workflows() -> State:
 
 
 @step("Resume found workflows")
-def resume_found_workflows(waiting_process_ids: List[UUIDstr]) -> State:
+def resume_found_workflows(waiting_process_ids: list[UUIDstr]) -> State:
     resumed_process_ids = []
     for process_id in waiting_process_ids:
         try:

--- a/orchestrator/workflows/tasks/validate_products.py
+++ b/orchestrator/workflows/tasks/validate_products.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any
 
 from more_itertools.more import one
 from more_itertools.recipes import first_true
@@ -104,7 +104,7 @@ def check_that_products_have_at_least_one_workflow() -> State:
 def check_that_products_have_create_modify_and_terminate_workflows() -> State:
     product_data = get_products(filters=[ProductTable.status == "active"])
 
-    workflows_not_complete: List = []
+    workflows_not_complete: list = []
     for product in product_data:
         workflows = {
             c.target
@@ -140,13 +140,13 @@ def check_db_fixed_input_config() -> State:
     stmt = select(FixedInputTable).options(joinedload(FixedInputTable.product))
     fixed_inputs = db.session.scalars(stmt)
 
-    data: Dict = {"fixed_inputs": [], "by_tag": {}}
-    errors: List = []
+    data: dict = {"fixed_inputs": [], "by_tag": {}}
+    errors: list = []
 
     for tag in product_tags:
         data["by_tag"][tag] = []
     for fi in fixed_inputs:
-        fi_data: Dict = first_true(
+        fi_data: dict = first_true(
             fixed_input_configuration["fixed_inputs"], {}, lambda i: i["name"] == fi.name  # noqa: B023
         )
         if not fi_data:
@@ -175,7 +175,7 @@ def check_db_fixed_input_config() -> State:
 @step("Check subscription models")
 def check_subscription_models() -> State:
     subscriptions = db.session.scalars(select(SubscriptionTable))
-    failures: Dict[str, Any] = {}
+    failures: dict[str, Any] = {}
     for subscription in subscriptions:
         try:
             SubscriptionModel.from_subscription(subscription.subscription_id)

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -11,8 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from inspect import isgeneratorfunction
-from typing import Callable, Optional, cast
+from typing import cast
 from uuid import UUID
 
 from more_itertools import first_true
@@ -64,7 +65,7 @@ def _generate_new_subscription_form(_workflow_target: str, workflow_name: str) -
     return NewProductPage
 
 
-def wrap_create_initial_input_form(initial_input_form: Optional[InputStepFunc]) -> Optional[StateInputStepFunc]:
+def wrap_create_initial_input_form(initial_input_form: InputStepFunc | None) -> StateInputStepFunc | None:
     """Wrap initial input for create workflows.
 
     This is needed because the frontend expects all create workflows to start with a page that only contains the product.
@@ -142,7 +143,7 @@ def _generate_modify_form(workflow_target: str, workflow_name: str) -> InputForm
     return ModifySubscriptionPage
 
 
-def wrap_modify_initial_input_form(initial_input_form: Optional[InputStepFunc]) -> Optional[StateInputStepFunc]:
+def wrap_modify_initial_input_form(initial_input_form: InputStepFunc | None) -> StateInputStepFunc | None:
     """Wrap initial input for modify and terminate workflows.
 
     This is needed because the frontend expects all modify workflows to start with a page that only contains the
@@ -189,9 +190,9 @@ push_domain_models = conditional(lambda _: caching_models_enabled())
 
 def create_workflow(
     description: str,
-    initial_input_form: Optional[InputStepFunc] = None,
+    initial_input_form: InputStepFunc | None = None,
     status: SubscriptionLifecycle = SubscriptionLifecycle.ACTIVE,
-    additional_steps: Optional[StepList] = None,
+    additional_steps: StepList | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow with a target=Target.CREATE.
 
@@ -224,8 +225,8 @@ def create_workflow(
 
 def modify_workflow(
     description: str,
-    initial_input_form: Optional[InputStepFunc] = None,
-    additional_steps: Optional[StepList] = None,
+    initial_input_form: InputStepFunc | None = None,
+    additional_steps: StepList | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow.
 
@@ -261,8 +262,8 @@ def modify_workflow(
 
 def terminate_workflow(
     description: str,
-    initial_input_form: Optional[InputStepFunc] = None,
-    additional_steps: Optional[StepList] = None,
+    initial_input_form: InputStepFunc | None = None,
+    additional_steps: StepList | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,8 @@ classifiers = [
     "Intended Audience :: Telecommunications Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]
@@ -63,14 +62,14 @@ dependencies = [
     "typer==0.7.0",
     "uvicorn[standard]~=0.20.0",
     "nwa-stdlib~=1.5.4",
-    "oauth2-lib~=1.4.2",
+    "oauth2-lib~=1.5.0",
     "tabulate==0.9.0",
     "strawberry-graphql==0.209.8",
     "pydantic-forms==1.0.0",
 ]
 
 description-file = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.11,<3.13"
 
 [project.urls]
 Documentation = "https://workfloworchestrator.org/orchestrator-core/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "pydantic[email]~=2.5.1",
     "pydantic-settings~=2.1.0",
     "python-dateutil==2.8.2",
-    "python-rapidjson==1.9",
+    "python-rapidjson>=1.9,<1.15",
     "pytz==2023.3.post1",
     "redis>=4.6, <4.7.0",
     "schedule==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "nwa-stdlib~=1.5.4",
     "oauth2-lib~=1.5.0",
     "tabulate==0.9.0",
-    "strawberry-graphql==0.209.8",
+    "strawberry-graphql==0.210.0",
     "pydantic-forms==1.0.0",
 ]
 

--- a/test/acceptance_tests/fixtures/test_orchestrator/product_blocks/test_product_blocks.py
+++ b/test/acceptance_tests/fixtures/test_orchestrator/product_blocks/test_product_blocks.py
@@ -13,7 +13,6 @@
 
 
 from ipaddress import IPv4Address, IPv6Address
-from typing import Union
 from uuid import UUID
 
 from orchestrator.domain.base import ProductBlockModel
@@ -21,21 +20,21 @@ from orchestrator.types import SubscriptionLifecycle
 
 
 class TestProductBlockInactive(ProductBlockModel, product_block_name="Test Product Block"):
-    an_int: Union[int, None] = None
-    a_str: Union[str, None] = None
-    a_bool: Union[bool, None] = None
-    an_uuid: Union[UUID, None] = None
-    an_ipv4: Union[IPv4Address, None] = None
-    an_ipv6: Union[IPv6Address, None] = None
+    an_int: int | None = None
+    a_str: str | None = None
+    a_bool: bool | None = None
+    an_uuid: UUID | None = None
+    an_ipv4: IPv4Address | None = None
+    an_ipv6: IPv6Address | None = None
 
 
 class TestProductBlockProvisioning(TestProductBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
     an_int: int
     a_str: str
-    a_bool: Union[bool, None] = None
+    a_bool: bool | None = None
     an_uuid: UUID
-    an_ipv4: Union[IPv4Address, None] = None
-    an_ipv6: Union[IPv6Address, None] = None
+    an_ipv4: IPv4Address | None = None
+    an_ipv6: IPv6Address | None = None
 
 
 class TestProductBlock(TestProductBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):

--- a/test/unit_tests/api/test_processes_ws.py
+++ b/test/unit_tests/api/test_processes_ws.py
@@ -1,7 +1,8 @@
 import time
+from collections.abc import Generator
 from http import HTTPStatus
 from threading import Condition
-from typing import Any, Dict, Generator
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -52,7 +53,7 @@ def test_workflow_2(generic_subscription_1: UUIDstr, generic_product_type_1) -> 
         return {"subscription_id": str(uuid4()), "model": GenericProductOne.from_subscription(generic_subscription_1)}
 
     @step("Test that it is a string now")
-    def check_object(subscription_id: Any, model: Dict) -> None:
+    def check_object(subscription_id: Any, model: dict) -> None:
         # This is actually a test. It would be nicer to have this in a proper test but that takes to much setup that
         # already happens here. So we hijack this fixture and run this test for all tests that use this fixture
         # (which should not be an issue)

--- a/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
@@ -1,5 +1,4 @@
 import json
-from typing import List, Union
 
 from sqlalchemy import select, text
 
@@ -75,10 +74,10 @@ def test_migrate_domain_models_new_product_block_on_product_block(
     ):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
-        list_field: List[int]
+        list_field: list[int]
         new_block: TestBlock
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -131,10 +130,10 @@ def test_migrate_domain_models_new_resource_type(
     ):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
         new_int_field: int
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -236,10 +235,10 @@ def test_migrate_domain_models_update_resource_type(
     ):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
-        new_list_field: List[int]
+        new_list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -287,17 +286,17 @@ def test_migrate_domain_models_create_and_rename_resource_type(test_product_type
     ):
         int_field: int
         str_field: str
-        new_list_field: List[int]
+        new_list_field: list[int]
 
     class ProductBlockOneForTestUpdated(
         ProductBlockModel, product_block_name="ProductBlockOneForTest", lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
         sub_block: SubBlockOneForTestNewResource
         sub_block_2: SubBlockOneForTestNewResource
-        sub_block_list: List[SubBlockOneForTestNewResource]
+        sub_block_list: list[SubBlockOneForTestNewResource]
         str_field: str
         int_field: int
-        new_list_field: List[int]
+        new_list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -362,10 +361,10 @@ def test_migrate_domain_models_create_and_rename_and_delete_resource_type(
         product_block_name="ProductBlockWithListUnionForTest",
         lifecycle=[SubscriptionLifecycle.ACTIVE],
     ):
-        list_union_blocks: List[Union[SubBlockTwoForTestChanged, SubBlockOneForTestChanged]]
+        list_union_blocks: list[SubBlockTwoForTestChanged | SubBlockOneForTestChanged]
         changed_int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductSubListUnionTest(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: ProductBlockWithListUnionForTestNew
@@ -488,7 +487,7 @@ def test_migrate_domain_models_remove_product_block(test_product_type_one, produ
     assert subscription.block
     assert subscription.block.int_field
 
-    int_field_resource: List[ResourceTypeTable] = get_resource_types(
+    int_field_resource: list[ResourceTypeTable] = get_resource_types(
         filters=[ResourceTypeTable.resource_type == "int_field"]
     )
     int_field_instance_values = db.session.scalars(
@@ -528,7 +527,7 @@ def test_migrate_domain_models_remove_resource_type(
     ):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
 
@@ -569,10 +568,10 @@ def test_migrate_domain_models_update_block_resource_type(
     ):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         update_str_field: str
         int_field: int
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -631,10 +630,10 @@ def test_migrate_domain_models_rename_and_update_block_resource_type(test_produc
     ):
         sub_block: SubBlockOneForTesUpdated
         sub_block_2: SubBlockOneForTesUpdated
-        sub_block_list: List[SubBlockOneForTesUpdated]
+        sub_block_list: list[SubBlockOneForTesUpdated]
         update_str_field: str
         int_field: int
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -1,5 +1,4 @@
 import json
-from typing import List, Union
 
 from sqlalchemy import select, text
 
@@ -225,10 +224,10 @@ def test_migrate_domain_models_new_product_block_on_product_block(
     class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
-        list_field: List[int]
+        list_field: list[int]
         new_block: TestBlock
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -285,10 +284,10 @@ def test_migrate_domain_models_new_resource_type(
     class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
         new_int_field: int
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -339,10 +338,10 @@ def test_migrate_domain_models_rename_resource_type(
     class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
-        new_list_field: List[int]
+        new_list_field: list[int]
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -397,15 +396,15 @@ def test_migrate_domain_models_rename_and_relate_resource_type(
     class SubBlockOneForTestNewResource(SubBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         int_field: int
         str_field: str
-        new_list_field: List[int]  # add/relate renamed resource type to block
+        new_list_field: list[int]  # add/relate renamed resource type to block
 
     class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTestNewResource
         sub_block_2: SubBlockOneForTestNewResource
-        sub_block_list: List[SubBlockOneForTestNewResource]
+        sub_block_list: list[SubBlockOneForTestNewResource]
         str_field: str
         int_field: int
-        new_list_field: List[int]  # renamed from 'list_field'
+        new_list_field: list[int]  # renamed from 'list_field'
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -474,10 +473,10 @@ def test_migrate_domain_models_rename_and_relate_and_remove_resource_type(
     class ProductBlockWithListUnionForTestNew(
         ProductBlockWithListUnionForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
-        list_union_blocks: List[Union[SubBlockTwoForTestChanged, SubBlockOneForTestChanged]]
+        list_union_blocks: list[SubBlockTwoForTestChanged | SubBlockOneForTestChanged]
         changed_int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductSubListUnionTest(ProductSubListUnionProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: ProductBlockWithListUnionForTestNew
@@ -534,10 +533,10 @@ def test_migrate_domain_models_update_block_resource_type(
     class ProductBlockOneForTestUpdated(ProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         str_field: str
         new_int_field: int
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -685,7 +684,7 @@ def test_migrate_domain_models_remove_resource_type(
     class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
 

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import typing
 from contextlib import closing
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import pytest
 import requests
@@ -263,8 +263,8 @@ def test_client(fastapi_app):
             self,
             method: str,
             url: str,
-            data: Optional[Any] = None,
-            headers: Optional[typing.MutableMapping[str, str]] = None,
+            data: Any | None = None,
+            headers: typing.MutableMapping[str, str] | None = None,
             json: typing.Any = None,
             **kwargs: Any,
         ) -> requests.Response:
@@ -474,7 +474,7 @@ def generic_product_3(generic_product_block_2):
 @pytest.fixture
 def generic_product_block_type_1(generic_product_block_1):
     class GenericProductBlockOneInactive(ProductBlockModel, product_block_name="PB_1"):
-        rt_1: Optional[str] = None
+        rt_1: str | None = None
 
     class GenericProductBlockOne(GenericProductBlockOneInactive, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         rt_1: str
@@ -485,8 +485,8 @@ def generic_product_block_type_1(generic_product_block_1):
 @pytest.fixture
 def generic_product_block_type_2(generic_product_block_2):
     class GenericProductBlockTwoInactive(ProductBlockModel, product_block_name="PB_2"):
-        rt_2: Optional[int] = None
-        rt_3: Optional[str] = None
+        rt_2: int | None = None
+        rt_3: str | None = None
 
     class GenericProductBlockTwo(GenericProductBlockTwoInactive, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         rt_2: int
@@ -498,7 +498,7 @@ def generic_product_block_type_2(generic_product_block_2):
 @pytest.fixture
 def generic_product_block_type_3(generic_product_block_3):
     class GenericProductBlockThreeInactive(ProductBlockModel, product_block_name="PB_3"):
-        rt_2: Optional[int] = None
+        rt_2: int | None = None
 
     class GenericProductBlockThree(GenericProductBlockThreeInactive, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         rt_2: int
@@ -578,7 +578,7 @@ def product_type_1_subscriptions_factory(product_type_1_subscription_factory):
                 description=f"Subscription {i}",
                 start_date=(
                     datetime.datetime.fromisoformat("2023-05-24T00:00:00+00:00") + datetime.timedelta(days=i)
-                ).replace(tzinfo=datetime.timezone.utc),
+                ).replace(tzinfo=datetime.UTC),
             )
             for i in range(0, amount)
         ]

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List, Optional
 from unittest import mock
 from uuid import uuid4
 
@@ -850,7 +849,7 @@ def test_update_lists(test_product_one, test_product_block_one):
     ProductBlockOneForTestInactive, _, _ = test_product_block_one
 
     class TestListProductType(SubscriptionModel, is_base=True):
-        saps: List[ProductBlockOneForTestInactive]
+        saps: list[ProductBlockOneForTestInactive]
 
     # Creates
     ip = TestListProductType.from_product_id(product_id=test_product_one, customer_id=str(uuid4()))
@@ -873,7 +872,7 @@ def test_update_optional(test_product_one, test_product_block_one):
     ProductBlockOneForTestInactive, _, _ = test_product_block_one
 
     class TestListProductType(SubscriptionModel, is_base=True):
-        sap: Optional[ProductBlockOneForTestInactive] = None
+        sap: ProductBlockOneForTestInactive | None = None
 
     # Creates
     ip = TestListProductType.from_product_id(product_id=test_product_one, customer_id=str(uuid4()))
@@ -971,42 +970,42 @@ def test_abstract_super_block(test_product_one, test_product_type_one, test_prod
     ProductTypeOneForTestInactive, ProductTypeOneForTestProvisioning, ProductTypeOneForTest = test_product_type_one
 
     class AbstractProductBlockOneForTestInactive(ProductBlockModel):
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
 
     class AbstractProductBlockOneForTestProvisioning(
         AbstractProductBlockOneForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
     ):
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
 
     class AbstractProductBlockOneForTest(
         AbstractProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductBlockOneForTestInactive(
         AbstractProductBlockOneForTestInactive, product_block_name="ProductBlockOneForTest"
     ):
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
-        int_field: Optional[int] = None
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
+        int_field: int | None = None
 
     class ProductBlockOneForTestProvisioning(
         ProductBlockOneForTestInactive,
         AbstractProductBlockOneForTestProvisioning,
         lifecycle=[SubscriptionLifecycle.PROVISIONING],
     ):
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
         int_field: int
 
     class ProductBlockOneForTest(
         ProductBlockOneForTestProvisioning, AbstractProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
         int_field: int
 
     class AbstractProductTypeOneForTestInactive(SubscriptionModel):
@@ -1156,42 +1155,42 @@ def test_diff_in_db_missing_in_db(test_product_type_one):
 
 def test_from_other_lifecycle_abstract(test_product_one):
     class AbstractProductBlockOneForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneForTest"):
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
 
     class AbstractProductBlockOneForTestProvisioning(
         AbstractProductBlockOneForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
     ):
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
 
     class AbstractProductBlockOneForTest(
         AbstractProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     class ProductBlockOneForTestInactive(
         AbstractProductBlockOneForTestInactive, product_block_name="ProductBlockOneForTest"
     ):
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
-        int_field: Optional[int] = None
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
+        int_field: int | None = None
 
     class ProductBlockOneForTestProvisioning(
         ProductBlockOneForTestInactive,
         AbstractProductBlockOneForTestProvisioning,
         lifecycle=[SubscriptionLifecycle.PROVISIONING],
     ):
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
         int_field: int
 
     class ProductBlockOneForTest(
         ProductBlockOneForTestProvisioning, AbstractProductBlockOneForTest, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
         int_field: int
 
     block = ProductBlockOneForTestInactive.new(subscription_id=uuid4())

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from typing import List, Optional
 from unittest import mock
@@ -1107,13 +1106,7 @@ def test_diff_in_db_empty(test_product_one, test_product_type_one):
     assert ProductTypeOneForTestInactive.diff_product_in_database(test_product_one) == {}
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="Python 3.10 changed behavior of object.__annotations__ on empty derived class"
-)
 def test_diff_in_db_when_no_fields(test_product_one, test_product_type_one):
-    # As of Python 3.10, __annotations__ of an empty derived class no longer contain inherited fields
-    # Skipping this test for <3.10 because we have no usecase for empty derived classes + it's very difficult to fix this
-
     class Wrong(SubscriptionModel):
         pass
 

--- a/test/unit_tests/domain/test_lifecycle.py
+++ b/test/unit_tests/domain/test_lifecycle.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import pytest
 
 from orchestrator.domain.base import ProductBlockModel
@@ -9,7 +7,7 @@ from orchestrator.types import SubscriptionLifecycle
 @pytest.fixture
 def setup():
     class SubBlockInactive(ProductBlockModel, product_block_name="SubBlock"):
-        int_field: Optional[int] = None
+        int_field: int | None = None
 
     class SubBlockProvisioning(SubBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         int_field: int
@@ -48,4 +46,4 @@ def test_invalid_lifecycle_status_union(setup):
 
         class MainBlockProvisioning(MainBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
             sub_block1: SubBlockProvisioning
-            sub_block2: Union[SubBlockProvisioning, SubBlockInactive]  # first lifecycle is valid, second is not
+            sub_block2: SubBlockProvisioning | SubBlockInactive  # first lifecycle is valid, second is not

--- a/test/unit_tests/fixtures/__init__.py
+++ b/test/unit_tests/fixtures/__init__.py
@@ -1,6 +1,6 @@
 import random
 import string
-from typing import Any, Dict
+from typing import Any
 
 from orchestrator.db import (
     ProductTable,
@@ -19,7 +19,7 @@ def randomstr(length=3):
 
 
 def create_subscription_for_mapping(
-    product: ProductTable, mapping: SubscriptionMapping, values: Dict[str, Any], **kwargs: Any
+    product: ProductTable, mapping: SubscriptionMapping, values: dict[str, Any], **kwargs: Any
 ) -> SubscriptionTable:
     """Create a subscription in the test coredb for the given subscription_mapping and values.
 

--- a/test/unit_tests/fixtures/processes.py
+++ b/test/unit_tests/fixtures/processes.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from datetime import datetime, timedelta
-from typing import Any, Dict, Generator
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -24,7 +25,7 @@ def test_workflow(generic_subscription_1: UUIDstr, generic_product_type_1) -> Ge
         return {"subscription_id": str(uuid4()), "model": GenericProductOne.from_subscription(generic_subscription_1)}
 
     @step("Test that it is a string now")
-    def check_object(subscription_id: Any, model: Dict) -> None:
+    def check_object(subscription_id: Any, model: dict) -> None:
         # This is actually a test. It would be nicer to have this in a proper test but that takes to much setup that
         # already happens here. So we hijack this fixture and run this test for all tests that use this fixture
         # (which should not be an issue)

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_list_nested.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_list_nested.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import pytest
 
 from orchestrator.db import ProductBlockTable, db
@@ -8,21 +6,21 @@ from orchestrator.types import SubscriptionLifecycle
 
 
 class ProductBlockListNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockListNestedForTest"):
-    sub_block_list: List["ProductBlockListNestedForTestInactive"]
-    int_field: Optional[int] = None
+    sub_block_list: list["ProductBlockListNestedForTestInactive"]
+    int_field: int | None = None
 
 
 class ProductBlockListNestedForTestProvisioning(
     ProductBlockListNestedForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
 ):
-    sub_block_list: List["ProductBlockListNestedForTestProvisioning"]  # type: ignore
+    sub_block_list: list["ProductBlockListNestedForTestProvisioning"]  # type: ignore
     int_field: int
 
 
 class ProductBlockListNestedForTest(
     ProductBlockListNestedForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
 ):
-    sub_block_list: List["ProductBlockListNestedForTest"]  # type: ignore
+    sub_block_list: list["ProductBlockListNestedForTest"]  # type: ignore
     int_field: int
 
 

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_one.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_one.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import pytest
 from pydantic import Field, computed_field
 
@@ -15,11 +13,11 @@ def test_product_block_one(test_product_sub_block_one):
 
     class ProductBlockOneForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneForTest"):
         sub_block: SubBlockOneForTestInactive
-        sub_block_2: Optional[SubBlockOneForTestInactive] = None
-        sub_block_list: List[SubBlockOneForTestInactive] = []
-        int_field: Optional[int] = None
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
+        sub_block_2: SubBlockOneForTestInactive | None = None
+        sub_block_list: list[SubBlockOneForTestInactive] = []
+        int_field: int | None = None
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
 
         @computed_field  # type: ignore[misc]
         @property
@@ -31,18 +29,18 @@ def test_product_block_one(test_product_sub_block_one):
     ):
         sub_block: SubBlockOneForTestProvisioning
         sub_block_2: SubBlockOneForTestProvisioning
-        sub_block_list: List[SubBlockOneForTestProvisioning]
+        sub_block_list: list[SubBlockOneForTestProvisioning]
         int_field: int
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
 
     class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
         sub_block_2: SubBlockOneForTest
-        sub_block_list: List[SubBlockOneForTest]
+        sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     return ProductBlockOneForTestInactive, ProductBlockOneForTestProvisioning, ProductBlockOneForTest
 

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_one_nested.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_one_nested.py
@@ -9,7 +9,7 @@ from orchestrator.types import SubscriptionLifecycle
 
 class ProductBlockOneNestedForTestInactive(ProductBlockModel, product_block_name="ProductBlockOneNestedForTest"):
     sub_block: Optional["ProductBlockOneNestedForTestInactive"] = None
-    int_field: Optional[int] = None
+    int_field: int | None = None
 
 
 class ProductBlockOneNestedForTestProvisioning(

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_with_list_union.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_with_list_union.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Union
-
 import pytest
 from pydantic import Field
 
@@ -16,26 +14,26 @@ def test_product_block_with_list_union(test_product_sub_block_one, test_product_
     class ProductBlockWithListUnionForTestInactive(
         ProductBlockModel, product_block_name="ProductBlockWithListUnionForTest"
     ):
-        list_union_blocks: List[Union[SubBlockTwoForTestInactive, SubBlockOneForTestInactive]]
-        int_field: Optional[int] = None
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
+        list_union_blocks: list[SubBlockTwoForTestInactive | SubBlockOneForTestInactive]
+        int_field: int | None = None
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
 
     class ProductBlockWithListUnionForTestProvisioning(
         ProductBlockWithListUnionForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
     ):
-        list_union_blocks: List[Union[SubBlockTwoForTestProvisioning, SubBlockOneForTestProvisioning]]
+        list_union_blocks: list[SubBlockTwoForTestProvisioning | SubBlockOneForTestProvisioning]
         int_field: int
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
 
     class ProductBlockWithListUnionForTest(
         ProductBlockWithListUnionForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
-        list_union_blocks: List[Union[SubBlockTwoForTest, SubBlockOneForTest]]
+        list_union_blocks: list[SubBlockTwoForTest | SubBlockOneForTest]
         int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     return (
         ProductBlockWithListUnionForTestInactive,

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_with_union.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_with_union.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Union
-
 import pytest
 from pydantic import Field
 
@@ -14,26 +12,26 @@ def test_product_block_with_union(test_product_sub_block_one, test_product_sub_b
     SubBlockTwoForTestInactive, SubBlockTwoForTestProvisioning, SubBlockTwoForTest = test_product_sub_block_two
 
     class ProductBlockWithUnionForTestInactive(ProductBlockModel, product_block_name="ProductBlockWithUnionForTest"):
-        union_block: Optional[Union[SubBlockOneForTestInactive, SubBlockTwoForTestInactive]] = None
-        int_field: Optional[int] = None
-        str_field: Optional[str] = None
-        list_field: List[int] = Field(default_factory=list)
+        union_block: SubBlockOneForTestInactive | SubBlockTwoForTestInactive | None = None
+        int_field: int | None = None
+        str_field: str | None = None
+        list_field: list[int] = Field(default_factory=list)
 
     class ProductBlockWithUnionForTestProvisioning(
         ProductBlockWithUnionForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
     ):
-        union_block: Union[SubBlockOneForTestProvisioning, SubBlockTwoForTestProvisioning]
+        union_block: SubBlockOneForTestProvisioning | SubBlockTwoForTestProvisioning
         int_field: int
-        str_field: Optional[str] = None
-        list_field: List[int]
+        str_field: str | None = None
+        list_field: list[int]
 
     class ProductBlockWithUnionForTest(
         ProductBlockWithUnionForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
     ):
-        union_block: Union[SubBlockOneForTest, SubBlockTwoForTest]
+        union_block: SubBlockOneForTest | SubBlockTwoForTest
         int_field: int
         str_field: str
-        list_field: List[int]
+        list_field: list[int]
 
     return ProductBlockWithUnionForTestInactive, ProductBlockWithUnionForTestProvisioning, ProductBlockWithUnionForTest
 

--- a/test/unit_tests/fixtures/products/product_blocks/product_sub_block_one.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_sub_block_one.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 from orchestrator.db import ProductBlockTable, db
@@ -10,12 +8,12 @@ from orchestrator.types import SubscriptionLifecycle
 @pytest.fixture
 def test_product_sub_block_one():
     class SubBlockOneForTestInactive(ProductBlockModel, product_block_name="SubBlockOneForTest"):
-        int_field: Optional[int] = None
-        str_field: Optional[str] = None
+        int_field: int | None = None
+        str_field: str | None = None
 
     class SubBlockOneForTestProvisioning(SubBlockOneForTestInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         int_field: int
-        str_field: Optional[str] = None
+        str_field: str | None = None
 
     class SubBlockOneForTest(SubBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         int_field: int

--- a/test/unit_tests/fixtures/products/product_types/product_type_list_union.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_list_union.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import pytest
 from pydantic import conlist
 
@@ -20,15 +18,15 @@ def test_product_type_list_union(test_product_sub_block_one, test_product_sub_bl
 
     class ProductListUnionInactive(SubscriptionModel, is_base=True):
         test_fixed_input: bool
-        list_union_blocks: list_of_ports(Union[SubBlockTwoForTestInactive, SubBlockOneForTestInactive])
+        list_union_blocks: list_of_ports(SubBlockTwoForTestInactive | SubBlockOneForTestInactive)
 
     class ProductListUnionProvisioning(ProductListUnionInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_fixed_input: bool
-        list_union_blocks: list_of_ports(Union[SubBlockTwoForTestProvisioning, SubBlockOneForTestProvisioning])
+        list_union_blocks: list_of_ports(SubBlockTwoForTestProvisioning | SubBlockOneForTestProvisioning)
 
     class ProductListUnion(ProductListUnionProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
-        list_union_blocks: list_of_ports(Union[SubBlockTwoForTest, SubBlockOneForTest])
+        list_union_blocks: list_of_ports(SubBlockTwoForTest | SubBlockOneForTest)
 
     SUBSCRIPTION_MODEL_REGISTRY["ProductListUnion"] = ProductListUnion
     yield ProductListUnionInactive, ProductListUnionProvisioning, ProductListUnion

--- a/test/unit_tests/fixtures/products/product_types/product_type_list_union_overlap.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_list_union_overlap.py
@@ -1,4 +1,3 @@
-from typing import Optional, Union
 from uuid import uuid4
 
 import pytest
@@ -19,16 +18,16 @@ def test_product_type_list_union_overlap(test_product_block_one, test_product_su
         return conlist(t, min_length=1)
 
     class ProductListUnionInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[ProductBlockOneForTestInactive]
-        list_union_blocks: list_of_ports(Union[ProductBlockOneForTestInactive, SubBlockOneForTestInactive])
+        test_block: ProductBlockOneForTestInactive | None
+        list_union_blocks: list_of_ports(ProductBlockOneForTestInactive | SubBlockOneForTestInactive)
 
     class ProductListUnionProvisioning(ProductListUnionInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: ProductBlockOneForTestProvisioning
-        list_union_blocks: list_of_ports(Union[ProductBlockOneForTestProvisioning, SubBlockOneForTestProvisioning])
+        list_union_blocks: list_of_ports(ProductBlockOneForTestProvisioning | SubBlockOneForTestProvisioning)
 
     class ProductListUnion(ProductListUnionProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: ProductBlockOneForTest
-        list_union_blocks: list_of_ports(Union[ProductBlockOneForTest, SubBlockOneForTest])
+        list_union_blocks: list_of_ports(ProductBlockOneForTest | SubBlockOneForTest)
 
     SUBSCRIPTION_MODEL_REGISTRY["ProductListUnion"] = ProductListUnion
     yield ProductListUnionInactive, ProductListUnionProvisioning, ProductListUnion

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_list_union.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_list_union.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from uuid import uuid4
 
 import pytest
@@ -18,7 +17,7 @@ def test_product_type_sub_list_union(test_product_block_with_list_union):
     ) = test_product_block_with_list_union
 
     class ProductSubListUnionInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[ProductBlockWithListUnionForTestInactive]
+        test_block: ProductBlockWithListUnionForTestInactive | None
 
     class ProductSubListUnionProvisioning(ProductSubListUnionInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: ProductBlockWithListUnionForTestProvisioning

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_one.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_one.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from uuid import uuid4
 
 import pytest
@@ -14,7 +13,7 @@ def test_product_type_sub_one(test_product_sub_block_one):
     SubBlockOneForTestInactive, SubBlockOneForTestProvisioning, SubBlockOneForTest = test_product_sub_block_one
 
     class ProductSubOneInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[SubBlockOneForTestInactive]
+        test_block: SubBlockOneForTestInactive | None
 
     class ProductSubOneProvisioning(ProductSubOneInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: SubBlockOneForTestProvisioning

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_two.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_two.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from uuid import uuid4
 
 import pytest
@@ -14,7 +13,7 @@ def test_product_type_sub_two(test_product_sub_block_two):
     SubBlockTwoForTestInactive, SubBlockTwoForTestProvisioning, SubBlockTwoForTest = test_product_sub_block_two
 
     class ProductSubTwoInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[SubBlockTwoForTestInactive]
+        test_block: SubBlockTwoForTestInactive | None
 
     class ProductSubTwoProvisioning(ProductSubTwoInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: SubBlockTwoForTestProvisioning

--- a/test/unit_tests/fixtures/products/product_types/product_type_sub_union.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_sub_union.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 
 from orchestrator.db import ProductTable, db
@@ -17,7 +15,7 @@ def test_union_type_sub_product(test_product_block_with_union):
     ) = test_product_block_with_union
 
     class UnionProductSubInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[ProductBlockWithUnionForTestInactive]
+        test_block: ProductBlockWithUnionForTestInactive | None
 
     class UnionProductSubProvisioning(UnionProductSubInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: ProductBlockWithUnionForTestProvisioning

--- a/test/unit_tests/fixtures/products/product_types/product_type_union.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_union.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import pytest
 
 from orchestrator.db import ProductTable, db
@@ -14,16 +12,16 @@ def test_union_type_product(test_product_block_one, test_product_sub_block_one):
     SubBlockOneForTestInactive, SubBlockOneForTestProvisioning, SubBlockOneForTest = test_product_sub_block_one
 
     class UnionProductInactive(SubscriptionModel, is_base=True):
-        test_block: Optional[ProductBlockOneForTestInactive]
-        union_block: Optional[Union[ProductBlockOneForTestInactive, SubBlockOneForTestInactive]]
+        test_block: ProductBlockOneForTestInactive | None
+        union_block: ProductBlockOneForTestInactive | SubBlockOneForTestInactive | None
 
     class UnionProductProvisioning(UnionProductInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
         test_block: ProductBlockOneForTestProvisioning
-        union_block: Union[ProductBlockOneForTestProvisioning, SubBlockOneForTestProvisioning]
+        union_block: ProductBlockOneForTestProvisioning | SubBlockOneForTestProvisioning
 
     class UnionProduct(UnionProductProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_block: ProductBlockOneForTest
-        union_block: Union[ProductBlockOneForTest, SubBlockOneForTest]
+        union_block: ProductBlockOneForTest | SubBlockOneForTest
 
     SUBSCRIPTION_MODEL_REGISTRY["UnionProduct"] = UnionProduct
     yield UnionProductInactive, UnionProductProvisioning, UnionProduct

--- a/test/unit_tests/graphql/test_customer.py
+++ b/test/unit_tests/graphql/test_customer.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Union
 
 import pytest
 
@@ -11,8 +10,8 @@ from test.unit_tests.config import GRAPHQL_ENDPOINT, GRAPHQL_HEADERS
 def get_customers_query(
     first: int = 1,
     after: int = 0,
-    filter_by: Union[list[str], None] = None,
-    sort_by: Union[list[dict[str, str]], None] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
 ) -> bytes:
     query = """
 query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 
@@ -44,9 +43,9 @@ process_fields = [
 def get_processes_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!], $query: String) {
@@ -103,9 +102,9 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
 def get_processes_query_with_subscriptions(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!], $query: String) {
@@ -173,9 +172,9 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
 def get_processes_state_updates_and_delta(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterBy: [GraphqlFilter!], $query: String) {

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 from fastapi import Response
@@ -9,9 +8,9 @@ from fastapi import Response
 def get_product_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProductQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!], $query: String) {
@@ -82,9 +81,9 @@ query ProductQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sor
 def get_products_with_related_subscriptions_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProductQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!], $query: String) {

--- a/test/unit_tests/graphql/test_product_blocks.py
+++ b/test/unit_tests/graphql/test_product_blocks.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 from fastapi import Response
@@ -11,9 +10,9 @@ from test.unit_tests.helpers import assert_no_diff
 def get_product_blocks_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ProductBlocksQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!], $query: String) {

--- a/test/unit_tests/graphql/test_resource_types.py
+++ b/test/unit_tests/graphql/test_resource_types.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 from fastapi import Response
@@ -9,9 +8,9 @@ from fastapi import Response
 def get_resource_types_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query ResourceTypesQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!], $query: String) {

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 import datetime
 import json
-import sys
 from http import HTTPStatus
 from typing import Optional
 
@@ -1070,7 +1069,6 @@ def test_single_subscription_with_in_use_by_subscriptions(
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="types get different origin with 3.10 and higher")
 def test_single_subscription_schema(
     fastapi_app_graphql,
     test_client,

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -13,7 +13,6 @@
 import datetime
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 
@@ -63,9 +62,9 @@ query SubscriptionQuery(
 def get_subscriptions_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[dict]] = None,
-    sort_by: Optional[list] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict] | None = None,
+    sort_by: list | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     gql_query = build_subscriptions_query(
         """{
@@ -124,9 +123,9 @@ def get_subscriptions_query(
 def get_subscriptions_query_with_relations(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[dict[str, str]]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict[str, str]] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = build_subscriptions_query(
         """{
@@ -218,9 +217,9 @@ def get_subscriptions_query_with_relations(
 def get_subscriptions_product_block_json_schema_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[dict[str, str]]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict[str, str]] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = build_subscriptions_query(
         """{
@@ -255,9 +254,9 @@ def get_subscriptions_product_block_json_schema_query(
 def get_subscriptions_product_generic_one(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[str]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = build_subscriptions_query(
         """{
@@ -307,9 +306,9 @@ def get_subscriptions_product_generic_one(
 def get_subscriptions_product_sub_list_union(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[dict[str, str]]] = None,
-    sort_by: Optional[list[str]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict[str, str]] | None = None,
+    sort_by: list[str] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = build_subscriptions_query(
         """{
@@ -370,9 +369,9 @@ def get_subscriptions_product_sub_list_union(
 def get_subscriptions_with_metadata_and_schema_query(
     first: int = 1,
     after: int = 0,
-    filter_by: Optional[list[dict[str, str]]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict[str, str]] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     gql_query = build_subscriptions_query(
         """{

--- a/test/unit_tests/graphql/test_workflows.py
+++ b/test/unit_tests/graphql/test_workflows.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 
@@ -15,9 +14,9 @@ def _add_soft_deleted_workflows(add_soft_deleted_workflows):  # noqa: F811
 def get_workflows_query(
     first: int = 10,
     after: int = 0,
-    filter_by: Optional[list[dict[str, str]]] = None,
-    sort_by: Optional[list[dict[str, str]]] = None,
-    query_string: Optional[str] = None,
+    filter_by: list[dict[str, str]] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
+    query_string: str | None = None,
 ) -> bytes:
     query = """
 query WorkflowsQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!], $query: String) {

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -1,6 +1,5 @@
 import json
 from http import HTTPStatus
-from typing import Union
 from uuid import UUID
 
 import pytest
@@ -52,22 +51,22 @@ def override_class_app_graphql(
 def get_customers_query(
     first: int = 1,
     after: int = 0,
-    filter_by: Union[list[str], None] = None,
-    sort_by: Union[list[dict[str, str]], None] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
     override_fields: bool = False,
 ) -> bytes:
     query = """
-query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
-  customers(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
-    page {
+query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  customers(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
       customerId
       fullname
       shortcode
-        %s
-    }
-  }
-}
-    """ % (
+        {}
+    }}
+  }}
+}}
+    """.format(
         "newField" if override_fields else "",
     )
     return json.dumps(
@@ -87,24 +86,24 @@ query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $so
 def get_subscriptions_customer_query(
     first: int = 1,
     after: int = 0,
-    filter_by: Union[list[str], None] = None,
-    sort_by: Union[list[dict[str, str]], None] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
     override_fields: bool = False,
 ) -> bytes:
     query = """
-query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
-  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
-    page {
-      customer {
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
+      customer {{
         customerId
         fullname
         shortcode
-        %s
-      }
-    }
-  }
-}
-    """ % (
+        {}
+      }}
+    }}
+  }}
+}}
+    """.format(
         "newField" if override_fields else "",
     )
     return json.dumps(
@@ -124,26 +123,26 @@ query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!],
 def get_subscriptions_detail_customer_query(
     first: int = 1,
     after: int = 0,
-    filter_by: Union[list[str], None] = None,
-    sort_by: Union[list[dict[str, str]], None] = None,
+    filter_by: list[str] | None = None,
+    sort_by: list[dict[str, str]] | None = None,
     override_fields: bool = False,
 ) -> bytes:
     query = """
-query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {
-  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {
-    page {
-      ... on ProductSubOneSubscription {
-        customer {
+query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sortBy: [GraphqlSort!]) {{
+  subscriptions(first: $first, after: $after, filterBy: $filterBy, sortBy: $sortBy) {{
+    page {{
+      ... on ProductSubOneSubscription {{
+        customer {{
           customerId
           fullname
           shortcode
-          %s
-        }
-      }
-    }
-  }
-}
-    """ % (
+          {}
+        }}
+      }}
+    }}
+  }}
+}}
+    """.format(
         "newField" if override_fields else "",
     )
     return json.dumps(

--- a/test/unit_tests/test_types.py
+++ b/test/unit_tests/test_types.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 from orchestrator.types import is_of_type
 
@@ -9,4 +9,4 @@ def test_is_of_type():
     assert is_of_type(int, Union[str, int])
     assert is_of_type(str, Union[int, str])
     assert is_of_type(str, Union[str, int])
-    assert is_of_type(List[str], Union[str, int]) is False
+    assert is_of_type(list[str], Union[str, int]) is False

--- a/test/unit_tests/test_workflow.py
+++ b/test/unit_tests/test_workflow.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from functools import reduce
-from typing import List, NoReturn, Tuple, Type
+from typing import NoReturn
 from unittest import mock
 from uuid import UUID, uuid4
 
@@ -74,7 +74,7 @@ def step3(steps):
 
 
 @inputstep("Input Name", assignee=Assignee.SYSTEM)
-def user_action() -> Type[FormPage]:
+def user_action() -> type[FormPage]:
     class Form(FormPage):
         name: str
 
@@ -382,7 +382,7 @@ def test_input_in_substate() -> None:
         lambda: begin >> input_action >> purestep("process inputs")(Success)
     )
 
-    log: List[Tuple[str, Process]] = []
+    log: list[tuple[str, Process]] = []
     process_id = uuid4()
     p = ProcessStat(
         process_id=process_id,

--- a/test/unit_tests/utils/test_functional.py
+++ b/test/unit_tests/utils/test_functional.py
@@ -1,5 +1,4 @@
 import functools
-from typing import Optional
 
 import pytest
 
@@ -86,7 +85,7 @@ def test_expand_ranges():
 def test_as_t():
     # Don't know how to check type annotations at runtime yet. Hence test only basic functionality of `as_t` and not
     # the casting of Optional[T] to just T
-    x: Optional[int] = 7
+    x: int | None = 7
     y: int = as_t(x)
     assert y == 7
     with pytest.raises(ValueError):

--- a/test/unit_tests/utils/test_state.py
+++ b/test/unit_tests/utils/test_state.py
@@ -1,6 +1,5 @@
 # type: ignore
 
-from typing import List, Optional
 from uuid import uuid4
 
 import pytest
@@ -56,7 +55,7 @@ def test_state() -> None:
         step_func_fail(STATE)
 
     @inject_args
-    def step_func_opt_arg(opt: Optional[str] = None) -> None:
+    def step_func_opt_arg(opt: str | None = None) -> None:
         assert opt is None
 
     step_func_opt_arg(STATE)
@@ -141,7 +140,7 @@ def test_inject_args_list(generic_product_1, generic_product_type_1) -> None:
     generic_sub.save()
 
     @inject_args
-    def step_existing(generic_sub: List[GenericProduct]) -> State:
+    def step_existing(generic_sub: list[GenericProduct]) -> State:
         assert len(generic_sub) == 1
         assert generic_sub[0].subscription_id
         assert generic_sub[0].pb_1.rt_1 == "test"
@@ -183,7 +182,7 @@ def test_inject_args_optional(generic_product_1, generic_product_type_1) -> None
     generic_sub.save()
 
     @inject_args
-    def step_existing(generic_sub: Optional[GenericProduct]) -> State:
+    def step_existing(generic_sub: GenericProduct | None) -> State:
         assert generic_sub is not None, "Generic Sub IS NONE"
         assert generic_sub.subscription_id
         assert generic_sub.pb_1.rt_1 == "test"


### PR DESCRIPTION
* Drop Python 3.9 and 3.10 support, remove backwards compatibility code
* Add Python 3.12 support
* Used pyupgrade to rewrite `List[A]` to `list[A]`, `Union[A, B]` to `A | B`, etc
* Fixed type annotations in `orchestrator/domain/lifecycle.py` and `orchestrator/api/models.py`