### PR TITLE
Fix search queries for all Postgres versions

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -5,16 +5,17 @@ on:
 
 jobs:
   container_job:
-    name: Unit tests
+    name: Unit tests Python (${{ matrix.python-version }}) Postgres (${{ matrix.postgres-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
+        postgres-version: ['11', '12', '13', '14', '15', '16']
       fail-fast: false
     container: python:${{ matrix.python-version }}-slim
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:${{ matrix.postgres-version }}-alpine
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: nwa

--- a/orchestrator/db/filters/process.py
+++ b/orchestrator/db/filters/process.py
@@ -24,6 +24,7 @@ from orchestrator.db.filters.search_filters import (
     inferred_filter,
     node_to_str_val,
 )
+from orchestrator.db.filters.search_filters.inferred_filter import filter_uuid_exact
 from orchestrator.utils.search_query import Node, WhereCondGenerator
 
 logger = structlog.get_logger(__name__)
@@ -65,9 +66,7 @@ def customer_clause(node: Node) -> BinaryExpression[bool] | ColumnElement[bool]:
 def make_subscription_id_clause(filter_generator: WhereCondGenerator) -> WhereCondGenerator:
     def subscription_id_clause(node: Node) -> BinaryExpression:
 
-        process_subscriptions = (
-            select(ProcessSubscriptionTable.process_id).join(SubscriptionTable).where(filter_generator(node)).subquery()
-        )
+        process_subscriptions = select(ProcessSubscriptionTable.process_id).where(filter_generator(node)).subquery()
 
         return ProcessTable.process_id.in_(process_subscriptions)
 
@@ -100,7 +99,7 @@ PROCESS_TABLE_COLUMN_CLAUSES = default_inferred_column_clauses(ProcessTable) | {
     "customer": customer_clause,
     "product": make_product_clause(inferred_filter(ProductTable.name)),
     "product_description": make_product_clause(inferred_filter(ProductTable.description)),
-    "subscription_id": make_subscription_id_clause(inferred_filter(SubscriptionTable.subscription_id)),
+    "subscription_id": make_subscription_id_clause(filter_uuid_exact(ProcessSubscriptionTable.subscription_id)),
     "tag": make_product_clause(filter_exact(ProductTable.tag)),
     "target": workflow_targets_clause,
     "workflow_name": workflow_name_clause,

--- a/orchestrator/db/filters/search_filters/inferred_filter.py
+++ b/orchestrator/db/filters/search_filters/inferred_filter.py
@@ -152,3 +152,17 @@ def filter_exact(field: ColumnClause) -> WhereCondGenerator:
         return _filter_string(field)(node)
 
     return _clause_gen
+
+
+def filter_uuid_exact(field: ColumnClause) -> WhereCondGenerator:
+    assert field.type.python_type == uuid.UUID  # noqa: S101
+
+    def _clause_gen(node: Node) -> BinaryExpression[bool] | ColumnElement[bool]:
+        try:
+            v = uuid.UUID(node_to_str_val(node))
+        except ValueError:
+            # Not a valid uuid
+            return sqlalchemy.false()
+        return eq(field, v)
+
+    return _clause_gen

--- a/orchestrator/db/helpers.py
+++ b/orchestrator/db/helpers.py
@@ -1,7 +1,27 @@
+import functools
+
+import structlog
+from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql.elements import CompilerElement
+
+from orchestrator.db import db
+
+logger = structlog.get_logger(__name__)
 
 
 def to_sql_string(stmt: CompilerElement) -> str:
     dialect = postgresql.dialect()  # type: ignore
     return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+@functools.cache
+def get_postgres_version() -> int:
+    """Returns the Postgres major version as an int."""
+    try:
+        # The pg_version_num is pg_major_version * 10000 + pg_minor_version
+        pg_version_num = int(db.session.scalar(text("show server_version_num")))
+        return pg_version_num // 10000
+    except ValueError:
+        logger.error("Unable to query Postgres version")
+        return 0

--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -131,7 +131,9 @@ class ProcessSubscriptionTable(BaseModel):
     __tablename__ = "processes_subscriptions"
 
     id = mapped_column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True)
-    process_id = mapped_column("pid", UUIDType, ForeignKey("processes.pid", ondelete="CASCADE"), index=True)
+    process_id = mapped_column(
+        "pid", UUIDType, ForeignKey("processes.pid", ondelete="CASCADE"), index=True, nullable=False
+    )
     process = relationship("ProcessTable", back_populates="process_subscriptions")
     subscription_id = mapped_column(UUIDType, ForeignKey("subscriptions.subscription_id"), nullable=False, index=True)
     subscription = relationship("SubscriptionTable", lazy=True)
@@ -537,7 +539,9 @@ class SubscriptionCustomerDescriptionTable(BaseModel):
 class SubscriptionTable(BaseModel):
     __tablename__ = "subscriptions"
 
-    subscription_id = mapped_column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True)
+    subscription_id = mapped_column(
+        UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, nullable=False
+    )
     description = mapped_column(Text(), nullable=False)
     status = mapped_column(String(STATUS_LENGTH), nullable=False, index=True)
     product_id = mapped_column(UUIDType, ForeignKey("products.product_id"), nullable=False, index=True)

--- a/orchestrator/migrations/versions/schema/2023-09-25_da5c9f4cce1c_add_subscription_metadata_to_fulltext_.sql
+++ b/orchestrator/migrations/versions/schema/2023-09-25_da5c9f4cce1c_add_subscription_metadata_to_fulltext_.sql
@@ -5,17 +5,10 @@ DROP MATERIALIZED VIEW IF EXISTS subscriptions_search;
 CREATE MATERIALIZED VIEW IF NOT EXISTS subscriptions_search AS
 WITH rt_info AS (SELECT s.subscription_id,
                         concat_ws(
-                                ', ',
-                                string_agg(
-                                                rt.resource_type || ':' || siv.value,
-                                                ', '
-                                                ORDER BY rt.resource_type
-                                    ),
-                                string_agg(
-                                        distinct 'subscription_instance_id' || ':' || si.subscription_instance_id,
-                                        ', '
-                                    )
-                            ) AS rt_info
+                                ' ',
+                                string_agg(rt.resource_type || ' ' || siv.value, ' '),
+                                string_agg(distinct 'subscription_instance_id' || ':' || si.subscription_instance_id, ' ')
+                        ) AS rt_info
                  FROM subscription_instance_values siv
                           JOIN resource_types rt ON siv.resource_type_id = rt.resource_type_id
                           JOIN subscription_instances si ON siv.subscription_instance_id = si.subscription_instance_id
@@ -30,48 +23,46 @@ WITH rt_info AS (SELECT s.subscription_id,
                                           'note:' || coalesce(s.note, ''),
                                           'customer_id:' || s.customer_id,
                                           'product_id:' || s.product_id],
-                                      ', '
-                                  ) AS sub_info,
+                                      ' '
+                              ) AS sub_info,
                               array_to_string(
                                       ARRAY ['product_name:' || p.name,
                                           'product_description:' || p.description,
                                           'tag:' || p.tag,
                                           'product_type:', p.product_type],
-                                      ', '
-                                  ) AS prod_info
+                                      ' '
+                              ) AS prod_info
                        FROM subscriptions s
                                 JOIN products p ON s.product_id = p.product_id),
      fi_info AS (SELECT s.subscription_id,
-                        string_agg(
-                                        fi.name || ':' || fi.value,
-                                        ', '
-                                        ORDER BY fi.name
-                            ) AS fi_info
+                        string_agg(fi.name || ':' || fi.value, ' ') AS fi_info
                  FROM subscriptions s
                           JOIN products p ON s.product_id = p.product_id
                           JOIN fixed_inputs fi ON p.product_id = fi.product_id
                  GROUP BY s.subscription_id),
      cust_info AS (SELECT s.subscription_id,
-                          string_agg(
-                                      'customer_description: ' || scd.description,
-                                      ', '
-                              ) AS cust_info
+                          string_agg('customer_description: ' || scd.description, ' ') AS cust_info
                    FROM subscriptions s
                             JOIN subscription_customer_descriptions scd ON s.subscription_id = scd.subscription_id
                    GROUP BY s.subscription_id)
