### PR TITLE
Fix GraphQL subscription status with detailed information

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1rc2
+current_version = 2.1.1rc3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.1.1rc2"
+__version__ = "2.1.1rc3"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/graphql/resolvers/subscription.py
+++ b/orchestrator/graphql/resolvers/subscription.py
@@ -58,11 +58,12 @@ def get_subscription_details(subscription: SubscriptionTable) -> SubscriptionInt
 
     subscription_details = SubscriptionModel.from_subscription(subscription.subscription_id)
     base_model = subscription_details.__base_type__ if subscription_details.__base_type__ else subscription_details
-    subscription_details = base_model.from_other_lifecycle(  # type: ignore
+    base_subscription_details = base_model.from_other_lifecycle(  # type: ignore
         subscription_details, SubscriptionLifecycle.INITIAL, skip_validation=True
     )
+    base_subscription_details.status = subscription_details.status
     strawberry_type = GRAPHQL_MODELS[graphql_subscription_name(base_model.__name__)]  # type: ignore
-    return strawberry_type.from_pydantic(subscription_details)
+    return strawberry_type.from_pydantic(base_subscription_details)
 
 
 def format_base_subscription(subscription: SubscriptionTable) -> SubscriptionInterface:

--- a/orchestrator/utils/enrich_process.py
+++ b/orchestrator/utils/enrich_process.py
@@ -106,6 +106,7 @@ def enrich_process(process: ProcessTable, p_stat: ProcessStat | None = None) -> 
         "failed_reason": process.failed_reason,
         "created_by": process.created_by,
         "started_at": process.started_at,
+        "traceback": process.traceback,
         "last_modified_at": process.last_modified_at,
         "product": subscriptions[0]["product"] if subscriptions else None,
         "subscriptions": subscriptions,

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -877,7 +877,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
-    assert subscriptions[0]["status"] == "ACTIVE"
+    assert subscriptions[0]["status"] == SubscriptionLifecycle.ACTIVE.name
     assert subscriptions[0]["customerDescriptions"] == [
         {
             "subscriptionId": subscription_id,
@@ -1312,7 +1312,7 @@ def test_subscriptions_product_generic_one(
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
-    assert subscriptions[0]["status"] == "ACTIVE"
+    assert subscriptions[0]["status"] == SubscriptionLifecycle.ACTIVE.name
     assert subscriptions[0]["pb1"] == {"rt1": "Value1"}
     assert subscriptions[0]["pb2"] == {"rt2": 42, "rt3": "Value2"}
     assert subscriptions[0]["customerDescriptions"] == [
@@ -1353,7 +1353,7 @@ def test_single_subscription_product_list_union_type(
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
-    assert subscriptions[0]["status"] == "ACTIVE"
+    assert subscriptions[0]["status"] == SubscriptionLifecycle.ACTIVE.name
     assert subscriptions[0]["testBlock"] == {
         "intField": 1,
         "strField": "blah",

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -877,6 +877,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert subscriptions[0]["status"] == "ACTIVE"
     assert subscriptions[0]["customerDescriptions"] == [
         {
             "subscriptionId": subscription_id,
@@ -1311,6 +1312,7 @@ def test_subscriptions_product_generic_one(
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert subscriptions[0]["status"] == "ACTIVE"
     assert subscriptions[0]["pb1"] == {"rt1": "Value1"}
     assert subscriptions[0]["pb2"] == {"rt2": 42, "rt3": "Value2"}
     assert subscriptions[0]["customerDescriptions"] == [
@@ -1351,6 +1353,7 @@ def test_single_subscription_product_list_union_type(
         "totalItems": 1,
     }
     assert subscriptions[0]["subscriptionId"] == subscription_id
+    assert subscriptions[0]["status"] == "ACTIVE"
     assert subscriptions[0]["testBlock"] == {
         "intField": 1,
         "strField": "blah",


### PR DESCRIPTION
- status stays INITIAL because we convert subscriptions to the initial lifecycle but now we overwite it back with the original subscription status.
- update graphql single subscription tests to also check if the status is correct.
- add forgotten traceback to enrich_process.