### PR TITLE
Improve the way to add strawberry models to the schema

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.2rc1
+current_version = 2.2.2rc2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/docs/architecture/application/graphql.md
+++ b/docs/architecture/application/graphql.md
@@ -72,6 +72,8 @@ app.register_graphql(query=NewQuery)
 
 ## Adding federated types to the graphql
 
+federation introduction: https://strawberry.rocks/docs/federation/introduction
+
 Within a federation, it is possible to add orchestrator data to graphql types from other sources by extending the `DEFAULT_GRAPHL_MODELS` dictionary with your own federated classes and adding them as parameter to `app.register_graphql(graphql_models={})`. Here is an example for when instead of overriding the customers resolver, you instead use a different graphql source (know that not storing any customer data in the orchestator will make filtering and sorting unavailable and very tricky to implement):
 
 ```python

--- a/docs/architecture/application/graphql.md
+++ b/docs/architecture/application/graphql.md
@@ -72,7 +72,7 @@ app.register_graphql(query=NewQuery)
 
 ## Adding federated types to the graphql
 
-Within a federation, it is possible to add orchestrator data to graphql types from other sources by extending the `DEFAULT_GRAPHL_MODELS` dictionary with your own federated classes and adding them as parameter to `app.register_graphql(graphql_models={}). Here is an example for when instead of overriding the customers resolver, you instead use a different graphql source (know that not storing any customer data in the orchestator will make filtering and sorting unavailable and very tricky to implement):
+Within a federation, it is possible to add orchestrator data to graphql types from other sources by extending the `DEFAULT_GRAPHL_MODELS` dictionary with your own federated classes and adding them as parameter to `app.register_graphql(graphql_models={})`. Here is an example for when instead of overriding the customers resolver, you instead use a different graphql source (know that not storing any customer data in the orchestator will make filtering and sorting unavailable and very tricky to implement):
 
 ```python
 import strawberry
@@ -115,7 +115,7 @@ app.register_graphql(query=OrchestratorQuery, graphql_models=UPDATED_GRAPHQL_MOD
 ```
 
 Types that are added in this way but aren't used in a resolver, will be viewable outside of a federation inside the types in the graphql ui interface.
-Adding product or product block strawberry types to the `graphql_models` will skip their generation inside `autoregister_domain_models`. more info [here](#domain-models-auto-registration-for-graphql)
+Adding product or product block strawberry types to the `graphql_models` will skip their generation inside `register_domain_models`. More info [here](#domain-models-auto-registration-for-graphql)
 
 ## Add Json schema for metadata
 
@@ -159,7 +159,7 @@ This will result in json schema:
 ## Domain Models Auto Registration for GraphQL
 
 When using the `app.register_graphql()` function, all products in the `SUBSCRIPTION_MODEL_REGISTRY` will be automatically converted into GraphQL types.
-You are able to turn this off with `app.register_graphql(register_models=False)` but will only be able to fetch the default `Subscription` data.
+You are able to turn this off with `app.register_graphql(register_models=False)`, but then you can only query fields from the default `SubscriptionModel`.
 The registration process iterates through the list, starting from the deepest product block and working its way back up to the product level.
 
 However, there is a potential issue when dealing with a `ProductBlock` that references itself, as it could lead to an error expecting the `ProductBlock` type to exist.

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.2.2rc1"
+__version__ = "2.2.2rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings, oauth2_settings

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -42,7 +42,9 @@ from orchestrator.distlock import init_distlock_manager
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
 from orchestrator.exception_handlers import problem_detail_handler
 from orchestrator.graphql import Mutation, Query, create_graphql_router
+from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS
 from orchestrator.graphql.schemas.subscription import SubscriptionInterface
+from orchestrator.graphql.types import StrawberryModelType
 from orchestrator.services.process_broadcast_thread import ProcessDataBroadcastThread
 from orchestrator.settings import AppSettings, ExecutorType, app_settings
 from orchestrator.version import GIT_COMMIT_HASH
@@ -188,9 +190,13 @@ class OrchestratorCore(FastAPI):
         mutation: Any = Mutation,
         register_models: bool = True,
         subscription_interface: Any = SubscriptionInterface,
+        graphql_models: StrawberryModelType | None = None,
     ) -> None:
+        if not graphql_models:
+            graphql_models = DEFAULT_GRAPHQL_MODELS
+
         new_router = create_graphql_router(
-            query, mutation, register_models, subscription_interface, self.broadcast_thread
+            query, mutation, register_models, subscription_interface, self.broadcast_thread, graphql_models
         )
         if not self.graphql_router:
             self.graphql_router = new_router

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -42,9 +42,8 @@ from orchestrator.distlock import init_distlock_manager
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
 from orchestrator.exception_handlers import problem_detail_handler
 from orchestrator.graphql import Mutation, Query, create_graphql_router
-from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS
 from orchestrator.graphql.schemas.subscription import SubscriptionInterface
-from orchestrator.graphql.types import StrawberryModelType
+from orchestrator.graphql.types import ScalarOverrideType, StrawberryModelType
 from orchestrator.services.process_broadcast_thread import ProcessDataBroadcastThread
 from orchestrator.settings import AppSettings, ExecutorType, app_settings
 from orchestrator.version import GIT_COMMIT_HASH
@@ -191,12 +190,16 @@ class OrchestratorCore(FastAPI):
         register_models: bool = True,
         subscription_interface: Any = SubscriptionInterface,
         graphql_models: StrawberryModelType | None = None,
+        scalar_overrides: ScalarOverrideType | None = None,
     ) -> None:
