### PR TITLE
#2194 refactor to more abstract validation workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.2rc1
+current_version = 2.9.2rc2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.9.2rc1"
+__version__ = "2.9.2rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
+++ b/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
@@ -12,8 +12,6 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-
-# revision identifiers, used by Alembic.
 revision = "4fjdn13f83ga"
 down_revision = "4c5859620539"
 branch_labels = None

--- a/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
+++ b/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
@@ -18,28 +18,24 @@ branch_labels = None
 depends_on = None
 
 
-workflows = [
-    {
-        "name": "task_validate_product_type",
-        "target": "SYSTEM",
-        "description": "Validate all subscriptions of Product Type",
-        "workflow_id": uuid4(),
-    }
-]
+workflow = {
+    "name": "task_validate_product_type",
+    "target": "SYSTEM",
+    "description": "Validate all subscriptions of Product Type",
+    "workflow_id": uuid4(),
+}
 
 
 def upgrade() -> None:
     conn = op.get_bind()
-    for workflow in workflows:
-        conn.execute(
-            sa.text(
-                "INSERT INTO workflows VALUES (:workflow_id, :name, :target, :description, now()) ON CONFLICT DO NOTHING"
-            ),
-            workflow,
-        )
+    conn.execute(
+        sa.text(
+            "INSERT INTO workflows VALUES (:workflow_id, :name, :target, :description, now()) ON CONFLICT DO NOTHING"
+        ),
+        workflow,
+    )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    for workflow in workflows:
-        conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": workflow["name"]})
+    conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": workflow["name"]})

