### PR TITLE
Fix that a process resumed through callback would not broadcast events

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -183,7 +183,8 @@ def continue_awaiting_process_endpoint(
         raise_status(HTTPStatus.CONFLICT, "This process is not in an awaiting state.")
 
     try:
-        continue_awaiting_process(process, token=token, input_data=json_data)
+        broadcast_func = api_broadcast_process_data(request)
+        continue_awaiting_process(process, token=token, input_data=json_data, broadcast_func=broadcast_func)
     except AssertionError as e:
         raise_status(HTTPStatus.NOT_FOUND, str(e))
 

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -78,10 +78,11 @@ async def get_subscription_product_blocks(
         def value_parser(value: Any) -> str:
             if isinstance(value, (str, int, float, type(None))):
                 return value
-            elif isinstance(value, list):
+
+            if isinstance(value, list):
                 return [value_parser(v) for v in value if is_resource_type(v)]
-            else:
-                return str(value)
+
+            return str(value)
 
         return ProductBlockInstance(
             id=product_block["id"],

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -75,7 +75,7 @@ async def get_subscription_product_blocks(
         def included(key: str, value: Any) -> bool:
             return is_resource_type(value) and requested_resource_type(key) and key not in pb_instance_property_keys
 
-        def value_parser(value: Any) -> str:
+        def value_parser(value: Any) -> str | int | float | list | None:
             if isinstance(value, (str, int, float, type(None))):
                 return value
 

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -567,6 +567,7 @@ def continue_awaiting_process(
     *,
     token: str,
     input_data: State,
+    broadcast_func: BroadcastFunc | None = None,
 ) -> UUID:
     """Continue a process awaiting data from a callback.
 
@@ -574,6 +575,7 @@ def continue_awaiting_process(
         process: Process from database
         token: The token which was generated for the process. This must match.
         input_data: Data posted to the callback
+        broadcast_func: Optional function to broadcast process data
 
     Returns:
         process id
@@ -601,7 +603,7 @@ def continue_awaiting_process(
 
     # Continue the workflow
     resume_func = get_execution_context()["resume"]
-    return resume_func(process)
+    return resume_func(process, broadcast_func=broadcast_func)
 
 
 async def _async_resume_processes(


### PR DESCRIPTION
* Add `broadcast_func` to `continue_awaiting_process_endpoint` so that when using ThreadPool executor, processes resumed through callback URL will broadcast events

Closes #744