### PR TITLE
Revert pydantic-forms 1.1.1 to 1.1.0 summary not shown

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.1rc4
+current_version = 2.8.0rc5
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.0rc4
+current_version = 2.8.1rc4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.8.0rc4"
+__version__ = "2.8.1rc4"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.8.1rc4"
+__version__ = "2.8.0rc5"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
     "strawberry-graphql==0.232.2",
-    "pydantic-forms~=1.1.1",
+    "pydantic-forms==1.1.0",
 ]
 
 description-file = "README.md"

--- a/test/unit_tests/forms/test_display_subscription.py
+++ b/test/unit_tests/forms/test_display_subscription.py
@@ -36,7 +36,6 @@ def test_display_only_schema():
         summary: Summary
 
     expected = {
-        "$defs": {"MigrationSummaryValue": {"properties": {}, "title": "MigrationSummaryValue", "type": "object"}},
         "additionalProperties": False,
         "properties": {
             "display_sub": {
@@ -53,7 +52,6 @@ def test_display_only_schema():
                 "type": "string",
             },
             "summary": {
-                "allOf": [{"$ref": "#/$defs/MigrationSummaryValue"}],
                 "format": "summary",
                 "default": None,
                 "type": "string",


### PR DESCRIPTION
Reverting the pydantic forms to old version because there were some issues with the workflow summary not being shown correctly 