+-- to_tsvector handles parsing of hyphened words in a peculiar way and is inconsistent with how to_tsquery parses it in Postgres <14
+-- Replacing all hyphens with underscores makes the parsing more predictable and removes some issues arising when searching for subscription ids for example
+-- See: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=0c4f355c6a5fd437f71349f2f3d5d491382572b7
 SELECT s.subscription_id,
        to_tsvector(
                'simple',
-               concat_ws(
-                       ', ',
-                       spi.sub_info,
-                       spi.prod_info,
-                       fi.fi_info,
-                       rti.rt_info,
-                       ci.cust_info,
-                       md.metadata::text
-                   )
-           ) as tsv
+               replace(
+                       concat_ws(
+                               ' ',
+                               spi.sub_info,
+                               spi.prod_info,
+                               fi.fi_info,
+                               rti.rt_info,
+                               ci.cust_info,
+                               md.metadata::text
+                       ),
+                       '-', '_')
+       ) as tsv
 FROM subscriptions s
          LEFT JOIN sub_prod_info spi ON s.subscription_id = spi.subscription_id
          LEFT JOIN fi_info fi ON s.subscription_id = fi.subscription_id

--- a/orchestrator/utils/search_query.py
+++ b/orchestrator/utils/search_query.py
@@ -290,7 +290,7 @@ class TSQueryVisitor:
         # Postgres is finicky with single quotes in the query. In some situations it throws an error.
         # To avoid the special handling of ' by PG, we replace it with double quotes.
         # We also replace underscores with the 'followed by' operator
