### PR TITLE
Replace ProcessFormType with JSON

### DIFF
--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -13,7 +13,7 @@ from orchestrator.graphql.pagination import EMPTY_PAGE, Connection
 from orchestrator.graphql.schemas.customer import CustomerType
 from orchestrator.graphql.schemas.product import ProductType
 from orchestrator.graphql.types import GraphqlFilter, GraphqlSort, OrchestratorInfo
-from orchestrator.schemas.process import ProcessForm, ProcessSchema, ProcessStepSchema
+from orchestrator.schemas.process import ProcessSchema, ProcessStepSchema
 from orchestrator.settings import app_settings
 from orchestrator.workflow import ProcessStatus
 
@@ -22,16 +22,6 @@ if TYPE_CHECKING:
 
 
 federation_key_directives = [Key(fields="id", resolvable=UNSET)]
-
-
-@strawberry.experimental.pydantic.type(model=ProcessForm)
-class ProcessFormType:
-    title: strawberry.auto
-    type: strawberry.auto
-    additionalProperties: strawberry.auto
-    required: strawberry.auto
-    properties: JSON
-    definitions: JSON | None
 
 
 @strawberry.experimental.pydantic.type(model=ProcessStepSchema)
@@ -71,7 +61,7 @@ class ProcessType:
     last_modified_at: strawberry.auto
     is_task: strawberry.auto
     steps: strawberry.auto
-    form: strawberry.auto
+    form: JSON | None
     current_state: JSON | None
 
     @authenticated_field(

--- a/orchestrator/schemas/process.py
+++ b/orchestrator/schemas/process.py
@@ -86,7 +86,7 @@ class ProcessSchema(ProcessBaseSchema):
     subscriptions: list[SubscriptionSchema]
     current_state: dict[str, Any] | None = None
     steps: list[ProcessStepSchema] | None = None
-    form: ProcessForm | None = None
+    form: dict[str, Any] | None = None
 
 
 class ProcessDeprecationsSchema(ProcessSchema):

--- a/orchestrator/schemas/process.py
+++ b/orchestrator/schemas/process.py
@@ -15,8 +15,7 @@ from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import ConfigDict, Field, model_serializer
-from pydantic_core.core_schema import SerializerFunctionWrapHandler, ValidationInfo
+from pydantic import ConfigDict, Field
 
 from orchestrator.config.assignee import Assignee
 from orchestrator.schemas.base import OrchestratorBaseModel
@@ -27,27 +26,6 @@ from orchestrator.workflow import ProcessStatus
 
 class ProcessIdSchema(OrchestratorBaseModel):
     id: UUID
-
-
-class ProcessForm(OrchestratorBaseModel):
-    title: str
-    type: str
-    properties: dict[str, Any]
-    additionalProperties: bool  # noqa: N815
-    required: list[str] = []
-    definitions: dict[str, Any] | None = Field(None, validation_alias="$defs")
-
-    @model_serializer(mode="wrap", when_used="json")
-    def serialize_defs(self, handler: SerializerFunctionWrapHandler, _info: ValidationInfo) -> dict[str, Any]:
-        """Serialize ProcessForm model.
-
-        Pydantic 2.x renamed 'definitions' to '$defs' to be compliant with JSONSchema.
-        Python doesn't allow variables starting with $ so we keep the field name 'definitions', we set a
-        validation_alias '$defs' for the input, and in the json output this serializer renames it to '$defs'.
-        """
-        serialized = handler(self)
-        serialized["$defs"] = serialized.pop("definitions")
-        return serialized
 
 
 class ProcessBaseSchema(OrchestratorBaseModel):

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -199,6 +199,16 @@ def test_complete_workflow(test_client, test_workflow):
     steps = process["steps"]
     assert "success" == steps[0]["status"]
 
+    response = test_client.get(f"/api/processes/{process_id}")
+    assert response.json()["form"] == {
+        "title": "unknown",
+        "type": "object",
+        "properties": {"generic_select": {"$ref": "#/$defs/TestChoice"}},
+        "additionalProperties": False,
+        "required": ["generic_select"],
+        "$defs": {"TestChoice": {"enum": ["A", "B", "C"], "title": "TestChoice", "type": "string"}},
+    }
+
     # Check type validation
     user_input = {"generic_select": 123}
     response = test_client.put(f"/api/processes/{process_id}/resume", json=[user_input])


### PR DESCRIPTION
Treats the form field in a process GraphQL datatype as a single value. Allows returning a proper JSON schema and removes inconsistency between the GraphQL and REST process resources 