### PR TITLE
send Invalidate cache of subscription/s through websocket

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0rc4
+current_version = 2.3.0rc5
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.3.0rc4"
+__version__ = "2.3.0rc5"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/api/api_v1/endpoints/settings.py
+++ b/orchestrator/api/api_v1/endpoints/settings.py
@@ -96,7 +96,7 @@ async def set_global_status(
             [WS_CHANNELS.ENGINE_SETTINGS],
             {"engine-status": generate_engine_status_response(result)},
         )
-        await broadcast_invalidate_cache("engineStatus")
+        await broadcast_invalidate_cache({"type": "engineStatus"})
     return status_response
 
 

--- a/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
@@ -32,15 +32,15 @@ router = APIRouter()
 
 
 @router.post("/", response_model=None, status_code=HTTPStatus.NO_CONTENT)
-def save_subscription_customer_description_endpoint(data: SubscriptionDescriptionBaseSchema = Body(...)) -> None:
-    create_subscription_customer_description(data.customer_id, data.subscription_id, data.description)
+async def save_subscription_customer_description_endpoint(data: SubscriptionDescriptionBaseSchema = Body(...)) -> None:
+    await create_subscription_customer_description(data.customer_id, data.subscription_id, data.description)
 
 
 @router.put("/", response_model=None, status_code=HTTPStatus.NO_CONTENT)
-def update_subscription_customer_description_endpoint(data: SubscriptionDescriptionSchema = Body(...)) -> None:
+async def update_subscription_customer_description_endpoint(data: SubscriptionDescriptionSchema = Body(...)) -> None:
     description = get_customer_description_by_customer_subscription(data.customer_id, data.subscription_id)
     if description:
-        update_subscription_customer_description(description, data.description, data.created_at)
+        await update_subscription_customer_description(description, data.description, data.created_at)
 
 
 @router.delete("/{_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)

--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -50,6 +50,7 @@ from orchestrator.settings import app_settings
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.utils.deprecation_logger import deprecated_endpoint
 from orchestrator.utils.get_subscription_dict import get_subscription_dict
+from orchestrator.websocket import sync_broadcast_invalidate_cache
 
 router = APIRouter()
 
@@ -209,6 +210,7 @@ def subscription_set_in_sync(subscription_id: UUID, current_user: OIDCUserModel 
                 subscription.insync = True
                 db.session.commit()
                 logger.info("Subscription set in sync", user=current_user)
+                sync_broadcast_invalidate_cache("subscriptions", str(subscription.subscription_id))
             else:
                 raise_status(
                     HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -50,7 +50,7 @@ from orchestrator.settings import app_settings
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.utils.deprecation_logger import deprecated_endpoint
 from orchestrator.utils.get_subscription_dict import get_subscription_dict
-from orchestrator.websocket import sync_broadcast_invalidate_cache
+from orchestrator.websocket import sync_invalidate_subscription_cache
 
 router = APIRouter()
 
@@ -210,7 +210,7 @@ def subscription_set_in_sync(subscription_id: UUID, current_user: OIDCUserModel 
                 subscription.insync = True
                 db.session.commit()
                 logger.info("Subscription set in sync", user=current_user)
-                sync_broadcast_invalidate_cache("subscriptions", str(subscription.subscription_id))
+                sync_invalidate_subscription_cache(subscription.subscription_id)
             else:
                 raise_status(
                     HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/orchestrator/domain/customer_description.py
+++ b/orchestrator/domain/customer_description.py
@@ -21,6 +21,7 @@ from sqlalchemy import select
 from orchestrator.api.models import delete
 from orchestrator.db import SubscriptionCustomerDescriptionTable, db
 from orchestrator.utils.redis import delete_subscription_from_redis
+from orchestrator.websocket import sync_broadcast_invalidate_cache
 
 router = APIRouter()
 
@@ -46,6 +47,7 @@ def create_subscription_customer_description(
     )
     db.session.add(customer_description)
     db.session.commit()
+    sync_broadcast_invalidate_cache("subscriptions", str(subscription_id))
     return customer_description
 
 
@@ -56,6 +58,7 @@ def update_subscription_customer_description(
     customer_description.description = description
     customer_description.created_at = created_at if created_at else datetime.now(tz=timezone("UTC"))
     db.session.commit()
+    sync_broadcast_invalidate_cache("subscriptions", str(customer_description.subscription_id))
     return customer_description
 
 
@@ -68,4 +71,5 @@ def delete_subscription_customer_description_by_customer_subscription(
         return None
 
     delete(SubscriptionCustomerDescriptionTable, customer_description.id)
+    sync_broadcast_invalidate_cache("subscriptions", str(customer_description.subscription_id))
     return customer_description

--- a/orchestrator/domain/customer_description.py
+++ b/orchestrator/domain/customer_description.py
@@ -21,7 +21,7 @@ from sqlalchemy import select
 from orchestrator.api.models import delete
 from orchestrator.db import SubscriptionCustomerDescriptionTable, db
 from orchestrator.utils.redis import delete_subscription_from_redis
-from orchestrator.websocket import sync_broadcast_invalidate_cache
+from orchestrator.websocket import sync_invalidate_subscription_cache
 
 router = APIRouter()
 
@@ -47,7 +47,7 @@ def create_subscription_customer_description(
     )
     db.session.add(customer_description)
     db.session.commit()
-    sync_broadcast_invalidate_cache("subscriptions", str(subscription_id))
+    sync_invalidate_subscription_cache(subscription_id)
     return customer_description
 
 
@@ -58,7 +58,7 @@ def update_subscription_customer_description(
     customer_description.description = description
     customer_description.created_at = created_at if created_at else datetime.now(tz=timezone("UTC"))
     db.session.commit()
-    sync_broadcast_invalidate_cache("subscriptions", str(customer_description.subscription_id))
+    sync_invalidate_subscription_cache(customer_description.subscription_id)
     return customer_description
 
 
@@ -71,5 +71,5 @@ def delete_subscription_customer_description_by_customer_subscription(
         return None
 
     delete(SubscriptionCustomerDescriptionTable, customer_description.id)
-    sync_broadcast_invalidate_cache("subscriptions", str(customer_description.subscription_id))
+    sync_invalidate_subscription_cache(customer_description.subscription_id)
     return customer_description

--- a/orchestrator/graphql/mutations/customer_description.py
+++ b/orchestrator/graphql/mutations/customer_description.py
@@ -29,21 +29,21 @@ from orchestrator.graphql.types import MutationError, NotFoundError
 logger = structlog.get_logger(__name__)
 
 
-def upsert_customer_description(
+async def upsert_customer_description(
     customer_id: str, subscription_id: UUID, description: str
 ) -> SubscriptionCustomerDescriptionTable | NotFoundError:
     current_description = get_customer_description_by_customer_subscription(customer_id, subscription_id)
 
     if current_description:
-        return update_subscription_customer_description(current_description, description)
-    return create_subscription_customer_description(customer_id, subscription_id, description)
+        return await update_subscription_customer_description(current_description, description)
+    return await create_subscription_customer_description(customer_id, subscription_id, description)
 
 
 async def resolve_upsert_customer_description(
     customer_id: str, subscription_id: UUID, description: str
 ) -> CustomerDescription | NotFoundError | MutationError:
     try:
-        customer_description = upsert_customer_description(customer_id, subscription_id, description)
+        customer_description = await upsert_customer_description(customer_id, subscription_id, description)
     except Exception:
         return NotFoundError(message="Subscription not found")
     return CustomerDescription.from_pydantic(customer_description)  # type: ignore
@@ -52,7 +52,7 @@ async def resolve_upsert_customer_description(
 async def resolve_remove_customer_description(
     customer_id: str, subscription_id: UUID
 ) -> CustomerDescription | NotFoundError | MutationError:
-    description = delete_subscription_customer_description_by_customer_subscription(
+    description = await delete_subscription_customer_description_by_customer_subscription(
         customer_id=customer_id, subscription_id=subscription_id
     )
     if not description:

--- a/orchestrator/utils/redis.py
+++ b/orchestrator/utils/redis.py
@@ -86,8 +86,8 @@ def delete_subscription_from_redis(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     def _delete_subscription_from_redis(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
-        def wrapper(*args: tuple, **kwargs: dict[str, Any]) -> Any:
-            data = func(*args, **kwargs)
+        async def wrapper(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+            data = await func(*args, **kwargs)
             key = extract_fn(data)
             delete_from_redis(key)
             return data

--- a/orchestrator/workflows/steps.py
+++ b/orchestrator/workflows/steps.py
@@ -26,7 +26,7 @@ from orchestrator.targets import Target
 from orchestrator.types import State, SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.json import to_serializable
 from orchestrator.utils.redis import delete_from_redis, to_redis
-from orchestrator.websocket import sync_broadcast_invalidate_cache
+from orchestrator.websocket import sync_invalidate_subscription_cache
 from orchestrator.workflow import Step, step
 
 logger = structlog.get_logger(__name__)
@@ -207,12 +207,12 @@ def cache_domain_models(workflow_name: str, subscription: SubscriptionModel | No
     for subscription_id in cached_subscription_ids:
         subscription_model = SubscriptionModel.from_subscription(subscription_id)
         to_redis(build_extended_domain_model(subscription_model))
-        sync_broadcast_invalidate_cache(str(subscription.subscription_id))
+        sync_invalidate_subscription_cache(subscription.subscription_id, invalidate_all=False)
 
     # Cache the main subscription
     to_redis(build_extended_domain_model(subscription))
     cached_subscription_ids.add(subscription.subscription_id)
-    sync_broadcast_invalidate_cache("subscriptions", str(subscription.subscription_id))
+    sync_invalidate_subscription_cache(subscription.subscription_id)
 
     return {"cached_subscription_ids": cached_subscription_ids}
 

--- a/orchestrator/workflows/steps.py
+++ b/orchestrator/workflows/steps.py
@@ -26,6 +26,7 @@ from orchestrator.targets import Target
 from orchestrator.types import State, SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.json import to_serializable
 from orchestrator.utils.redis import delete_from_redis, to_redis
+from orchestrator.websocket import sync_broadcast_invalidate_cache
 from orchestrator.workflow import Step, step
 
 logger = structlog.get_logger(__name__)
@@ -206,10 +207,12 @@ def cache_domain_models(workflow_name: str, subscription: SubscriptionModel | No
     for subscription_id in cached_subscription_ids:
         subscription_model = SubscriptionModel.from_subscription(subscription_id)
         to_redis(build_extended_domain_model(subscription_model))
+        sync_broadcast_invalidate_cache(str(subscription.subscription_id))
 
     # Cache the main subscription
     to_redis(build_extended_domain_model(subscription))
     cached_subscription_ids.add(subscription.subscription_id)
+    sync_broadcast_invalidate_cache("subscriptions", str(subscription.subscription_id))
 
     return {"cached_subscription_ids": cached_subscription_ids}
 

--- a/test/unit_tests/api/test_ws.py
+++ b/test/unit_tests/api/test_ws.py
@@ -16,14 +16,14 @@ def test_websocket_events_ping_pong(test_client):
 
 def test_websocket_events_invalidate_cache(test_client):
     with test_client.websocket_connect("api/ws/events") as websocket:
-        sync_broadcast_invalidate_cache("foobar")
-        assert websocket.receive_json() == {"name": "invalidateCache", "value": ["foobar"]}
+        sync_broadcast_invalidate_cache({"type": "foobar"})
+        assert websocket.receive_json() == {"name": "invalidateCache", "value": {"type": "foobar"}}
 
 
 async def test_websocket_events_invalidate_cache_async(test_client):
     with test_client.websocket_connect("api/ws/events") as websocket:
-        await broadcast_invalidate_cache("foo", "bar")
-        assert websocket.receive_json() == {"name": "invalidateCache", "value": ["foo", "bar"]}
+        await broadcast_invalidate_cache({"type": "foobar", "id": "bar"})
+        assert websocket.receive_json() == {"name": "invalidateCache", "value": {"type": "foobar", "id": "bar"}}
 
 
 @mock.patch("orchestrator.websocket.websocket_manager.authorize_websocket")


### PR DESCRIPTION
- invalidate subscription/s cache in cache domain model step.
- invalidate subscription/s cache in 'set in sync' endpoint.
- invalidate subscription/s cache in create and update subscription description.
- Change invalidation to return a dict instead of a list to have it in line with frontend cache invalidation, [check the discussion](https://github.com/workfloworchestrator/orchestrator-core/pull/671#discussion_r1628930882)

Closes: https://github.com/workfloworchestrator/orchestrator-core/issues/574