### PR TITLE
[Bug] Use broadcast websocket manager for secure redis

### DIFF
--- a/orchestrator/websocket/websocket_manager.py
+++ b/orchestrator/websocket/websocket_manager.py
@@ -33,7 +33,7 @@ class WebSocketManager:
         self.enabled = websockets_enabled
         self.broadcaster_type = urlparse(broadcast_url).scheme
         self.connected = False
-        if self.broadcaster_type == "redis":
+        if self.broadcaster_type in ("redis", "rediss"):
             self._backend = BroadcastWebsocketManager(broadcast_url)
         else:
             self._backend = MemoryWebsocketManager()


### PR DESCRIPTION
```python
>>> broadcast_url = 'rediss://<redacted>@redis:6380/0?ssl_cert_reqs=required'
>>> broadcaster_type = urlparse(broadcast_url).scheme
>>> broadcaster_type
'rediss'
```