--- a/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
+++ b/orchestrator/migrations/versions/schema/2025-10-19_4fjdn13f83ga_add_validate_product_type_task.py
@@ -1,0 +1,47 @@
+"""Validate Product Type.
+
+Revision ID: 4fjdn13f83ga
+Revises: 2c7e8a43d4f9
+Create Date: 2025-10-13 16:21:43.956814
+
+"""
+
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+
+# revision identifiers, used by Alembic.
+revision = "4fjdn13f83ga"
+down_revision = "4c5859620539"
+branch_labels = None
+depends_on = None
+
+
+workflows = [
+    {
+        "name": "task_validate_product_type",
+        "target": "SYSTEM",
+        "description": "Validate all subscriptions of Product Type",
+        "workflow_id": uuid4(),
+    }
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for workflow in workflows:
+        conn.execute(
+            sa.text(
+                "INSERT INTO workflows VALUES (:workflow_id, :name, :target, :description, now()) ON CONFLICT DO NOTHING"
+            ),
+            workflow,
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for workflow in workflows:
+        conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": workflow["name"]})

--- a/orchestrator/schedules/validate_subscriptions.py
+++ b/orchestrator/schedules/validate_subscriptions.py
@@ -15,14 +15,14 @@
 from threading import BoundedSemaphore
 
 import structlog
-from sqlalchemy import select
 
-from orchestrator.db import ProductTable, SubscriptionTable, db
 from orchestrator.schedules.scheduling import scheduler
-from orchestrator.services.processes import get_execution_context
-from orchestrator.services.subscriptions import TARGET_DEFAULT_USABLE_MAP, WF_USABLE_MAP
-from orchestrator.settings import app_settings
-from orchestrator.targets import Target
+
+from orchestrator.services.subscriptions import get_subscriptions_on_product_table_in_sync
+from orchestrator.services.workflows import (
+    get_system_product_workflows_for_subscription,
+    start_validation_workflow_for_workflows
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -32,31 +32,20 @@ task_semaphore = BoundedSemaphore(value=2)
 
 @scheduler(name="Subscriptions Validator", time_unit="day", at="00:10")
 def validate_subscriptions() -> None:
-    if app_settings.VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS:
-        # Automatically re-validate out-of-sync subscriptions. This is not recommended for production.
-        select_query = select(SubscriptionTable).join(ProductTable)
-    else:
-        select_query = select(SubscriptionTable).join(ProductTable).filter(SubscriptionTable.insync.is_(True))
-    subscriptions = db.session.scalars(select_query)
+    subscriptions = get_subscriptions_on_product_table_in_sync()
+
     for subscription in subscriptions:
-        validation_workflow = None
+        system_product_workflows = get_system_product_workflows_for_subscription(subscription)
 
-        for workflow in subscription.product.workflows:
-            if workflow.target == Target.SYSTEM:
-                validation_workflow = workflow.name
-
-        if validation_workflow:
-            default = TARGET_DEFAULT_USABLE_MAP[Target.SYSTEM]
-            usable_when = WF_USABLE_MAP.get(validation_workflow, default)
-
-            if subscription.status in usable_when:
-                json = [{"subscription_id": str(subscription.subscription_id)}]
-
-                validate_func = get_execution_context()["validate"]
-                validate_func(validation_workflow, json=json)
-        else:
+        if not system_product_workflows:
             logger.warning(
                 "SubscriptionTable has no validation workflow",
                 subscription=subscription,
                 product=subscription.product.name,
             )
+            break
+
+        start_validation_workflow_for_workflows(
+            subscription=subscription,
+            workflows=system_product_workflows
+        )

--- a/orchestrator/schedules/validate_subscriptions.py
+++ b/orchestrator/schedules/validate_subscriptions.py
@@ -17,15 +17,15 @@ from threading import BoundedSemaphore
 import structlog
 
 from orchestrator.schedules.scheduling import scheduler
-from orchestrator.settings import app_settings
 from orchestrator.services.subscriptions import (
     get_subscriptions_on_product_table,
-    get_subscriptions_on_product_table_in_sync
+    get_subscriptions_on_product_table_in_sync,
 )
 from orchestrator.services.workflows import (
     get_system_product_workflows_for_subscription,
     start_validation_workflow_for_workflows,
 )
+from orchestrator.settings import app_settings
 
 logger = structlog.get_logger(__name__)
 

--- a/orchestrator/schedules/validate_subscriptions.py
+++ b/orchestrator/schedules/validate_subscriptions.py
@@ -17,11 +17,10 @@ from threading import BoundedSemaphore
 import structlog
 
 from orchestrator.schedules.scheduling import scheduler
-
 from orchestrator.services.subscriptions import get_subscriptions_on_product_table_in_sync
 from orchestrator.services.workflows import (
     get_system_product_workflows_for_subscription,
-    start_validation_workflow_for_workflows
+    start_validation_workflow_for_workflows,
 )
 
 logger = structlog.get_logger(__name__)
@@ -45,7 +44,4 @@ def validate_subscriptions() -> None:
             )
             break
 
-        start_validation_workflow_for_workflows(
-            subscription=subscription,
-            workflows=system_product_workflows
-        )
+        start_validation_workflow_for_workflows(subscription=subscription, workflows=system_product_workflows)

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -42,11 +42,11 @@ from orchestrator.db.models import (
     SubscriptionMetadataTable,
 )
 from orchestrator.domain.base import SubscriptionModel
+from orchestrator.settings import app_settings
 from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.datetime import nowtz
 from orchestrator.utils.helpers import is_ipaddress_type
-from orchestrator.settings import app_settings
 
 logger = structlog.get_logger(__name__)
 

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -46,6 +46,7 @@ from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.datetime import nowtz
 from orchestrator.utils.helpers import is_ipaddress_type
+from orchestrator.settings import app_settings
 
 logger = structlog.get_logger(__name__)
 
@@ -670,3 +671,13 @@ def format_extended_domain_model(subscription: dict, filter_owner_relations: boo
         filter_instance_ids_on_subscription()
 
     return subscription
+
+
+def get_subscriptions_on_product_table_in_sync(in_sync: bool = True) -> list[SubscriptionTable]:
+    if app_settings.VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS:
+        # Automatically re-validate out-of-sync subscriptions. This is not recommended for production.
+        select_query = select(SubscriptionTable).join(ProductTable)
+    else:
+        select_query = select(SubscriptionTable).join(ProductTable).filter(SubscriptionTable.insync.is_(in_sync))
+
+    return list(db.session.scalars(select_query))

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -42,7 +42,6 @@ from orchestrator.db.models import (
     SubscriptionMetadataTable,
 )
 from orchestrator.domain.base import SubscriptionModel
-from orchestrator.settings import app_settings
 from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle, UUIDstr
 from orchestrator.utils.datetime import nowtz
@@ -673,11 +672,11 @@ def format_extended_domain_model(subscription: dict, filter_owner_relations: boo
     return subscription
 
 
-def get_subscriptions_on_product_table_in_sync(in_sync: bool = True) -> list[SubscriptionTable]:
-    if app_settings.VALIDATE_OUT_OF_SYNC_SUBSCRIPTIONS:
-        # Automatically re-validate out-of-sync subscriptions. This is not recommended for production.
-        select_query = select(SubscriptionTable).join(ProductTable)
-    else:
-        select_query = select(SubscriptionTable).join(ProductTable).filter(SubscriptionTable.insync.is_(in_sync))
+def get_subscriptions_on_product_table() -> list[SubscriptionTable]:
+    select_query = select(SubscriptionTable).join(ProductTable)
+    return list(db.session.scalars(select_query))
 
+
+def get_subscriptions_on_product_table_in_sync(in_sync: bool = True) -> list[SubscriptionTable]:
+    select_query = select(SubscriptionTable).join(ProductTable).filter(SubscriptionTable.insync.is_(in_sync))
     return list(db.session.scalars(select_query))

--- a/orchestrator/services/workflows.py
+++ b/orchestrator/services/workflows.py
@@ -71,6 +71,7 @@ def start_validation_workflow_for_workflows(
 
             # against circular import
             from orchestrator.services.processes import get_execution_context
+
             validate_func = get_execution_context()["validate"]
             validate_func(workflow, json=json)
 

--- a/orchestrator/services/workflows.py
+++ b/orchestrator/services/workflows.py
@@ -3,15 +3,14 @@ from collections.abc import Iterable
 from sqlalchemy import Select, select
 
 from orchestrator.db import (
-    WorkflowTable,
     SubscriptionTable,
+    WorkflowTable,
     db,
 )
 from orchestrator.schemas import StepSchema, WorkflowSchema
-from orchestrator.workflows import get_workflow
-from orchestrator.targets import Target
 from orchestrator.services.subscriptions import TARGET_DEFAULT_USABLE_MAP, WF_USABLE_MAP
-from orchestrator.services.processes import get_execution_context
+from orchestrator.targets import Target
+from orchestrator.workflows import get_workflow
 
 
 def _get_steps(workflow: WorkflowTable) -> list[StepSchema]:
@@ -52,17 +51,11 @@ def get_workflow_by_name(workflow_name: str) -> WorkflowTable | None:
 
 
 def get_system_product_workflows_for_subscription(subscription: SubscriptionTable) -> list:
-    return [
-        workflow
-        for workflow in subscription.product.workflows
-        if workflow.target == Target.SYSTEM
-    ]
+    return [workflow for workflow in subscription.product.workflows if workflow.target == Target.SYSTEM]
 
 
 def start_validation_workflow_for_workflows(
-        subscription: SubscriptionTable,
-        workflows: list,
-        product_type_filter: str | None = None
+    subscription: SubscriptionTable, workflows: list, product_type_filter: str | None = None
 ) -> int:
     """Start validation workflows for a subscription."""
     total_started_validation_workflows = 0
@@ -76,6 +69,8 @@ def start_validation_workflow_for_workflows(
         ):
             json = [{"subscription_id": str(subscription.subscription_id)}]
 
+            # against circular import
+            from orchestrator.services.processes import get_execution_context
             validate_func = get_execution_context()["validate"]
             validate_func(workflow, json=json)
 

--- a/orchestrator/workflows/__init__.py
+++ b/orchestrator/workflows/__init__.py
@@ -110,5 +110,6 @@ LazyWorkflowInstance(".modify_note", "modify_note")
 LazyWorkflowInstance(".tasks.cleanup_tasks_log", "task_clean_up_tasks")
 LazyWorkflowInstance(".tasks.resume_workflows", "task_resume_workflows")
 LazyWorkflowInstance(".tasks.validate_products", "task_validate_products")
+LazyWorkflowInstance(".tasks.validate_product_type", "task_validate_product_type")
 
 __doc__ = make_workflow_index_doc(ALL_WORKFLOWS)

--- a/orchestrator/workflows/tasks/validate_product_type.py
+++ b/orchestrator/workflows/tasks/validate_product_type.py
@@ -1,0 +1,92 @@
+# Copyright 2019-2024 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import cache
+from typing import Any
+
+import structlog
+
+from orchestrator.db import ProductTable
+from orchestrator.forms import FormPage
+from orchestrator.forms.validators import Choice
+from orchestrator.services.subscriptions import (
+    get_subscriptions_on_product_table_in_sync,
+)
+from orchestrator.services.workflows import (
+    get_system_product_workflows_for_subscription,
+    start_validation_workflow_for_workflows,
+)
+from orchestrator.targets import Target
+from orchestrator.types import FormGenerator, State
+from orchestrator.workflow import StepList, done, init, step, workflow
+
+logger = structlog.get_logger(__name__)
+
+
+def create_select_product_type_form() -> type[FormPage]:
+    """Get and create the choices form for the product type."""
+
+    @cache
+    def get_product_type_choices() -> dict[Any, Any]:
+        return {product.product_type: product.product_type for product in ProductTable.query.all()}
+
+    ProductTypeChoices = Choice.__call__("Product Type", get_product_type_choices())
+
+    class SelectProductTypeForm(FormPage):
+        product_type: ProductTypeChoices  # type: ignore
+
+    return SelectProductTypeForm
+
+
+def initial_input_form_generator() -> FormGenerator:
+    """Generate the form."""
+
+    init_input = yield create_select_product_type_form()
+    user_input_data = init_input.model_dump()
+
+    return user_input_data
+
+
+@step("Validate Product Type")
+def validate_product_type(product_type: str) -> State:
+    result = []
+    subscriptions = get_subscriptions_on_product_table_in_sync()
+
+    for subscription in subscriptions:
+        system_product_workflows = get_system_product_workflows_for_subscription(
+            subscription=subscription,
+        )
+
+        if not system_product_workflows:
+            logger.warning(
+                "SubscriptionTable has no validation workflow",
+                subscription=subscription,
+                product=subscription.product.name,
+            )
+            break
+
+        validation_result = start_validation_workflow_for_workflows(
+            subscription=subscription,
+            workflows=system_product_workflows,
+            product_type_filter=product_type,
+        )
+        if len(validation_result) > 0:
+            result.append({"total_workflows_validated": len(validation_result), "workflows": validation_result})
+
+    return {"result": result}
+
+
+@workflow(
+    "Validate all subscriptions of Product Type", target=Target.SYSTEM, initial_input_form=initial_input_form_generator
+)
+def task_validate_product_type() -> StepList:
+    return init >> validate_product_type >> done

--- a/orchestrator/workflows/tasks/validate_product_type.py
+++ b/orchestrator/workflows/tasks/validate_product_type.py
@@ -72,7 +72,7 @@ def validate_product_type(product_type: str) -> State:
                 subscription=subscription,
                 product=subscription.product.name,
             )
-            break
+            continue
 
         validation_result = start_validation_workflow_for_workflows(
             subscription=subscription,

--- a/orchestrator/workflows/translations/en-GB.json
+++ b/orchestrator/workflows/translations/en-GB.json
@@ -5,7 +5,8 @@
             "note_info": "Notes, reminders and feedback about this description.",
             "subscription_id": "Subscription",
             "version": "Version",
-            "subscription_id_info": "The subscription for this action"
+            "subscription_id_info": "The subscription for this action",
+            "product_type": "Product Type"
         }
     },
     "workflow": {
@@ -13,6 +14,7 @@
         "task_clean_up_tasks": "Clean up old tasks",
         "task_resume_workflows": "Resume all workflows that are stuck on tasks with the status 'waiting'",
         "task_validate_products": "Validate Products and Subscriptions",
+        "task_validate_product_type": "Validate all subscriptions of Product Type",
         "reset_subscription_description": "Reset description of a subscription to default"
     }
 }

--- a/test/unit_tests/graphql/test_workflows.py
+++ b/test/unit_tests/graphql/test_workflows.py
@@ -114,7 +114,7 @@ def test_workflows_has_previous_page(test_client):
         "task_clean_up_tasks",
         "task_resume_workflows",
         "task_validate_product_type",
-        "task_validate_products"
+        "task_validate_products",
     ]
 
 
@@ -142,7 +142,12 @@ def test_workflows_filter_by_name(test_client, query_args):
         "startCursor": 0,
         "totalItems": 4,
     }
