### PR TITLE
Add processId to the invalidate cache broadcast of send_process_data_to_websocket

### DIFF
--- a/orchestrator/websocket/__init__.py
+++ b/orchestrator/websocket/__init__.py
@@ -118,7 +118,7 @@ def send_process_data_to_websocket(
         logger.debug("Broadcast process data directly to websocket_manager", process_id=str(process_id))
 
         anyio.run(websocket_manager.broadcast_data, [WS_CHANNELS.ALL_PROCESSES], data)
-        sync_broadcast_invalidate_cache("processes")
+        sync_broadcast_invalidate_cache("processes", str(process_id))
 
 
 async def empty_handler() -> None:

--- a/test/unit_tests/graphql/test_product_blocks.py
+++ b/test/unit_tests/graphql/test_product_blocks.py
@@ -94,7 +94,7 @@ def test_product_blocks_query(test_client, query_args, num_results):
 
 
 def test_product_blocks_payload(test_client):
-    data = get_product_blocks_query(first=2)
+    data = get_product_blocks_query(first=2, sort_by=[{"field": "name", "order": "ASC"}])
     response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code


### PR DESCRIPTION
- Add ordering to test_product_blocks_payload unit test to fix flakiness

related: https://github.com/workfloworchestrator/orchestrator-core/issues/572