### PR TITLE
Upgrade strawberry graphql to 0.246.2 and above

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.0
+current_version = 2.9.0rc1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.8.0"
+__version__ = "2.9.0rc1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/graphql/autoregistration.py
+++ b/orchestrator/graphql/autoregistration.py
@@ -17,9 +17,9 @@ from typing import Any, get_args
 import strawberry
 import structlog
 from more_itertools import one
+from strawberry import UNSET
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
 from strawberry.federation.schema_directives import Key
-from strawberry.unset import UNSET
 
 from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.domain.base import DomainModel, get_depends_on_product_block_type_list
@@ -76,8 +76,8 @@ def create_block_strawberry_type(
     strawberry_name: str,
     model: type[DomainModel],
 ) -> type[StrawberryTypeFromPydantic[DomainModel]]:
+    from strawberry import UNSET
     from strawberry.federation.schema_directives import Key
-    from strawberry.unset import UNSET
 
     federation_key_directives = [Key(fields="subscriptionInstanceId", resolvable=UNSET)]
 

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -188,9 +188,6 @@ def create_graphql_router(
 
     if register_models:
         models = register_domain_models(subscription_interface, existing_models=models)
-        # TODO: remove log after debugging
-        model_values = list(models.values())
-        logger.info("registered models", are_models_unique=len(model_values) == len(set(model_values)), models=models)
 
     extensions = extensions or list(get_extensions(mutation, query))
 

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -188,6 +188,9 @@ def create_graphql_router(
 
     if register_models:
         models = register_domain_models(subscription_interface, existing_models=models)
+        # TODO: remove log after debugging
+        model_values = list(models.values())
+        logger.info("registered models", are_models_unique=len(model_values) == len(set(model_values)), models=models)
 
     extensions = extensions or list(get_extensions(mutation, query))
 

--- a/orchestrator/graphql/schemas/process.py
+++ b/orchestrator/graphql/schemas/process.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Annotated
 
 import strawberry
+from strawberry import UNSET
 from strawberry.federation.schema_directives import Key
 from strawberry.scalars import JSON
-from strawberry.unset import UNSET
 
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.db import ProcessTable, ProductTable, db

--- a/orchestrator/graphql/schemas/product.py
+++ b/orchestrator/graphql/schemas/product.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Annotated
 
 import strawberry
+from strawberry import UNSET
 from strawberry.federation.schema_directives import Key
-from strawberry.unset import UNSET
 
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.db import ProductTable

--- a/orchestrator/graphql/schemas/strawberry_pydantic_patch.py
+++ b/orchestrator/graphql/schemas/strawberry_pydantic_patch.py
@@ -2,7 +2,7 @@ from typing import Any, cast
 
 import strawberry
 from strawberry.experimental.pydantic.conversion import _convert_from_pydantic_to_strawberry_type
-from strawberry.field import StrawberryField
+from strawberry.types.field import StrawberryField
 
 # Vendored convert_pydantic_model_to_strawberry_class from
 # https://github.com/strawberry-graphql/strawberry/blob/d721eb33176cfe22be5e47f5bf2c21a4a022a6d6/strawberry/experimental/pydantic/conversion.py

--- a/orchestrator/graphql/schemas/strawberry_pydantic_patch.py
+++ b/orchestrator/graphql/schemas/strawberry_pydantic_patch.py
@@ -2,7 +2,7 @@ from typing import Any, cast
 
 import strawberry
 from strawberry.experimental.pydantic.conversion import _convert_from_pydantic_to_strawberry_type
-from strawberry.types.field import StrawberryField
+from strawberry.field import StrawberryField
 
 # Vendored convert_pydantic_model_to_strawberry_class from
 # https://github.com/strawberry-graphql/strawberry/blob/d721eb33176cfe22be5e47f5bf2c21a4a022a6d6/strawberry/experimental/pydantic/conversion.py

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -5,8 +5,8 @@ from uuid import UUID
 import strawberry
 from pydantic import BaseModel
 from sqlalchemy import select
+from strawberry import UNSET
 from strawberry.federation.schema_directives import Key
-from strawberry.unset import UNSET
 
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.db import FixedInputTable, ProductTable, SubscriptionTable, db

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -18,12 +18,12 @@ from typing import Any, NewType, TypeVar
 
 import strawberry
 from graphql import GraphQLError
+from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
 from strawberry.dataloader import DataLoader
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
 from strawberry.scalars import JSON
 from strawberry.types import Info
 from strawberry.types.info import RootValueType
-from strawberry.types.scalar import ScalarDefinition, ScalarWrapper
 
 from nwastdlib.vlans import VlanRanges
 from oauth2_lib.fastapi import AuthManager

--- a/orchestrator/graphql/types.py
+++ b/orchestrator/graphql/types.py
@@ -18,12 +18,12 @@ from typing import Any, NewType, TypeVar
 
 import strawberry
 from graphql import GraphQLError
-from strawberry.custom_scalar import ScalarDefinition, ScalarWrapper
 from strawberry.dataloader import DataLoader
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
 from strawberry.scalars import JSON
 from strawberry.types import Info
 from strawberry.types.info import RootValueType
+from strawberry.types.scalar import ScalarDefinition, ScalarWrapper
 
 from nwastdlib.vlans import VlanRanges
 from oauth2_lib.fastapi import AuthManager

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,4 +1,4 @@
-from strawberry.field import StrawberryField
+from strawberry.types.field import StrawberryField
 
 
 def override_class(strawberry_class: type, fields: list[StrawberryField]) -> type:

--- a/orchestrator/graphql/utils/override_class.py
+++ b/orchestrator/graphql/utils/override_class.py
@@ -1,4 +1,4 @@
-from strawberry.types.field import StrawberryField
+from strawberry.field import StrawberryField
 
 
 def override_class(strawberry_class: type, fields: list[StrawberryField]) -> type:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,10 @@ dependencies = [
     "structlog",
     "typer==0.12.5",
     "uvicorn[standard]~=0.32.0",
-    "nwa-stdlib~=1.7.3",
+    "nwa-stdlib~=1.8.0",
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
-    "strawberry-graphql~=0.236.0",
+    "strawberry-graphql>=0.246.2",
     "pydantic-forms==1.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,10 @@ dependencies = [
     "structlog",
     "typer==0.12.5",
     "uvicorn[standard]~=0.32.0",
-    "nwa-stdlib~=1.7.3",
+    "nwa-stdlib~=1.8.0",
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
-    "strawberry-graphql==0.233.0",
+    "strawberry-graphql>=0.246.2",
     "pydantic-forms==1.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,10 @@ dependencies = [
     "structlog",
     "typer==0.12.5",
     "uvicorn[standard]~=0.32.0",
-    "nwa-stdlib~=1.8.0",
+    "nwa-stdlib~=1.7.3",
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
-    "strawberry-graphql>=0.246.2",
+    "strawberry-graphql==0.233.0",
     "pydantic-forms==1.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "nwa-stdlib~=1.7.3",
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
-    "strawberry-graphql==0.232.2",
+    "strawberry-graphql~=0.236.0",
     "pydantic-forms==1.1.0",
 ]
 

--- a/test/unit_tests/graphql/conftest.py
+++ b/test/unit_tests/graphql/conftest.py
@@ -44,9 +44,6 @@ def fix_graphql_model_registration():
     # This block caches the "ProductBlockListNestedForTestInactive" model to avoid re-instantiation in each test case.
     # This is necessary because this product block has a self referencing property, which strawberry can't handle correctly,
     # and lead to an error expecting the `ProductBlockListNestedForTestInactive` strawberry type to already exist.
-    # This block caches the "ProductBlockListNestedForTestInactive" model to avoid re-instantiation in each test case.
-    # This is necessary because this product block has a self referencing property, which strawberry can't handle correctly,
-    # and lead to an error expecting the `ProductBlockListNestedForTestInactive` strawberry type to already exist.
     internal_graphql_models = {"ProductBlockListNestedForTestInactive": ProductBlockListNestedForTestInactiveGraphql}
 
     def patched_register_domain_models(*args, **kwargs):

--- a/test/unit_tests/graphql/test_product_blocks.py
+++ b/test/unit_tests/graphql/test_product_blocks.py
@@ -220,7 +220,7 @@ def test_product_block_query_with_relations(test_client, query_args):
 
 
 def test_product_blocks_has_previous_page(test_client):
-    data = get_product_blocks_query(after=1)
+    data = get_product_blocks_query(after=1, sort_by=[{"field": "name", "order": "ASC"}])
     response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code


### PR DESCRIPTION
upgrading to above `0.246.2` to be consistent with nwa-stdlib package. could also change it to above `0.236.0` to be consistent with the [strawberry breaking import change](https://github.com/strawberry-graphql/strawberry/releases/tag/0.236.0).

I found the upgrading problem in strawberry version `0.233.0`, where they refactor the federation schema to use strawberry typing instead of converting strawberry types to graphql types https://github.com/strawberry-graphql/strawberry/pull/3525

### bumpversion to 2.9.0rc1 and strawberry breaking imports should be included in the release message.

## Upgrade problem description

The problem was that the `autoregistration` unnecessarily created a type based on the output of the `pydantic_wrapper` function, which already generates the required Strawberry type.

This led to the same Strawberry type being created twice at runtime, but from different locations:
 1. Directly in the `pydantic_wrapper`, resulting in `strawberry.experimental.pydantic.object_type.YourStrawberryType`.
 2. Indirectly in `autoregistration`, which created a type using the result of `pydantic_wrapper`, resulting in `orchestrator.graphql.autoregistration.YourStrawberryType` 
  - with the function `create_block_strawberry_type` or `create_subscription_strawberry_type`.

Previously Strawberry handled this duplication because it already needed to convert Strawberry types to GraphQL types, so we never noticed that we created the type twice.

Strawberry refactored `strawberry.federation.schema` to use Strawberry types directly (removing GraphQL type conversion) in version `0.233.0`.
This implementation does not unintentionally fix our duplicate types and resulted in the runtime error: `Union type _Entity can only include type YourStrawberryType once`.

Removing the type create in `autoregistration` fixed this problem.