-    expected_workflows = ["task_clean_up_tasks", "task_resume_workflows", "task_validate_product_type", "task_validate_products"]
+    expected_workflows = [
+        "task_clean_up_tasks",
+        "task_resume_workflows",
+        "task_validate_product_type",
+        "task_validate_products",
+    ]
     assert [rt["name"] for rt in workflows] == expected_workflows
 
 
@@ -213,5 +218,11 @@ def test_workflows_sort_by_resource_type_desc(test_client):
         "endCursor": 4,
         "totalItems": 5,
     }
-    expected_workflows = ["task_validate_products", "task_validate_product_type", "task_resume_workflows", "task_clean_up_tasks", "modify_note"]
+    expected_workflows = [
+        "task_validate_products",
+        "task_validate_product_type",
+        "task_resume_workflows",
+        "task_clean_up_tasks",
+        "modify_note",
+    ]
     assert [rt["name"] for rt in workflows] == expected_workflows

--- a/test/unit_tests/graphql/test_workflows.py
+++ b/test/unit_tests/graphql/test_workflows.py
@@ -86,7 +86,7 @@ def test_workflows_query(test_client):
         "hasNextPage": True,
         "startCursor": 0,
         "endCursor": 1,
-        "totalItems": 4,
+        "totalItems": 5,
     }
 
 
