### PR TITLE
Add app_setting VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS + Bump nwa-stdlib 1.8.3 for ErrorType.BAD_REQUEST

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.0rc1
+current_version = 2.9.0rc2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.9.0rc1"
+__version__ = "2.9.0rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/graphql/utils/create_resolver_error_handler.py
+++ b/orchestrator/graphql/utils/create_resolver_error_handler.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from nwastdlib.graphql.extensions.error_handler_extension import register_error
+from nwastdlib.graphql.extensions.error_handler_extension import ErrorType, register_error
 from orchestrator.db.filters import CallableErrorHandler
 from orchestrator.graphql.types import OrchestratorInfo
 
@@ -25,6 +25,6 @@ def _format_context(context: dict) -> str:
 
 def create_resolver_error_handler(info: OrchestratorInfo) -> CallableErrorHandler:
     def handle_error(message: str, **context) -> None:  # type: ignore
-        return register_error(" ".join([message, _format_context(context)]), info)
+        return register_error(" ".join([message, _format_context(context)]), info, error_type=ErrorType.BAD_REQUEST)
 
     return handle_error

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -81,6 +81,7 @@ class AppSettings(BaseSettings):
     ENABLE_GRAPHQL_DEPRECATION_CHECKER: bool = True
     ENABLE_GRAPHQL_PROFILING_EXTENSION: bool = False
     ENABLE_GRAPHQL_STATS_EXTENSION: bool = False
+    VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS: bool = False
 
 
 app_settings = AppSettings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "structlog",
     "typer==0.12.5",
     "uvicorn[standard]~=0.32.0",
-    "nwa-stdlib~=1.8.0",
+    "nwa-stdlib~=1.8.3",
     "oauth2-lib~=2.3.0",
     "tabulate==0.9.0",
     "strawberry-graphql>=0.246.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "pytz==2024.1",
     "redis==5.0.3",
     "schedule==1.1.0",
-    "sentry-sdk[fastapi]==2.17.0",
+    "sentry-sdk[fastapi]~=2.18.0",
     "SQLAlchemy==2.0.31",
     "SQLAlchemy-Utils==0.41.2",
     "structlog",

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -414,7 +414,7 @@ def test_processes_filtering_with_invalid_filter(
                 "'workflowName'])"
             ),
             "path": ["processes"],
-            "extensions": {"error_type": "internal_error"},
+            "extensions": {"error_type": "bad_request"},
         }
     ]
     assert pageinfo == {

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -649,7 +649,7 @@ def test_subscriptions_sorting_invalid_field(test_client, product_type_1_subscri
                 "'subscriptionId', 'tag'])"
             ),
             "path": ["subscriptions"],
-            "extensions": {"error_type": "internal_error"},
+            "extensions": {"error_type": "bad_request"},
         }
     ]
 
@@ -668,7 +668,7 @@ def test_subscriptions_sorting_invalid_order(test_client, product_type_1_subscri
 
     assert not result["data"]
     assert "errors" in result
-    assert "Value 'test' does not exist in 'SortOrder'" in result["errors"][0]["message"]
+    assert "Internal Server Error" in result["errors"][0]["message"]
 
 
 @pytest.mark.parametrize(
@@ -807,7 +807,7 @@ def test_subscriptions_filtering_with_invalid_filter(
                 "'note', 'product', 'productId', 'startDate', 'status', 'subscriptionId', 'tag'])"
             ),
             "path": ["subscriptions"],
-            "extensions": {"error_type": "internal_error"},
+            "extensions": {"error_type": "bad_request"},
         }
     ]
     assert pageinfo == {


### PR DESCRIPTION
* Add option `VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS` to make the `validate_subscriptions` schedule also validate out-of-sync subscriptions. **This is not recommended for production, the intended purpose is for development**
* Bump `sentry-sdk` to fix import error
* Bump `nwa-stdlib` to 1.8.3 so GraphQL errors can be registered as `ErrorType.BAD_REQUEST` (such as bad input to sortBy/filterBy)
 
Bump version to 2.9.0rc2