### PR TITLE
Add optional version control for subscriptions and subscription customer descriptions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.1
+current_version = 2.9.2rc1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.9.1"
+__version__ = "2.9.2rc1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -25,7 +25,7 @@ from fastapi.param_functions import Body, Depends, Header
 from fastapi.routing import APIRouter
 from fastapi.websockets import WebSocket
 from fastapi_etag.dependency import CacheHit
-from more_itertools import chunked
+from more_itertools import chunked, first
 from sentry_sdk.tracing import trace
 from sqlalchemy import CompoundSelect, Select, select
 from sqlalchemy.orm import defer, joinedload
@@ -40,6 +40,7 @@ from orchestrator.db.filters import Filter
 from orchestrator.db.filters.process import filter_processes
 from orchestrator.db.sorting import Sort, SortOrder
 from orchestrator.db.sorting.process import sort_processes
+from orchestrator.domain.base import update_subscription_version
 from orchestrator.schemas import (
     ProcessIdSchema,
     ProcessResumeAllSchema,
@@ -63,6 +64,7 @@ from orchestrator.services.settings import get_engine_settings
 from orchestrator.settings import app_settings
 from orchestrator.types import JSON, State
 from orchestrator.utils.enrich_process import enrich_process
+from orchestrator.utils.get_subscription_dict import get_subscription_dict
 from orchestrator.websocket import (
     WS_CHANNELS,
     broadcast_invalidate_status_counts,
@@ -127,19 +129,33 @@ def delete(process_id: UUID) -> None:
     broadcast_process_update_to_websocket(process.process_id)
 
 
+async def validate_subscription_version(workflow_data: dict[str, Any]) -> None:
+    subscription_id = workflow_data.get("subscription_id")
+    new_version = workflow_data.get("version")
+
+    if new_version is not None and subscription_id:
+        subscription, _ = await get_subscription_dict(subscription_id)
+        current_version = subscription.get("version")
+        if current_version > new_version:
+            raise_status(HTTPStatus.BAD_REQUEST, f"Stale data ({current_version} < {new_version})")
+        update_subscription_version(subscription_id, new_version)
+
+
 @router.post(
     "/{workflow_key}",
     response_model=ProcessIdSchema,
     status_code=HTTPStatus.CREATED,
     dependencies=[Depends(check_global_lock, use_cache=False)],
 )
-def new_process(
+async def new_process(
     workflow_key: str,
     request: Request,
     json_data: list[dict[str, Any]] | None = Body(...),
     user: str = Depends(user_name),
 ) -> dict[str, UUID]:
     broadcast_func = api_broadcast_process_data(request)
+    if json_data and (first_wf_data := first(json_data, None)):
+        await validate_subscription_version(first_wf_data)
     process_id = start_process(workflow_key, user_inputs=json_data, user=user, broadcast_func=broadcast_func)
 
     return {"id": process_id}

--- a/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
@@ -26,6 +26,8 @@ from orchestrator.domain.customer_description import (
     update_subscription_customer_description,
 )
 from orchestrator.schemas import SubscriptionDescriptionBaseSchema, SubscriptionDescriptionSchema
+from orchestrator.schemas.subscription_descriptions import UpdateSubscriptionDescriptionSchema
+from orchestrator.utils.errors import StaleDataError
 from orchestrator.utils.redis import delete_from_redis
 
 router = APIRouter()
@@ -37,12 +39,14 @@ async def save_subscription_customer_description_endpoint(data: SubscriptionDesc
 
 
 @router.put("/", response_model=None, status_code=HTTPStatus.NO_CONTENT)
-async def update_subscription_customer_description_endpoint(data: SubscriptionDescriptionSchema = Body(...)) -> None:
+async def update_subscription_customer_description_endpoint(
+    data: UpdateSubscriptionDescriptionSchema = Body(...),
+) -> None:
     description = get_customer_description_by_customer_subscription(data.customer_id, data.subscription_id)
     if description:
         try:
             await update_subscription_customer_description(description, data.description, data.created_at, data.version)
-        except ValueError as error:
+        except StaleDataError as error:
             raise_status(HTTPStatus.BAD_REQUEST, str(error))
 
 

--- a/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscription_customer_descriptions.py
@@ -40,7 +40,10 @@ async def save_subscription_customer_description_endpoint(data: SubscriptionDesc
 async def update_subscription_customer_description_endpoint(data: SubscriptionDescriptionSchema = Body(...)) -> None:
     description = get_customer_description_by_customer_subscription(data.customer_id, data.subscription_id)
     if description:
-        await update_subscription_customer_description(description, data.description, data.created_at)
+        try:
+            await update_subscription_customer_description(description, data.description, data.created_at, data.version)
+        except ValueError as error:
+            raise_status(HTTPStatus.BAD_REQUEST, str(error))
 
 
 @router.delete("/{_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)

--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -626,7 +626,6 @@ class SubscriptionMetadataTable(BaseModel):
         index=True,
     )
     metadata_ = mapped_column("metadata", pg.JSONB(), nullable=False)  # type: ignore
-    version = mapped_column(Integer, nullable=False, server_default="1")
 
     @staticmethod
     def find_by_subscription_id(subscription_id: str) -> SubscriptionMetadataTable | None:

--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -554,6 +554,7 @@ class SubscriptionCustomerDescriptionTable(BaseModel):
     customer_id = mapped_column(String, nullable=False, index=True)
     description = mapped_column(Text(), nullable=False)
     created_at = mapped_column(UtcTimestamp, nullable=False, server_default=text("current_timestamp()"))
+    version = mapped_column(Integer, nullable=False, server_default="1")
 
     subscription = relationship("SubscriptionTable", back_populates="customer_descriptions")
 
@@ -572,6 +573,7 @@ class SubscriptionTable(BaseModel):
     start_date = mapped_column(UtcTimestamp, nullable=True)
     end_date = mapped_column(UtcTimestamp)
     note = mapped_column(Text())
+    version = mapped_column(Integer, nullable=False, server_default="1")
 
     product = relationship("ProductTable", foreign_keys=[product_id])
     instances = relationship(
@@ -624,6 +626,7 @@ class SubscriptionMetadataTable(BaseModel):
         index=True,
     )
     metadata_ = mapped_column("metadata", pg.JSONB(), nullable=False)  # type: ignore
+    version = mapped_column(Integer, nullable=False, server_default="1")
 
     @staticmethod
     def find_by_subscription_id(subscription_id: str) -> SubscriptionMetadataTable | None:

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -33,7 +33,7 @@ import structlog
 from more_itertools import bucket, first, flatten, one, only
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.fields import PrivateAttr
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import selectinload
 
 from orchestrator.db import (
@@ -1017,6 +1017,7 @@ class SubscriptionModel(DomainModel):
     start_date: datetime | None = None  # pragma: no mutate
     end_date: datetime | None = None  # pragma: no mutate
     note: str | None = None  # pragma: no mutate
+    version: int = 1  # pragma: no mutate
 
     def __new__(cls, *args: Any, status: SubscriptionLifecycle | None = None, **kwargs: Any) -> "SubscriptionModel":
         # status can be none if created during change_lifecycle
@@ -1108,6 +1109,7 @@ class SubscriptionModel(DomainModel):
         start_date: datetime | None = None,
         end_date: datetime | None = None,
         note: str | None = None,
+        version: int = 1,
     ) -> S:
         """Use product_id (and customer_id) to return required fields of a new empty subscription."""
         # Caller wants a new instance and provided a product_id and customer_id
@@ -1140,6 +1142,7 @@ class SubscriptionModel(DomainModel):
             start_date=start_date,
             end_date=end_date,
             note=note,
+            version=version,
         )
         db.session.add(subscription)
 
@@ -1156,6 +1159,7 @@ class SubscriptionModel(DomainModel):
             start_date=start_date,
             end_date=end_date,
             note=note,
+            version=version,
             **fixed_inputs,
             **instances,
         )
@@ -1270,6 +1274,7 @@ class SubscriptionModel(DomainModel):
                 start_date=subscription.start_date,
                 end_date=subscription.end_date,
                 note=subscription.note,
+                version=subscription.version,
                 **fixed_inputs,
                 **instances,
             )
@@ -1320,6 +1325,7 @@ class SubscriptionModel(DomainModel):
                 start_date=subscription.start_date,
                 end_date=subscription.end_date,
                 note=subscription.note,
+                version=subscription.version,
                 **fixed_inputs,
                 **instances,
             )
@@ -1457,3 +1463,13 @@ def validate_lifecycle_change(
         subscription_description=other.description,
         status=status,
     )
+
+
+def update_subscription_version(subscription_id: UUID, new_version: int) -> None:
+    stmt = (
+        update(SubscriptionTable)
+        .where(SubscriptionTable.subscription_id == str(subscription_id))
+        .values(version=new_version)
+    )
+    db.session.execute(stmt)
+    db.session.commit()

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -33,7 +33,7 @@ import structlog
 from more_itertools import bucket, first, flatten, one, only
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.fields import PrivateAttr
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from orchestrator.db import (
@@ -1463,13 +1463,3 @@ def validate_lifecycle_change(
         subscription_description=other.description,
         status=status,
     )
-
-
-def update_subscription_version(subscription_id: UUID, new_version: int) -> None:
-    stmt = (
-        update(SubscriptionTable)
-        .where(SubscriptionTable.subscription_id == str(subscription_id))
-        .values(version=new_version)
-    )
-    db.session.execute(stmt)
-    db.session.commit()

--- a/orchestrator/domain/customer_description.py
+++ b/orchestrator/domain/customer_description.py
@@ -60,7 +60,9 @@ async def update_subscription_customer_description(
 ) -> SubscriptionCustomerDescriptionTable:
     if version is not None:
         if version < customer_description.version:
-            raise ValueError(f"Stale data ({version} < {customer_description.version})")
+            raise ValueError(
+                f"Stale data: given version ({version}) is lower than the current version ({customer_description.version})"
+            )
         customer_description.version = version
 
     customer_description.description = description

--- a/orchestrator/domain/customer_description.py
+++ b/orchestrator/domain/customer_description.py
@@ -20,7 +20,9 @@ from sqlalchemy import select
 
 from orchestrator.api.models import delete
 from orchestrator.db import SubscriptionCustomerDescriptionTable, db
+from orchestrator.utils.errors import StaleDataError
 from orchestrator.utils.redis import delete_subscription_from_redis
+from orchestrator.utils.validate_data_version import validate_data_version
 from orchestrator.websocket import invalidate_subscription_cache
 
 router = APIRouter()
@@ -58,12 +60,8 @@ async def update_subscription_customer_description(
     created_at: datetime | None = None,
     version: int | None = None,
 ) -> SubscriptionCustomerDescriptionTable:
-    if version is not None:
-        if version < customer_description.version:
-            raise ValueError(
-                f"Stale data: given version ({version}) is lower than the current version ({customer_description.version})"
-            )
-        customer_description.version = version
+    if not validate_data_version(customer_description.version, version):
+        raise StaleDataError(customer_description.version, version)
 
     customer_description.description = description
     customer_description.created_at = created_at if created_at else datetime.now(tz=timezone("UTC"))

--- a/orchestrator/domain/customer_description.py
+++ b/orchestrator/domain/customer_description.py
@@ -53,8 +53,16 @@ async def create_subscription_customer_description(
 
 @delete_subscription_from_redis()
 async def update_subscription_customer_description(
-    customer_description: SubscriptionCustomerDescriptionTable, description: str, created_at: datetime | None = None
+    customer_description: SubscriptionCustomerDescriptionTable,
+    description: str,
+    created_at: datetime | None = None,
+    version: int | None = None,
 ) -> SubscriptionCustomerDescriptionTable:
+    if version is not None:
+        if version < customer_description.version:
+            raise ValueError(f"Stale data ({version} < {customer_description.version})")
+        customer_description.version = version
+
     customer_description.description = description
     customer_description.created_at = created_at if created_at else datetime.now(tz=timezone("UTC"))
     db.session.commit()

--- a/orchestrator/graphql/mutations/customer_description.py
+++ b/orchestrator/graphql/mutations/customer_description.py
@@ -25,6 +25,7 @@ from orchestrator.domain.customer_description import (
 )
 from orchestrator.graphql.schemas.customer_description import CustomerDescription
 from orchestrator.graphql.types import MutationError, NotFoundError
+from orchestrator.utils.errors import StaleDataError
 
 logger = structlog.get_logger(__name__)
 
@@ -44,7 +45,7 @@ async def resolve_upsert_customer_description(
 ) -> CustomerDescription | NotFoundError | MutationError:
     try:
         customer_description = await upsert_customer_description(customer_id, subscription_id, description, version)
-    except ValueError as error:
+    except StaleDataError as error:
         return MutationError(message=str(error))
     except Exception:
         return NotFoundError(message="Subscription not found")

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -77,6 +77,7 @@ class SubscriptionInterface:
     status: SubscriptionLifecycle
     insync: bool
     note: str | None
+    version: int
 
     @strawberry.field(description="Product information")  # type: ignore
     async def product(self) -> ProductModelGraphql:

--- a/orchestrator/migrations/versions/schema/2025-01-08_4c5859620539_add_version_column_to_subscription.py
+++ b/orchestrator/migrations/versions/schema/2025-01-08_4c5859620539_add_version_column_to_subscription.py
@@ -1,0 +1,64 @@
+"""Add version column to subscription and subscription customer descriptions.
+
+Revision ID: 4c5859620539
+Revises: 460ec6748e37
+Create Date: 2025-01-08 15:07:41.957937
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4c5859620539"
+down_revision = "460ec6748e37"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    op.add_column(
+        "subscription_customer_descriptions", sa.Column("version", sa.Integer(), server_default="1", nullable=False)
+    )
+    op.add_column("subscriptions", sa.Column("version", sa.Integer(), server_default="1", nullable=False))
+
+    conn.execute(
+        sa.text(
+            """
+CREATE OR REPLACE FUNCTION increment_version()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.version := COALESCE(NEW.version, OLD.version) + 1;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER subscriptions_increment_version_trigger
+BEFORE UPDATE ON subscriptions
+FOR EACH ROW
+EXECUTE FUNCTION increment_version();
+
+CREATE TRIGGER subscription_customer_descriptions_increment_version_trigger
+BEFORE UPDATE ON subscription_customer_descriptions
+FOR EACH ROW
+EXECUTE FUNCTION increment_version();
+    """
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    op.drop_column("subscriptions", "version")
+    op.drop_column("subscription_customer_descriptions", "version")
+
+    conn.execute(
+        sa.text(
+            """
+DROP TRIGGER IF EXISTS subscriptions_increment_version_trigger on subscriptions;
+DROP TRIGGER IF EXISTS subscription_customer_descriptions_increment_version_trigger on subscription_customer_descriptions;
+DROP FUNCTION IF EXISTS increment_version;
+"""
+        )
+    )

--- a/orchestrator/migrations/versions/schema/2025-01-08_4c5859620539_add_version_column_to_subscription.py
+++ b/orchestrator/migrations/versions/schema/2025-01-08_4c5859620539_add_version_column_to_subscription.py
@@ -29,7 +29,7 @@ def upgrade() -> None:
 CREATE OR REPLACE FUNCTION increment_version()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.version := COALESCE(NEW.version, OLD.version) + 1;
+    NEW.version := OLD.version + 1;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/orchestrator/schemas/subscription.py
+++ b/orchestrator/schemas/subscription.py
@@ -84,6 +84,7 @@ class SubscriptionSchema(SubscriptionBaseSchema):
     product: ProductBaseSchema | None = None
     customer_descriptions: list[SubscriptionDescriptionSchema] | None = None
     tag: str | None = None
+    version: int = 1
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/orchestrator/schemas/subscription.py
+++ b/orchestrator/schemas/subscription.py
@@ -84,7 +84,7 @@ class SubscriptionSchema(SubscriptionBaseSchema):
     product: ProductBaseSchema | None = None
     customer_descriptions: list[SubscriptionDescriptionSchema] | None = None
     tag: str | None = None
-    version: int = 1
+    version: int
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/orchestrator/schemas/subscription_descriptions.py
+++ b/orchestrator/schemas/subscription_descriptions.py
@@ -28,5 +28,12 @@ class SubscriptionDescriptionBaseSchema(OrchestratorBaseModel):
 class SubscriptionDescriptionSchema(SubscriptionDescriptionBaseSchema):
     id: UUID
     created_at: datetime | None = None
-    version: int = 1
+    version: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UpdateSubscriptionDescriptionSchema(SubscriptionDescriptionBaseSchema):
+    id: UUID
+    created_at: datetime | None = None
+    version: int | None = None
     model_config = ConfigDict(from_attributes=True)

--- a/orchestrator/schemas/subscription_descriptions.py
+++ b/orchestrator/schemas/subscription_descriptions.py
@@ -28,4 +28,5 @@ class SubscriptionDescriptionBaseSchema(OrchestratorBaseModel):
 class SubscriptionDescriptionSchema(SubscriptionDescriptionBaseSchema):
     id: UUID
     created_at: datetime | None = None
+    version: int = 1
     model_config = ConfigDict(from_attributes=True)

--- a/orchestrator/utils/enrich_process.py
+++ b/orchestrator/utils/enrich_process.py
@@ -33,6 +33,7 @@ def format_subscription(subscription: SubscriptionTable) -> dict:
         "note": subscription.note,
         "start_date": subscription.start_date if subscription.start_date else None,
         "end_date": subscription.end_date if subscription.end_date else None,
+        "version": subscription.version,
         "product": {
             "product_id": prod.product_id,
             "description": prod.description,

--- a/orchestrator/utils/errors.py
+++ b/orchestrator/utils/errors.py
@@ -74,6 +74,14 @@ class InconsistentDataError(ProcessFailureError):
     pass
 
 
+class StaleDataError(ValueError):
+    """The version of the update payload is older than the version in the database."""
+
+    def __init__(self, current_version: int, new_version: int | None = None) -> None:
+        message = f"Stale data: given version ({new_version}) does not match the current version ({current_version})"
+        super().__init__(message)
+
+
 def is_api_exception(ex: Exception) -> bool:
     """Test for swagger-codegen ApiException.
 

--- a/orchestrator/utils/errors.py
+++ b/orchestrator/utils/errors.py
@@ -75,7 +75,7 @@ class InconsistentDataError(ProcessFailureError):
 
 
 class StaleDataError(ValueError):
-    """The version of the update payload is older than the version in the database."""
+    """The version of the update payload does not match the version in the database."""
 
     def __init__(self, current_version: int, new_version: int | None = None) -> None:
         message = f"Stale data: given version ({new_version}) does not match the current version ({current_version})"

--- a/orchestrator/utils/validate_data_version.py
+++ b/orchestrator/utils/validate_data_version.py
@@ -1,0 +1,2 @@
+def validate_data_version(current_version: int, new_version: int | None = None) -> bool:
+    return (new_version is not None and new_version == current_version) or new_version is None

--- a/orchestrator/workflows/translations/en-GB.json
+++ b/orchestrator/workflows/translations/en-GB.json
@@ -4,6 +4,7 @@
             "note": "Notes",
             "note_info": "Notes, reminders and feedback about this description.",
             "subscription_id": "Subscription",
+            "version": "Version",
             "subscription_id_info": "The subscription for this action"
         }
     },

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -162,6 +162,7 @@ def wrap_modify_initial_input_form(initial_input_form: InputStepFunc | None) -> 
             "subscription_id": str(subscription.subscription_id),
             "product": str(subscription.product_id),
             "customer_id": subscription.customer_id,
+            "version": subscription.version,
         }
 
         if initial_input_form is None:

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -147,7 +147,9 @@ def _generate_modify_form(workflow_target: str, workflow_name: str) -> InputForm
                 subscription = db.session.get(SubscriptionTable, self.subscription_id)
                 current_version = subscription.version  # type: ignore
                 if current_version > self.version:
-                    raise ValueError(f"Stale data ({current_version} < {self.version})")
+                    raise ValueError(
+                        f"Stale data: given version ({self.version}) is lower than the current version ({current_version})"
+                    )
             return self
 
     return ModifySubscriptionPage

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -563,4 +563,6 @@ def test_new_process_version_check_invalid(test_client, generic_subscription_1):
     )
     assert HTTPStatus.BAD_REQUEST == response.status_code
     payload = response.json()
-    assert payload["validation_errors"][0]["msg"] == "Stale data (2 < 0)"
+    assert (
+        payload["validation_errors"][0]["msg"] == "Stale data: given version (0) is lower than the current version (2)"
+    )

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -531,3 +531,21 @@ def test_create_process_reporter(test_client, fastapi_app, oidc_user, reporter, 
     assert response.status_code == 201, response.text
     mock_start_process.assert_called()
     assert mock_start_process.mock_calls[0].kwargs["user"] == expected_user
+
+
+def test_new_process_version_check(test_client, generic_subscription_1):
+    with (mock.patch("orchestrator.api.api_v1.endpoints.processes.start_process") as mock_start_process,):
+        mock_start_process.return_value = uuid.uuid4()
+        response = test_client.post(
+            "/api/processes/terminate_sn8_light_path", json=[{"subscription_id": generic_subscription_1, "version": 1}]
+        )
+        assert HTTPStatus.CREATED == response.status_code
+
+
+def test_new_process_version_check_invalid(test_client, generic_subscription_1):
+    with (mock.patch("orchestrator.api.api_v1.endpoints.processes.start_process") as mock_start_process,):
+        mock_start_process.return_value = uuid.uuid4()
+        response = test_client.post(
+            "/api/processes/terminate_sn8_light_path", json=[{"subscription_id": generic_subscription_1, "version": 0}]
+        )
+        assert HTTPStatus.BAD_REQUEST == response.status_code

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -534,12 +534,16 @@ def test_create_process_reporter(test_client, fastapi_app, oidc_user, reporter, 
 
 
 def test_new_process_version_check(test_client, generic_subscription_1):
+    version = 5
     with (mock.patch("orchestrator.api.api_v1.endpoints.processes.start_process") as mock_start_process,):
         mock_start_process.return_value = uuid.uuid4()
         response = test_client.post(
-            "/api/processes/terminate_sn8_light_path", json=[{"subscription_id": generic_subscription_1, "version": 1}]
+            "/api/processes/terminate_sn8_light_path",
+            json=[{"subscription_id": generic_subscription_1, "version": version}],
         )
         assert HTTPStatus.CREATED == response.status_code
+        new_version = db.session.get(SubscriptionTable, generic_subscription_1).version
+        assert new_version == version + 1
 
 
 def test_new_process_version_check_invalid(test_client, generic_subscription_1):

--- a/test/unit_tests/api/test_subscription_customer_descriptions.py
+++ b/test/unit_tests/api/test_subscription_customer_descriptions.py
@@ -82,6 +82,7 @@ def test_update(seed, test_client):
 
     customer_description = db.session.query(SubscriptionCustomerDescriptionTable).first()
     assert new_desc == customer_description.description
+    assert 2 == customer_description.version
 
 
 def test_update_with_version(seed, test_client):

--- a/test/unit_tests/api/test_subscription_customer_descriptions.py
+++ b/test/unit_tests/api/test_subscription_customer_descriptions.py
@@ -118,7 +118,7 @@ def test_update_with_incorrect_version(seed, test_client):
     assert HTTPStatus.BAD_REQUEST == response.status_code
 
     data = response.json()
-    assert "Stale data (0 < 1)" == data["detail"]
+    assert "Stale data: given version (0) is lower than the current version (1)" == data["detail"]
 
 
 def test_delete(seed, test_client):

--- a/test/unit_tests/api/test_subscription_customer_descriptions.py
+++ b/test/unit_tests/api/test_subscription_customer_descriptions.py
@@ -105,7 +105,7 @@ def test_update_with_version(seed, test_client):
     assert version + 1 == customer_description.version
 
 
-def test_update_with_incorrect_version(seed, test_client):
+def test_update_with_lower_version_invalid(seed, test_client):
     new_desc = "Updated specific alias"
     body = {
         "id": SUBSCRIPTION_CUSTOMER_DESCRIPTION_ID,
@@ -118,7 +118,23 @@ def test_update_with_incorrect_version(seed, test_client):
     assert HTTPStatus.BAD_REQUEST == response.status_code
 
     data = response.json()
-    assert "Stale data: given version (0) is lower than the current version (1)" == data["detail"]
+    assert "Stale data: given version (0) does not match the current version (1)" == data["detail"]
+
+
+def test_update_with_higher_version_invalid(seed, test_client):
+    new_desc = "Updated specific alias"
+    body = {
+        "id": SUBSCRIPTION_CUSTOMER_DESCRIPTION_ID,
+        "subscription_id": SUBSCRIPTION_ID,
+        "customer_id": CUSTOMER_ID,
+        "description": new_desc,
+        "version": 10,
+    }
+    response = test_client.put("/api/subscription_customer_descriptions/", json=body)
+    assert HTTPStatus.BAD_REQUEST == response.status_code
+
+    data = response.json()
+    assert "Stale data: given version (10) does not match the current version (1)" == data["detail"]
 
 
 def test_delete(seed, test_client):

--- a/test/unit_tests/api/test_subscriptions.py
+++ b/test/unit_tests/api/test_subscriptions.py
@@ -817,6 +817,7 @@ def test_subscription_detail_special_fields(mock_from_redis, test_client):
         "status": "active",
         "customer_id": "f711c6fe-6de3-40bd-a4e7-9ac9d183a788",
         "insync": True,
+        "version": 1,
         "product": {
             "name": "fake name",
             "description": "fake description",
@@ -854,6 +855,7 @@ def test_subscription_detail_special_fields(mock_from_redis, test_client):
         },
         "customer_descriptions": [],
         "tag": None,
+        "version": 1,
         "ip_address": "127.0.0.1",
     }
 

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -660,6 +660,7 @@ def test_save_load(test_product_model, test_product_type_one, test_product_block
         "status": SubscriptionLifecycle.INITIAL,
         "subscription_id": IsUUID(),
         "test_fixed_input": False,
+        "version": 1,
     }
 
     # Set first value

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -680,7 +680,7 @@ def test_save_load(test_product_model, test_product_type_one, test_product_block
     db.session.commit()
 
     new_model = ProductTypeOneForTest.from_subscription(model.subscription_id)
-    assert model.model_dump() == new_model.model_dump()
+    assert model.model_dump() | {"version": model.version + 1} == new_model.model_dump()
 
     # Second save also works as expected
     new_model.save()

--- a/test/unit_tests/graphql/mutations/test_customer_description.py
+++ b/test/unit_tests/graphql/mutations/test_customer_description.py
@@ -231,7 +231,7 @@ def test_customer_description_update_with_incorrect_version(
     assert response.json() == {
         "data": {
             "upsertCustomerDescription": {
-                "message": "Stale data (0 < 1)",
+                "message": "Stale data: given version (0) is lower than the current version (1)",
             },
         },
     }

--- a/test/unit_tests/graphql/mutations/test_customer_description.py
+++ b/test/unit_tests/graphql/mutations/test_customer_description.py
@@ -9,17 +9,22 @@ def get_customer_description_upsert_mutation(
     customer_id: str,
     subscription_id: str,
     description: str,
+    version=None,
 ) -> bytes:
     query = """
-mutation CustomerDescriptionUpsertMutation ($customerId: String!, $subscriptionId: UUID!, $description: String!) {
-    upsertCustomerDescription(customerId: $customerId, subscriptionId: $subscriptionId, description: $description) {
+mutation CustomerDescriptionUpsertMutation ($customerId: String!, $subscriptionId: UUID!, $description: String!, $version: Int) {
+    upsertCustomerDescription(customerId: $customerId, subscriptionId: $subscriptionId, description: $description, version: $version) {
         ... on CustomerDescription {
             customerId
             subscriptionId
             description
+            version
         }
 
         ... on NotFoundError {
+            message
+        }
+        ... on MutationError {
             message
         }
     }
@@ -33,6 +38,7 @@ mutation CustomerDescriptionUpsertMutation ($customerId: String!, $subscriptionI
                 "customerId": customer_id,
                 "subscriptionId": subscription_id,
                 "description": description,
+                "version": version,
             },
         }
     ).encode("utf-8")
@@ -49,6 +55,7 @@ mutation CustomerDescriptionRemoveMutation ($customerId: String!, $subscriptionI
             customerId
             subscriptionId
             description
+            version
         }
 
         ... on NotFoundError {
@@ -91,6 +98,7 @@ def test_customer_description_create(httpx_mock, test_client, product_sub_list_u
                 "customerId": "0c43b714-0a11-e511-80d0-005056956c1a",
                 "subscriptionId": subscription_id,
                 "description": "create description",
+                "version": 1,
             }
         }
     }
@@ -150,8 +158,82 @@ def test_customer_description_update(httpx_mock, test_client, product_sub_list_u
                 "customerId": "0c43b714-0a11-e511-80d0-005056956c1a",
                 "subscriptionId": subscription_id,
                 "description": "update description",
+                "version": 2,
             }
         }
+    }
+
+
+def test_customer_description_update_with_version(httpx_mock, test_client, product_sub_list_union_subscription_1):
+    # given
+
+    subscription_id = str(product_sub_list_union_subscription_1)
+    customer_id = "0c43b714-0a11-e511-80d0-005056956c1a"
+    description = "update description"
+    version = 5
+
+    customer_description = SubscriptionCustomerDescriptionTable(
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        description="create description",
+        version=1,
+    )
+    db.session.add(customer_description)
+    db.session.commit()
+
+    # when
+    query = get_customer_description_upsert_mutation(customer_id, subscription_id, description, version)
+
+    with mutation_authorization():
+        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+
+    # then
+
+    assert response.json() == {
+        "data": {
+            "upsertCustomerDescription": {
+                "customerId": "0c43b714-0a11-e511-80d0-005056956c1a",
+                "subscriptionId": subscription_id,
+                "description": "update description",
+                "version": 6,
+            }
+        }
+    }
+
+
+def test_customer_description_update_with_incorrect_version(
+    httpx_mock, test_client, product_sub_list_union_subscription_1
+):
+    # given
+
+    subscription_id = str(product_sub_list_union_subscription_1)
+    customer_id = "0c43b714-0a11-e511-80d0-005056956c1a"
+    description = "update description"
+    version = 0
+
+    customer_description = SubscriptionCustomerDescriptionTable(
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        description="create description",
+        version=1,
+    )
+    db.session.add(customer_description)
+    db.session.commit()
+
+    # when
+    query = get_customer_description_upsert_mutation(customer_id, subscription_id, description, version)
+
+    with mutation_authorization():
+        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+
+    # then
+
+    assert response.json() == {
+        "data": {
+            "upsertCustomerDescription": {
+                "message": "Stale data (0 < 1)",
+            },
+        },
     }
 
 
@@ -184,6 +266,7 @@ def test_customer_description_delete(httpx_mock, test_client, product_sub_list_u
                 "customerId": "0c43b714-0a11-e511-80d0-005056956c1a",
                 "subscriptionId": subscription_id,
                 "description": "create description",
+                "version": 1,
             }
         }
     }

--- a/test/unit_tests/graphql/mutations/test_customer_description.py
+++ b/test/unit_tests/graphql/mutations/test_customer_description.py
@@ -170,13 +170,13 @@ def test_customer_description_update_with_version(httpx_mock, test_client, produ
     subscription_id = str(product_sub_list_union_subscription_1)
     customer_id = "0c43b714-0a11-e511-80d0-005056956c1a"
     description = "update description"
-    version = 5
+    version = 1
 
     customer_description = SubscriptionCustomerDescriptionTable(
         customer_id=customer_id,
         subscription_id=subscription_id,
         description="create description",
-        version=1,
+        version=version,
     )
     db.session.add(customer_description)
     db.session.commit()
@@ -195,7 +195,7 @@ def test_customer_description_update_with_version(httpx_mock, test_client, produ
                 "customerId": "0c43b714-0a11-e511-80d0-005056956c1a",
                 "subscriptionId": subscription_id,
                 "description": "update description",
-                "version": 6,
+                "version": version + 1,
             }
         }
     }
@@ -231,7 +231,7 @@ def test_customer_description_update_with_incorrect_version(
     assert response.json() == {
         "data": {
             "upsertCustomerDescription": {
-                "message": "Stale data: given version (0) is lower than the current version (1)",
+                "message": "Stale data: given version (0) does not match the current version (1)",
             },
         },
     }

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -646,7 +646,7 @@ def test_subscriptions_sorting_invalid_field(test_client, product_type_1_subscri
                 "'insync', 'note', 'productCreatedAt', 'productDescription', "
                 "'productEndDate', 'productId', 'productName', 'productStatus', "
                 "'productTag', 'productType', 'startDate', 'status', "
-                "'subscriptionId', 'tag'])"
+                "'subscriptionId', 'tag', 'version'])"
             ),
             "path": ["subscriptions"],
             "extensions": {"error_type": "bad_request"},
@@ -804,7 +804,7 @@ def test_subscriptions_filtering_with_invalid_filter(
             "message": (
                 "Invalid filter arguments (invalid_filters=['test'] "
                 "valid_filter_keys=['customerId', 'description', 'endDate', 'insync', "
-                "'note', 'product', 'productId', 'startDate', 'status', 'subscriptionId', 'tag'])"
+                "'note', 'product', 'productId', 'startDate', 'status', 'subscriptionId', 'tag', 'version'])"
             ),
             "path": ["subscriptions"],
             "extensions": {"error_type": "bad_request"},
@@ -1276,6 +1276,11 @@ def test_single_subscription_schema(
             },
             "note": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None, "title": "Note"},
             "test_block": {"anyOf": [{"$ref": "#/$defs/ProductBlockWithListUnionForTestInactive"}, {"type": "null"}]},
+            "version": {
+                "default": 1,
+                "title": "Version",
+                "type": "integer",
+            },
         },
         "required": ["product", "customer_id", "test_block"],
         "title": "ProductSubListUnionInactive",

--- a/test/unit_tests/services/test_subscriptions.py
+++ b/test/unit_tests/services/test_subscriptions.py
@@ -133,7 +133,7 @@ def test_build_extended_domain_model(generic_subscription_1, generic_product_1):
         # "start_date": datetime.datetime(2022, 12, 20, 10, 36, 36, tzinfo=datetime.timezone.utc),
         "status": "active",
         "subscription_id": generic_subscription_1,
-        "version": 1,
+        "version": 2,
     }
 
 

--- a/test/unit_tests/services/test_subscriptions.py
+++ b/test/unit_tests/services/test_subscriptions.py
@@ -133,6 +133,7 @@ def test_build_extended_domain_model(generic_subscription_1, generic_product_1):
         # "start_date": datetime.datetime(2022, 12, 20, 10, 36, 36, tzinfo=datetime.timezone.utc),
         "status": "active",
         "subscription_id": generic_subscription_1,
+        "version": 1,
     }
 
 

--- a/test/unit_tests/test_db.py
+++ b/test/unit_tests/test_db.py
@@ -173,7 +173,7 @@ def test_autouse_fixture_rolls_back_bbb():
 def test_str_method():
     assert (
         str(SubscriptionTable())
-        == "SubscriptionTable(subscription_id=None, description=None, status=None, product_id=None, customer_id=None, insync=None, start_date=None, end_date=None, note=None)"
+        == "SubscriptionTable(subscription_id=None, description=None, status=None, product_id=None, customer_id=None, insync=None, start_date=None, end_date=None, note=None, version=None)"
     )
 
 


### PR DESCRIPTION
- add optional version validation to the first form (`_generate_modify_form`) of modify workflows that validates if the version is the same as then the one in the db, when a version is given.
- add similar optional version validation for subscription customer description modifies that validates if the version is the same before executing the update.
- add and update unit tests.