@@ -105,15 +105,16 @@ def test_workflows_has_previous_page(test_client):
         "hasNextPage": False,
         "hasPreviousPage": True,
         "startCursor": 1,
-        "endCursor": 3,
-        "totalItems": 4,
+        "endCursor": 4,
+        "totalItems": 5,
     }
 
-    assert len(workflows) == 3
+    assert len(workflows) == 4
     assert [workflow["name"] for workflow in workflows] == [
         "task_clean_up_tasks",
         "task_resume_workflows",
-        "task_validate_products",
+        "task_validate_product_type",
+        "task_validate_products"
     ]
 
 
@@ -135,13 +136,13 @@ def test_workflows_filter_by_name(test_client, query_args):
 
     assert "errors" not in result
     assert pageinfo == {
-        "endCursor": 2,
+        "endCursor": 3,
         "hasNextPage": False,
         "hasPreviousPage": False,
         "startCursor": 0,
-        "totalItems": 3,
+        "totalItems": 4,
     }
-    expected_workflows = ["task_clean_up_tasks", "task_resume_workflows", "task_validate_products"]
+    expected_workflows = ["task_clean_up_tasks", "task_resume_workflows", "task_validate_product_type", "task_validate_products"]
     assert [rt["name"] for rt in workflows] == expected_workflows
 
 