-        if not graphql_models:
-            graphql_models = DEFAULT_GRAPHQL_MODELS
-
         new_router = create_graphql_router(
-            query, mutation, register_models, subscription_interface, self.broadcast_thread, graphql_models
+            query,
+            mutation,
+            register_models,
+            subscription_interface,
+            self.broadcast_thread,
+            graphql_models,
+            scalar_overrides,
         )
         if not self.graphql_router:
             self.graphql_router = new_router

--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -27,11 +27,10 @@ from orchestrator.graphql.schema import (
     custom_context_dependency,
     get_context,
 )
-from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS, GRAPHQL_MODELS
+from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS
 from orchestrator.graphql.types import SCALAR_OVERRIDES
 
 __all__ = [
-    "GRAPHQL_MODELS",
     "DEFAULT_GRAPHQL_MODELS",
     "SCALAR_OVERRIDES",
     "Query",

--- a/orchestrator/graphql/__init__.py
+++ b/orchestrator/graphql/__init__.py
@@ -17,21 +17,26 @@ from orchestrator.graphql.autoregistration import (
     register_domain_models,
 )
 from orchestrator.graphql.schema import (
+    CustomerQuery,
     Mutation,
     OrchestratorGraphqlRouter,
+    OrchestratorQuery,
     OrchestratorSchema,
     Query,
     create_graphql_router,
     custom_context_dependency,
     get_context,
 )
-from orchestrator.graphql.schemas import GRAPHQL_MODELS
+from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS, GRAPHQL_MODELS
 from orchestrator.graphql.types import SCALAR_OVERRIDES
 
 __all__ = [
     "GRAPHQL_MODELS",
+    "DEFAULT_GRAPHQL_MODELS",
     "SCALAR_OVERRIDES",
     "Query",
+    "OrchestratorQuery",
+    "CustomerQuery",
     "Mutation",
     "OrchestratorGraphqlRouter",
     "OrchestratorSchema",

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -23,7 +23,7 @@ from strawberry.unset import UNSET
 
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import DomainModel, get_depends_on_product_block_type_list
-from orchestrator.graphql.schemas import StrawberryModelType
+from orchestrator.graphql.types import StrawberryModelType
 from orchestrator.types import filter_nonetype, is_of_type, is_optional_type
 from orchestrator.utils.helpers import to_camel
 

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -148,23 +148,6 @@ def get_context(
     return _get_context
 
 
-INTERNAL_GRAPHQL_MODELS: StrawberryModelType = {}
-
-
-def internal_graphql_model_test_logic(graphql_models: dict) -> dict:
-    """Necessary Graphql logic for unit tests since we create and delete subscription models in each test and graphql expect static models.
-
-    We create and destroy the subscription models in each test. (which makes the pydantic model technically not the same after its re-created)
-    Strawberry will error saying that a nested product block can't be resolver and if you are actually using strawberry.field, This should never happen outside of testing.
-
-    returns INTERNAL_GRAPHQL_MOEDLS if environment is 'TESTING' and graphql_models if it isn't
-    """
-    if app_settings.ENVIRONMENT == "TESTING":
-        INTERNAL_GRAPHQL_MODELS.update(graphql_models)
-        return INTERNAL_GRAPHQL_MODELS
-    return graphql_models
-
-
 def create_graphql_router(
     query: Any = Query,
     mutation: Any = Mutation,
@@ -182,7 +165,6 @@ def create_graphql_router(
 
     if register_models:
         models = register_domain_models(subscription_interface, existing_models=models)
-        models = internal_graphql_model_test_logic(models)
 
     schema = OrchestratorSchema(
         query=query,

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -157,7 +157,7 @@ def internal_graphql_model_test_logic(graphql_models: dict) -> dict:
     We create and destroy the subscription models in each test. (which makes the pydantic model technically not the same after its re-created)
     Strawberry will error saying that a nested product block can't be resolver and if you are actually using strawberry.field, This should never happen outside of testing.
 
-    returns INTERNAL_GRAPHQL_MOEDLS if environment is 'TESTING' and graphql_models if isn't
+    returns INTERNAL_GRAPHQL_MOEDLS if environment is 'TESTING' and graphql_models if it isn't
     """
     if app_settings.ENVIRONMENT == "TESTING":
         INTERNAL_GRAPHQL_MODELS.update(graphql_models)

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -27,7 +27,7 @@ from strawberry.utils.logging import StrawberryLogger
 
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.domain.base import SubscriptionModel
-from orchestrator.graphql.autoregistration import register_domain_models
+from orchestrator.graphql.autoregistration import create_subscription_strawberry_type, register_domain_models
 from orchestrator.graphql.extensions.deprecation_checker_extension import make_deprecation_checker_extension
 from orchestrator.graphql.extensions.error_handler_extension import ErrorHandlerExtension
 from orchestrator.graphql.mutations.customer_description import CustomerSubscriptionDescriptionMutation
@@ -45,15 +45,16 @@ from orchestrator.graphql.resolvers import (
     resolve_workflows,
 )
 from orchestrator.graphql.resolvers.subscription import resolve_subscription
+from orchestrator.graphql.schemas import DEFAULT_GRAPHQL_MODELS
 from orchestrator.graphql.schemas.customer import CustomerType
 from orchestrator.graphql.schemas.process import ProcessType
 from orchestrator.graphql.schemas.product import ProductType
 from orchestrator.graphql.schemas.product_block import ProductBlock
 from orchestrator.graphql.schemas.resource_type import ResourceType
 from orchestrator.graphql.schemas.settings import StatusType
-from orchestrator.graphql.schemas.subscription import SubscriptionInterface, federation_key_directives
+from orchestrator.graphql.schemas.subscription import SubscriptionInterface
 from orchestrator.graphql.schemas.workflow import Workflow
-from orchestrator.graphql.types import SCALAR_OVERRIDES, OrchestratorContext, StrawberryModelType
+from orchestrator.graphql.types import SCALAR_OVERRIDES, OrchestratorContext, ScalarOverrideType, StrawberryModelType
 from orchestrator.security import get_oidc_user, get_opa_security_graphql
 from orchestrator.services.process_broadcast_thread import ProcessDataBroadcastThread
 from orchestrator.settings import app_settings
@@ -64,7 +65,7 @@ logger = structlog.get_logger(__name__)
 
 
 @strawberry.federation.type(description="Orchestrator queries")
-class Query:
+class OrchestratorQuery:
     processes: Connection[ProcessType] = authenticated_field(
         resolver=resolve_processes, description="Returns list of processes"
     )
@@ -90,11 +91,16 @@ class Query:
         resolver=resolve_settings,
         description="Returns information about cache, workers, and global engine settings",
     )
+
+
+@strawberry.federation.type(description="Orchestrator customer Query")
+class CustomerQuery:
     customers: Connection[CustomerType] = authenticated_field(
         resolver=resolve_customer, description="Returns default customer information"
     )
 
 
+Query = merge_types("Query", (OrchestratorQuery, CustomerQuery))
 Mutation = merge_types("Mutation", (SettingsMutation, CustomerSubscriptionDescriptionMutation, ProcessMutation))
 
 OrchestratorGraphqlRouter = GraphQLRouter
@@ -145,32 +151,38 @@ def get_context(
 INTERNAL_GRAPHQL_MODELS: StrawberryModelType = {}
 
 
-def internal_graphql_model_logic(graphql_models: dict) -> dict:
-    """Necessary for some reason yet to be found."""
-    INTERNAL_GRAPHQL_MODELS.update(graphql_models)
-    return INTERNAL_GRAPHQL_MODELS
+def internal_graphql_model_test_logic(graphql_models: dict) -> dict:
+    """Necessary Graphql logic for unit tests since we create and delete subscription models in each test and graphql expect static models.
+
+    We create and destroy the subscription models in each test. (which makes the pydantic model technically not the same after its re-created)
+    Strawberry will error saying that a nested product block can't be resolver and if you are actually using strawberry.field, This should never happen outside of testing.
+
+    returns INTERNAL_GRAPHQL_MOEDLS if environment is 'TESTING' and graphql_models if isn't
+    """
+    if app_settings.ENVIRONMENT == "TESTING":
+        INTERNAL_GRAPHQL_MODELS.update(graphql_models)
+        return INTERNAL_GRAPHQL_MODELS
+    return graphql_models
 
 
 def create_graphql_router(
     query: Any = Query,
     mutation: Any = Mutation,
     register_models: bool = True,
-    subscription_interface: type | None = SubscriptionInterface,
+    subscription_interface: type = SubscriptionInterface,
     broadcast_thread: ProcessDataBroadcastThread | None = None,
     graphql_models: StrawberryModelType | None = None,
+    scalar_overrides: ScalarOverrideType | None = None,
 ) -> OrchestratorGraphqlRouter:
-    @strawberry.experimental.pydantic.type(
-        model=SubscriptionModel, all_fields=True, directives=federation_key_directives
+    scalar_overrides = scalar_overrides if scalar_overrides else dict(SCALAR_OVERRIDES)
+    models = graphql_models if graphql_models else dict(DEFAULT_GRAPHQL_MODELS)
+    models["subscription"] = create_subscription_strawberry_type(
+        "Subscription", SubscriptionModel, subscription_interface
     )
-    class Subscription(SubscriptionInterface):
-        pass
-
-    models = dict(graphql_models) if graphql_models else {}
-    models["subscription"] = Subscription
 
     if register_models:
         models = register_domain_models(subscription_interface, existing_models=models)
-        models = internal_graphql_model_logic(models)
+        models = internal_graphql_model_test_logic(models)
 
     schema = OrchestratorSchema(
         query=query,
@@ -178,7 +190,7 @@ def create_graphql_router(
         enable_federation_2=app_settings.FEDERATION_ENABLED,
         types=tuple(models.values()),
         extensions=[ErrorHandlerExtension, make_deprecation_checker_extension(query=query)],
-        scalar_overrides=SCALAR_OVERRIDES,
+        scalar_overrides=scalar_overrides,
     )
 
     return OrchestratorGraphqlRouter(

--- a/orchestrator/graphql/schemas/__init__.py
+++ b/orchestrator/graphql/schemas/__init__.py
@@ -16,4 +16,3 @@ from orchestrator.graphql.types import StrawberryModelType
 DEFAULT_GRAPHQL_MODELS: StrawberryModelType = {
     "ProductModelGraphql": ProductModelGraphql,
 }
-GRAPHQL_MODELS: StrawberryModelType = DEFAULT_GRAPHQL_MODELS

--- a/orchestrator/graphql/schemas/__init__.py
+++ b/orchestrator/graphql/schemas/__init__.py
@@ -10,16 +10,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TypeVar
-
-from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
-
 from orchestrator.graphql.schemas.product import ProductModelGraphql
+from orchestrator.graphql.types import StrawberryModelType
 
-StrawberryPydanticModel = TypeVar("StrawberryPydanticModel", bound=StrawberryTypeFromPydantic)
-StrawberryModelType = dict[str, StrawberryPydanticModel]
-
-
-GRAPHQL_MODELS: StrawberryModelType = {
+DEFAULT_GRAPHQL_MODELS: StrawberryModelType = {
     "ProductModelGraphql": ProductModelGraphql,
 }
+GRAPHQL_MODELS: StrawberryModelType = DEFAULT_GRAPHQL_MODELS

--- a/orchestrator/graphql/schemas/customer.py
+++ b/orchestrator/graphql/schemas/customer.py
@@ -1,7 +1,7 @@
 import strawberry
 
 
-@strawberry.type
+@strawberry.federation.type(keys=["customerId"])
 class CustomerType:
     customer_id: str
     fullname: str

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from orchestrator.graphql.schemas.subscription import SubscriptionInterface
 
 
-federation_key_directives = [Key(fields="id", resolvable=UNSET)]
+federation_key_directives = [Key(fields="processId", resolvable=UNSET)]
 
 
 @strawberry.experimental.pydantic.type(model=ProcessStepSchema)

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -119,7 +119,8 @@ IntType = strawberry.scalar(
     parse_value=lambda v: v,
 )
 
-SCALAR_OVERRIDES: dict[object, Any | ScalarWrapper | ScalarDefinition] = {
+ScalarOverrideType = dict[object, type | ScalarWrapper | ScalarDefinition]
+SCALAR_OVERRIDES: ScalarOverrideType = {
     dict: JSON,
     VlanRanges: VlanRangesType,
     IPv4Address: IPv4AddressType,

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -15,12 +15,13 @@ from collections.abc import Awaitable, Callable
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface
 
 # Map some Orchestrator types to scalars
-from typing import Any, NewType
+from typing import Any, NewType, TypeVar
 
 import strawberry
 from graphql import GraphQLError
 from starlette.requests import Request
 from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
+from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
 from strawberry.scalars import JSON
 from strawberry.types import Info
 from strawberry.types.info import RootValueType
@@ -32,6 +33,9 @@ from orchestrator.db.filters import Filter
 from orchestrator.db.sorting import Sort, SortOrder
 from orchestrator.services.process_broadcast_thread import ProcessDataBroadcastThread
 
+StrawberryPydanticModel = TypeVar("StrawberryPydanticModel", bound=StrawberryTypeFromPydantic)
+StrawberryModelType = dict[str, StrawberryPydanticModel]
+
 
 def serialize_to_string(value: Any) -> str:
     return str(value)
@@ -42,16 +46,19 @@ def serialize_vlan(vlan: VlanRanges) -> list[tuple[int, int]]:
 
 
 class OrchestratorContext(OauthContext):
-    broadcast_thread: ProcessDataBroadcastThread | None = None
+    broadcast_thread: ProcessDataBroadcastThread | None
+    graphql_models: StrawberryModelType
 
     def __init__(
         self,
         get_current_user: Callable[[Request], Awaitable[OIDCUserModel]],
         get_opa_decision: Callable[[str, OIDCUserModel], Awaitable[bool | None]],
         broadcast_thread: ProcessDataBroadcastThread | None = None,
+        graphql_models: StrawberryModelType | None = None,
     ):
         self.errors: list[GraphQLError] = []
         self.broadcast_thread = broadcast_thread
+        self.graphql_models = graphql_models or {}
         super().__init__(get_current_user, get_opa_decision)
 
 

--- a/test/unit_tests/graphql/conftest.py
+++ b/test/unit_tests/graphql/conftest.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 import pytest
 
 from orchestrator import app_settings
+from orchestrator.graphql.autoregistration import register_domain_models
 
 
 @pytest.fixture(autouse=True)
@@ -31,3 +34,16 @@ def fastapi_app_graphql(
     fastapi_app.register_graphql()
     yield fastapi_app
     app_settings.ENVIRONMENT = actual_env
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fix_graphql_model_registration():
+    internal_graphql_models = {}
+
+    def patched_register_domain_models(*args, **kwargs):
+        graphql_models = register_domain_models(*args, **kwargs)
+        internal_graphql_models.update(graphql_models)
+        return internal_graphql_models
+
+    with mock.patch("orchestrator.graphql.schema.register_domain_models", side_effect=patched_register_domain_models):
+        yield

--- a/test/unit_tests/graphql/conftest.py
+++ b/test/unit_tests/graphql/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from orchestrator import app_settings
+
 
 @pytest.fixture(autouse=True)
 def fastapi_app_graphql(
@@ -24,5 +26,8 @@ def fastapi_app_graphql(
 
     MetadataDict.update({"metadata": Metadata})
 
+    actual_env = app_settings.ENVIRONMENT
+    app_settings.ENVIRONMENT = "TESTING"
     fastapi_app.register_graphql()
-    return fastapi_app
+    yield fastapi_app
+    app_settings.ENVIRONMENT = actual_env


### PR DESCRIPTION
- fix incorrect process id federation key
- change customer to a federated type
- Improve the way to add strawberry models to the schema
- - instead of overriding or adding strawberry types to the `GRAPHQL_MODELS` with `.updates()`, you can now extend it or use a different variable using parameter `graphql_models` inside `register_graphql`.
- - [x] update documentation
- Change `SCALAR_OVERRIDE` to a parameter instead of magical dict update (same as `GRAPHQL_MODELS`)
- split Query into OrchestratorQuery and CustomerQuery class, so customers can be left out if it comes from somewhere else in a federation.

- `GRAPHQL_MODELS` is replaced by `DEFAULT_GRAPHQL_MODELS`.