-        text = node[1].replace("'", '"').replace("_", " <-> ")
+        text = node[1].replace("'", '"').replace("_", " <-> ").replace("-", " <-> ")
         if node[0] == "Word":
             acc.append(text)
         elif node[0] == "PrefixWord":

--- a/test/unit_tests/fixtures/processes.py
+++ b/test/unit_tests/fixtures/processes.py
@@ -116,7 +116,7 @@ def mocked_processes(test_workflow, generic_subscription_1, generic_subscription
 
 @pytest.fixture
 def mocked_processes_resumeall(test_workflow, generic_subscription_1, generic_subscription_2):
-    first_datetime = datetime(2020, 1, 14, 9, 30, tzinfo=pytz.utc)
+    first_datetime = datetime(2020, 2, 14, 9, 30, tzinfo=pytz.utc)
 
     def mock_process(subscription_id, status, started, assignee=Assignee.SYSTEM, is_task=False):
         process_id = uuid4()

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -297,7 +297,7 @@ def test_processes_sorting_asc(
     }
 
     assert processes[0]["startedAt"] == "2020-01-14T09:30:00+00:00"
-    assert processes[1]["startedAt"] == "2020-01-14T09:30:00+00:00"
+    assert processes[1]["startedAt"] == "2020-01-15T09:30:00+00:00"
     assert processes[2]["startedAt"] == "2020-01-15T09:30:00+00:00"
 
 
@@ -329,11 +329,11 @@ def test_processes_sorting_desc(
         "totalItems": 19,
     }
 
-    assert processes[0]["startedAt"] == "2020-01-19T09:30:00+00:00"
-    assert processes[1]["startedAt"] == "2020-01-19T09:30:00+00:00"
-    assert processes[2]["startedAt"] == "2020-01-19T09:30:00+00:00"
-    assert processes[3]["startedAt"] == "2020-01-19T09:30:00+00:00"
-    assert processes[4]["startedAt"] == "2020-01-18T09:30:00+00:00"
+    assert processes[0]["startedAt"] == "2020-02-19T09:30:00+00:00"
+    assert processes[1]["startedAt"] == "2020-02-19T09:30:00+00:00"
+    assert processes[2]["startedAt"] == "2020-02-18T09:30:00+00:00"
+    assert processes[3]["startedAt"] == "2020-02-17T09:30:00+00:00"
+    assert processes[4]["startedAt"] == "2020-02-16T09:30:00+00:00"
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -979,6 +979,7 @@ def test_single_subscription_with_processes(
 
     product_type_1_subscriptions_factory(30)
     subscription_id = generic_subscription_1
+
     do_refresh_subscriptions_search_view()
 
     data = get_subscriptions_query_with_relations(**query_args(subscription_id))
@@ -1016,6 +1017,7 @@ def test_single_subscription_with_depends_on_subscriptions(
     # when
 
     product_type_1_subscriptions_factory(30)
+
     do_refresh_subscriptions_search_view()
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -1060,7 +1062,7 @@ def test_single_subscription_with_in_use_by_subscriptions(
     # when
 
     product_type_1_subscriptions_factory(30)
-    do_refresh_subscriptions_search_view()
+
     subscription_id = str(sub_one_subscription_1.subscription_id)
     subscription_query = get_subscriptions_query_with_relations(
         filter_by=[{"field": "subscriptionId", "value": subscription_id}]

--- a/test/unit_tests/test_db.py
+++ b/test/unit_tests/test_db.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
 from orchestrator.db import ResourceTypeTable, SubscriptionTable, WorkflowTable, db, transactional
+from orchestrator.db.helpers import get_postgres_version
 from orchestrator.targets import Target
 
 
@@ -174,3 +175,9 @@ def test_str_method():
         str(SubscriptionTable())
         == "SubscriptionTable(subscription_id=None, description=None, status=None, product_id=None, customer_id=None, insync=None, start_date=None, end_date=None, note=None)"
     )
+
+
+def test_get_postgres_version():
+    pg_version = get_postgres_version()
+    assert isinstance(pg_version, int)
+    assert 0 < pg_version < 20


### PR DESCRIPTION
Resolves #602 

- Add `filter_uuid_exact` clause matcher
- Implement Postgres version dependent splitting of search query terms