@@ -209,8 +210,8 @@ def test_workflows_sort_by_resource_type_desc(test_client):
         "hasNextPage": False,
         "hasPreviousPage": False,
         "startCursor": 0,
-        "endCursor": 3,
-        "totalItems": 4,
+        "endCursor": 4,
+        "totalItems": 5,
     }
-    expected_workflows = ["task_validate_products", "task_resume_workflows", "task_clean_up_tasks", "modify_note"]
+    expected_workflows = ["task_validate_products", "task_validate_product_type", "task_resume_workflows", "task_clean_up_tasks", "modify_note"]
     assert [rt["name"] for rt in workflows] == expected_workflows

--- a/test/unit_tests/workflows/tasks/test_validate_product_type.py
+++ b/test/unit_tests/workflows/tasks/test_validate_product_type.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from orchestrator.db import SubscriptionTable, db

--- a/test/unit_tests/workflows/tasks/test_validate_product_type.py
+++ b/test/unit_tests/workflows/tasks/test_validate_product_type.py
@@ -1,0 +1,40 @@
+
+import pytest
+
+from orchestrator.db import SubscriptionTable, db
+from orchestrator.targets import Target
+from test.unit_tests.workflows import (
+    assert_complete,
+    extract_state,
+    run_workflow,
+)
+
+
+@pytest.mark.workflow
+def test_check_subscriptions(generic_subscription_1, validation_workflow_instance):
+    product = db.session.get(SubscriptionTable, generic_subscription_1).product
+    product.workflows.append(validation_workflow_instance)
+    db.session.add(product)
+    db.session.commit()
+
+    init_data = {
+        "product_type": "Generic",
+    }
+
+    result, process, step_log = run_workflow("task_validate_product_type", init_data)
+
+    assert_complete(result)
+
+    state = extract_state(result)
+
+    assert state["product_type"] == "Generic"
+    assert state["workflow_name"] == "task_validate_product_type"
+    assert state["workflow_target"] == Target.SYSTEM
+
+    result = state["result"]
+
+    assert len(result) == 1
+    assert result[0]["total_workflows_validated"] == 1
+    assert len(result[0]["workflows"]) == 1
+    assert result[0]["workflows"][0]["workflow_name"] == "validation_workflow"
+    assert result[0]["workflows"][0]["product_type"] == "Generic"


### PR DESCRIPTION
The orchestrator-core contains a cronjob that validates workflows.
Refactored the validation code so that it can be used outside of the workflow and more abstract so that there can be a filter applied on product_type