### PR TITLE
Prevent linking the same instance more than once

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.0rc2
+current_version = 2.7.0rc3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.7.0rc2"
+__version__ = "2.7.0rc3"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/test/unit_tests/domain/test_base_multiple.py
+++ b/test/unit_tests/domain/test_base_multiple.py
@@ -109,7 +109,6 @@ def test_2_field_blocks_from_1_other_subscription(test_product_type_one, create_
     assert subscription_10.block.sub_block_2.int_field == 201
 
 
-@pytest.mark.xfail(reason="Raises sqlalchemy/psycopg2 error, see #726")
 def test_2_field_identical_blocks_from_1_other_subscription(test_product_type_one, create_fixtures):
     """Test using the exact same block in separate fields when both blocks are owned by 1 different subscription.
 
@@ -120,8 +119,7 @@ def test_2_field_identical_blocks_from_1_other_subscription(test_product_type_on
 
     subscription_20 = create_subscription(int_value=20, sub_block_values=[200, 201])
 
-    # TODO #726 this should raise a ValueError
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Cannot link the same subscription instance multiple times"):
         _ = create_subscription(
             int_value=10,
             sub_block1=subscription_20.block.sub_block,
@@ -188,7 +186,6 @@ def test_2_field_blocks_from_current_subscription_and_2_list_blocks_from_1_other
     assert subscription_10.block.sub_block_list[1].int_field == 201
 
 
-@pytest.mark.xfail(reason="Does not raise an error but it should, see #726")
 def test_2_field_blocks_from_current_subscription_and_2_identical_list_blocks_from_1_other_subscription(
     test_product_type_one, create_fixtures
 ):
@@ -201,8 +198,7 @@ def test_2_field_blocks_from_current_subscription_and_2_identical_list_blocks_fr
 
     subscription_20 = create_subscription(int_value=20, sub_block_values=[200, 201])
 
-    # TODO #726 this should raise a ValueError, currently it allows it
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Cannot link the same subscription instance multiple times"):
         _ = create_subscription(
             int_value=10,
             sub_block_list=[subscription_20.block.sub_block, subscription_20.block.sub_block],


### PR DESCRIPTION
* Before saving instances, ensure that the same subscription instance is not linked more than once. This only counts for the scope of a subscription or subscription instance. In different parts of a subscription's tree the same subscription instance could still be linked
* Bump version to 2.7.0rc3

Closes #726 