### PR TITLE
Restore the 'reporter' parameter for processes endpoints

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.2
+current_version = 2.7.3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.7.2"
+__version__ = "2.7.3"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -87,8 +87,9 @@ def check_global_lock() -> None:
 
 
 def resolve_user_name(
-    reporter: Reporter | None = None,
-    resolved_user: OIDCUserModel | None = None,
+    *,
+    reporter: Reporter | None,
+    resolved_user: OIDCUserModel | None,
 ) -> str:
     if reporter:
         return reporter
@@ -99,8 +100,11 @@ def resolve_user_name(
     return SYSTEM_USER
 
 
-def user_name(user: OIDCUserModel | None = Depends(authenticate)) -> str:
-    return resolve_user_name(resolved_user=user)
+def user_name(
+    reporter: Reporter | None = None,
+    user: OIDCUserModel | None = Depends(authenticate),
+) -> str:
+    return resolve_user_name(reporter=reporter, resolved_user=user)
 
 
 @router.delete("/{process_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)

--- a/orchestrator/graphql/mutations/start_process.py
+++ b/orchestrator/graphql/mutations/start_process.py
@@ -28,7 +28,7 @@ async def resolve_start_process(
     current_user = None
     if user_resolver := info.context.get_current_user:
         current_user = await user_resolver
-    user = resolve_user_name(reporter, current_user)
+    user = resolve_user_name(reporter=reporter, resolved_user=current_user)
 
     try:
         process_id = start_process(name, user_inputs=payload.payload, user=user, broadcast_func=broadcast_func)


### PR DESCRIPTION
This parameter was accidentally removed during the AuthN/AuthZ refactor in https://github.com/workfloworchestrator/orchestrator-core/pull/608

Bumps version to 2.7.3