### PR TITLE
Fix graphql autoregistration is_enum check for optional fields

### DIFF
--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 from enum import Enum, EnumMeta
 from typing import Any
 
@@ -24,6 +23,7 @@ from strawberry.unset import UNSET
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import DomainModel, get_depends_on_product_block_type_list
 from orchestrator.graphql.schemas import StrawberryModelType
+from orchestrator.types import is_of_type, is_optional_type
 from orchestrator.utils.helpers import to_camel
 
 logger = structlog.get_logger(__name__)
@@ -40,7 +40,7 @@ def is_not_strawberry_enum(key: str, strawberry_enums: EnumDict) -> bool:
 
 
 def is_enum(field: Any) -> bool:
-    return inspect.isclass(field) and issubclass(field, Enum)
+    return is_of_type(field, Enum) or is_optional_type(field, Enum)
 
 
 def create_strawberry_enums(model: type[DomainModel], strawberry_enums: EnumDict) -> EnumDict:

--- a/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_with_instances.py
@@ -9,6 +9,7 @@ from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import ProductBlockModel, SubscriptionModel
 from orchestrator.services.resource_types import get_resource_types
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 def test_migrate_domain_models_new_product_block(
@@ -78,6 +79,7 @@ def test_migrate_domain_models_new_product_block_on_product_block(
         str_field: str
         int_field: int
         list_field: list[int]
+        enum_field: DummyEnum
         new_block: TestBlock
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -134,6 +136,7 @@ def test_migrate_domain_models_new_resource_type(
         int_field: int
         str_field: str
         list_field: list[int]
+        enum_field: DummyEnum
         new_int_field: int
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -238,6 +241,7 @@ def test_migrate_domain_models_update_resource_type(
         sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
+        enum_field: DummyEnum
         new_list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -296,6 +300,7 @@ def test_migrate_domain_models_create_and_rename_resource_type(test_product_type
         sub_block_list: list[SubBlockOneForTestNewResource]
         str_field: str
         int_field: int
+        enum_field: DummyEnum
         new_list_field: list[int]
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -530,6 +535,7 @@ def test_migrate_domain_models_remove_resource_type(
         sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
+        enum_field: DummyEnum
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -572,6 +578,7 @@ def test_migrate_domain_models_update_block_resource_type(
         update_str_field: str
         int_field: int
         list_field: list[int]
+        enum_field: DummyEnum
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool
@@ -634,6 +641,7 @@ def test_migrate_domain_models_rename_and_update_block_resource_type(test_produc
         update_str_field: str
         int_field: int
         list_field: list[int]
+        enum_field: DummyEnum
 
     class ProductTypeOneForTestNew(SubscriptionModel, is_base=True, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool

--- a/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
+++ b/test/unit_tests/cli/test_migrate_domain_models_without_instances.py
@@ -9,6 +9,7 @@ from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import ProductBlockModel
 from orchestrator.services.resource_types import get_resource_types
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 def test_migrate_domain_models_new_product(test_product_type_one, test_product_sub_block_one_db):
@@ -24,11 +25,12 @@ def test_migrate_domain_models_new_product(test_product_type_one, test_product_s
         "int_field": {"ProductBlockOneForTest": "1"},
         "str_field": {"ProductBlockOneForTest": "test"},
         "list_field": {"description": "list field desc", "ProductBlockOneForTest": "list test"},
+        "enum_field": {"description": "an enum", "ProductBlockOneForTest": str(DummyEnum.FOO)},
     }
     upgrade_sql, downgrade_sql = migrate_domain_models("example", True, inputs=json.dumps(inputs))
 
-    assert len(upgrade_sql) == 9
-    assert len(downgrade_sql) == 18
+    assert len(upgrade_sql) == 11
+    assert len(downgrade_sql) == 20
 
     def fetch_product_ids(product_name):
         return db.session.scalars(select(ProductTable.product_id).where(ProductTable.name == product_name)).all()
@@ -52,7 +54,7 @@ def test_migrate_domain_models_new_product(test_product_type_one, test_product_s
             "missing_in_depends_on_blocks": {
                 "ProductBlockOneForTest": {
                     "missing_product_blocks_in_db": {"SubBlockOneForTest"},
-                    "missing_resource_types_in_db": {"int_field", "list_field", "str_field"},
+                    "missing_resource_types_in_db": {"int_field", "list_field", "str_field", "enum_field"},
                 }
             },
             "missing_product_blocks_in_db": {"ProductBlockOneForTest"},
@@ -228,6 +230,7 @@ def test_migrate_domain_models_new_product_block_on_product_block(
         str_field: str
         int_field: int
         list_field: list[int]
+        enum_field: DummyEnum
         new_block: TestBlock
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -287,6 +290,7 @@ def test_migrate_domain_models_new_resource_type(
         sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
+        enum_field: DummyEnum
         list_field: list[int]
         new_int_field: int
 
@@ -341,6 +345,7 @@ def test_migrate_domain_models_rename_resource_type(
         sub_block_list: list[SubBlockOneForTest]
         str_field: str
         int_field: int
+        enum_field: DummyEnum
         new_list_field: list[int]
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -404,6 +409,7 @@ def test_migrate_domain_models_rename_and_relate_resource_type(
         sub_block_list: list[SubBlockOneForTestNewResource]
         str_field: str
         int_field: int
+        enum_field: DummyEnum
         new_list_field: list[int]  # renamed from 'list_field'
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
@@ -535,6 +541,7 @@ def test_migrate_domain_models_update_block_resource_type(
         sub_block_2: SubBlockOneForTest
         sub_block_list: list[SubBlockOneForTest]
         str_field: str
+        enum_field: DummyEnum
         new_int_field: int
         list_field: list[int]
 
@@ -687,6 +694,7 @@ def test_migrate_domain_models_remove_resource_type(
         sub_block_list: list[SubBlockOneForTest]
         int_field: int
         str_field: str
+        enum_field: DummyEnum
 
     class ProductTypeOneForTestNew(ProductTypeOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         test_fixed_input: bool

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -114,6 +114,7 @@ from test.unit_tests.fixtures.products.product_types.product_type_union import (
     test_union_type_product,
 )
 from test.unit_tests.fixtures.products.resource_types import (  # noqa: F401
+    resource_type_enum,
     resource_type_int,
     resource_type_int_2,
     resource_type_list,

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -28,6 +28,7 @@ from orchestrator.types import SubscriptionLifecycle
 from test.unit_tests.fixtures.products.product_blocks.product_block_list_nested import (
     ProductBlockListNestedForTestInactive,
 )
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 from test.unit_tests.fixtures.products.product_blocks.product_block_one_nested import (
     ProductBlockOneNestedForTestInactive,
 )
@@ -402,6 +403,7 @@ def test_lifecycle_specific(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -426,6 +428,7 @@ def test_lifecycle_specific(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -450,6 +453,7 @@ def test_lifecycle_specific(
                 subscription_id=subscription_id,
                 int_field=3,
                 list_field=[1],
+                enum_field=DummyEnum.FOO,
                 sub_block=SubBlockOneForTestProvisioning.new(subscription_id=subscription_id, int_field=3),
                 sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             ),
@@ -471,6 +475,7 @@ def test_lifecycle_specific(
             subscription_id=subscription_id,
             int_field=3,
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTestProvisioning.new(subscription_id=subscription_id, int_field=3),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -502,6 +507,7 @@ def test_product_blocks_per_lifecycle(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -537,6 +543,7 @@ def test_product_blocks_per_lifecycle(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -558,6 +565,7 @@ def test_product_blocks_per_lifecycle(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -579,6 +587,7 @@ def test_product_blocks_per_lifecycle(
             int_field=3,
             str_field="",
             list_field=[1],
+            enum_field=DummyEnum.FOO,
             sub_block=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
             sub_block_2=SubBlockOneForTest.new(subscription_id=subscription_id, int_field=3, str_field=""),
         ),
@@ -687,6 +696,7 @@ def test_change_lifecycle(test_product_one, test_product_type_one, test_product_
     product_type.block.sub_block_list = [SubBlockOneForTestInactive.new(subscription_id=product_type.subscription_id)]
     product_type.block.sub_block_list[0].int_field = 4
     product_type.block.list_field = [1]
+    product_type.block.enum_field = DummyEnum.FOO
 
     # Does not work if constraints are not met
     with pytest.raises(ValidationError, match=r"str_field\n\s+Input should be a valid string"):
@@ -749,6 +759,7 @@ def test_save_load(test_product_model, test_product_type_one, test_product_block
     assert model.model_dump() == {
         "block": {
             "int_field": None,
+            "enum_field": None,
             "label": None,
             "list_field": [],
             "title": "TEST ProductBlockOneForTestInactive int_field=None",
@@ -790,6 +801,7 @@ def test_save_load(test_product_model, test_product_type_one, test_product_block
 
     # Set first value
     model.block.int_field = 3
+    model.block.enum_field = DummyEnum.FOO
     model.block.sub_block.int_field = 3
     model.block.sub_block_2 = SubBlockOneForTestInactive.new(subscription_id=model.subscription_id)
     model.block.sub_block_2.int_field = 3
@@ -1144,7 +1156,7 @@ def test_diff_in_db_missing_in_db(test_product_type_one):
             "missing_in_depends_on_blocks": {
                 "ProductBlockOneForTest": {
                     "missing_product_blocks_in_db": {"SubBlockOneForTest"},
-                    "missing_resource_types_in_db": {"int_field", "list_field", "str_field"},
+                    "missing_resource_types_in_db": {"int_field", "list_field", "str_field", "enum_field"},
                 },
                 "SubBlockOneForTest": {"missing_resource_types_in_db": {"int_field", "str_field"}},
             },
@@ -1213,7 +1225,7 @@ def test_from_other_lifecycle_sub(test_product_one, test_product_block_one, test
     subscription_id = uuid4()
 
     block = ProductBlockOneForTestInactive.new(
-        subscription_id=subscription_id, int_field=1, str_field="bla", list_field=[1]
+        subscription_id=subscription_id, int_field=1, str_field="bla", list_field=[1], enum_field=DummyEnum.FOO
     )
     block.sub_block = SubBlockOneForTestInactive.new(subscription_id=subscription_id, int_field=1, str_field="bla")
     block.sub_block_2 = SubBlockOneForTestInactive.new(subscription_id=subscription_id, int_field=1, str_field="bla")

--- a/test/unit_tests/domain/test_base_with_list_union.py
+++ b/test/unit_tests/domain/test_base_with_list_union.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from orchestrator.db import db
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 def test_product_model_with_list_union_type_directly_below(
@@ -82,6 +83,7 @@ def test_product_model_with_list_union_type_directly_below_with_relation_overlap
         int_field=3,
         str_field="",
         list_field=[1],
+        enum_field=DummyEnum.FOO,
         sub_block=SubBlockOneForTestInactive.new(
             subscription_id=list_union_subscription_inactive.subscription_id, int_field=3, str_field="2"
         ),

--- a/test/unit_tests/domain/test_base_with_union.py
+++ b/test/unit_tests/domain/test_base_with_union.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from orchestrator.db import db
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 def test_product_model_with_union_type_directly_below(
@@ -27,6 +28,7 @@ def test_product_model_with_union_type_directly_below(
         int_field=3,
         str_field="",
         list_field=[1],
+        enum_field=DummyEnum.FOO,
         sub_block=SubBlockOneForTestInactive.new(
             subscription_id=union_subscription_inactive.subscription_id, int_field=3, str_field=""
         ),

--- a/test/unit_tests/fixtures/products/product_blocks/product_block_one.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_one.py
@@ -1,3 +1,5 @@
+from enum import StrEnum, auto
+
 import pytest
 from pydantic import Field, computed_field
 
@@ -5,6 +7,11 @@ from orchestrator.db import ProductBlockTable, db
 from orchestrator.domain.base import ProductBlockModel, ProductModel
 from orchestrator.domain.lifecycle import ProductLifecycle
 from orchestrator.types import SubscriptionLifecycle
+
+
+class DummyEnum(StrEnum):
+    FOO = auto()
+    BAR = auto()
 
 
 @pytest.fixture
@@ -18,6 +25,7 @@ def test_product_block_one(test_product_sub_block_one):
         int_field: int | None = None
         str_field: str | None = None
         list_field: list[int] = Field(default_factory=list)
+        enum_field: DummyEnum | None = None
 
         @computed_field  # type: ignore[misc]
         @property
@@ -33,6 +41,7 @@ def test_product_block_one(test_product_sub_block_one):
         int_field: int
         str_field: str | None = None
         list_field: list[int]
+        enum_field: DummyEnum
 
     class ProductBlockOneForTest(ProductBlockOneForTestProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
         sub_block: SubBlockOneForTest
@@ -41,17 +50,20 @@ def test_product_block_one(test_product_sub_block_one):
         int_field: int
         str_field: str
         list_field: list[int]
+        enum_field: DummyEnum
 
     return ProductBlockOneForTestInactive, ProductBlockOneForTestProvisioning, ProductBlockOneForTest
 
 
 @pytest.fixture
-def test_product_block_one_db(resource_type_list, resource_type_int, resource_type_str, test_product_sub_block_one_db):
+def test_product_block_one_db(
+    resource_type_list, resource_type_int, resource_type_str, resource_type_enum, test_product_sub_block_one_db
+):
     product_block = ProductBlockTable(
         name="ProductBlockOneForTest", description="Test Block", tag="TEST", status="active"
     )
 
-    product_block.resource_types = [resource_type_int, resource_type_str, resource_type_list]
+    product_block.resource_types = [resource_type_int, resource_type_str, resource_type_list, resource_type_enum]
     product_block.depends_on = [test_product_sub_block_one_db]
 
     db.session.add(product_block)

--- a/test/unit_tests/fixtures/products/product_types/product_type_list_union_overlap.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_list_union_overlap.py
@@ -7,6 +7,7 @@ from orchestrator.db import ProductTable, db
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 @pytest.fixture
@@ -72,6 +73,7 @@ def sub_list_union_overlap_subscription_1(
         int_field=3,
         str_field="",
         list_field=[1, 2],
+        enum_field=DummyEnum.FOO,
         sub_block=SubBlockOneForTestInactive.new(
             subscription_id=list_union_subscription_inactive.subscription_id, int_field=3, str_field="2"
         ),

--- a/test/unit_tests/fixtures/products/product_types/product_type_one.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_one.py
@@ -8,6 +8,7 @@ from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import ProductModel, SubscriptionModel
 from orchestrator.domain.lifecycle import ProductLifecycle
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
 
 
 @pytest.fixture
@@ -81,6 +82,7 @@ def product_one_subscription_1(test_product_one, test_product_type_one, test_pro
     model.block.str_field = "A"
     model.block.int_field = 1
     model.block.list_field = [10, 20, 30]
+    model.block.enum_field = DummyEnum.BAR
     model.block.sub_block.str_field = "B"
     model.block.sub_block.int_field = 2
     model.block.sub_block_2 = SubBlockOneForTest.new(

--- a/test/unit_tests/fixtures/products/resource_types.py
+++ b/test/unit_tests/fixtures/products/resource_types.py
@@ -21,3 +21,8 @@ def resource_type_int_2():
 @pytest.fixture
 def resource_type_str():
     return ResourceTypeTable(resource_type="str_field", description="")
+
+
+@pytest.fixture
+def resource_type_enum():
+    return ResourceTypeTable(resource_type="enum_field", description="")

--- a/test/unit_tests/graphql/utils/test_autoregistration.py
+++ b/test/unit_tests/graphql/utils/test_autoregistration.py
@@ -1,0 +1,12 @@
+from orchestrator.graphql.autoregistration import create_strawberry_enums
+from test.unit_tests.fixtures.products.product_blocks.product_block_one import DummyEnum
+
+
+def test_create_strawberry_enums(test_product_block_one):
+    _, _, ProductBlockOneForTest = test_product_block_one
+    assert create_strawberry_enums(ProductBlockOneForTest, {}) == {"enum_field": DummyEnum}
+
+
+def test_create_strawberry_enums_optional(test_product_block_one):
+    ProductBlockOneForTestInactive, _, _ = test_product_block_one
+    assert create_strawberry_enums(ProductBlockOneForTestInactive, {}) == {"enum_field": DummyEnum}


### PR DESCRIPTION
Fix creating strawberry enums for optional enums.

After this PR all `@strawberry.enum` decorations can be removed.