### PR TITLE
Bump pydantic forms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "oauth2-lib~=2.2.0",
     "tabulate==0.9.0",
     "strawberry-graphql==0.232.2",
-    "pydantic-forms~=1.1.1rc1",
+    "pydantic-forms~=1.1.1",
 ]
 
 description-file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "oauth2-lib~=2.2.0",
     "tabulate==0.9.0",
     "strawberry-graphql==0.232.2",
-    "pydantic-forms~=1.1.0",
+    "pydantic-forms~=1.1.1rc1",
 ]
 
 description-file = "README.md"

--- a/test/unit_tests/forms/test_display_subscription.py
+++ b/test/unit_tests/forms/test_display_subscription.py
@@ -36,6 +36,7 @@ def test_display_only_schema():
         summary: Summary
 
     expected = {
+        "$defs": {"MigrationSummaryValue": {"properties": {}, "title": "MigrationSummaryValue", "type": "object"}},
         "additionalProperties": False,
         "properties": {
             "display_sub": {
@@ -52,6 +53,7 @@ def test_display_only_schema():
                 "type": "string",
             },
             "summary": {
+                "allOf": [{"$ref": "#/$defs/MigrationSummaryValue"}],
                 "format": "summary",
                 "default": None,
                 "type": "string",


### PR DESCRIPTION
Bump pydantic forms to make the stacktrace configurable. The stack trace will only be displayed in debug mode.