### PR TITLE
allow version 1.2.1 of pydantic forms to be installed

### DIFF
--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -458,7 +458,7 @@ class DomainModel(BaseModel):
 
 
 def get_depends_on_product_block_type_list(
-    product_block_types: dict[str, type["ProductBlockModel"] | tuple[type["ProductBlockModel"]]]
+    product_block_types: dict[str, type["ProductBlockModel"] | tuple[type["ProductBlockModel"]]],
 ) -> list[type["ProductBlockModel"]]:
     product_blocks_types_in_model = []
     for product_block_type in product_block_types.values():

--- a/orchestrator/utils/redis.py
+++ b/orchestrator/utils/redis.py
@@ -86,7 +86,7 @@ def default_get_subscription_id(data: Any) -> UUID:
 
 
 def delete_subscription_from_redis(
-    extract_fn: Callable[..., UUID] = default_get_subscription_id
+    extract_fn: Callable[..., UUID] = default_get_subscription_id,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     def _delete_subscription_from_redis(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "oauth2-lib~=2.4.0",
     "tabulate==0.9.0",
     "strawberry-graphql>=0.246.2",
-    "pydantic-forms~=1.1.3",
+    "pydantic-forms>=1.1.3",
 ]
 
 description-file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "oauth2-lib~=2.4.0",
     "tabulate==0.9.0",
     "strawberry-graphql>=0.246.2",
-    "pydantic-forms>=1.1.3",
+    "pydantic-forms~=1.2.1",
 ]
 
 description-file = "README.md"

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -6,6 +6,8 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+from pydantic_forms.core.translations import translations
+from pydantic_i18n import PydanticI18n
 from sqlalchemy import select
 
 from orchestrator.config.assignee import Assignee
@@ -846,7 +848,8 @@ def test_start_process(mock_get_workflow, mock_post_form, mock_db_create_process
         def errors(self):
             return []
 
-    mock_post_form.side_effect = FormValidationError("", MockEmptyValidationError())
+    tr = PydanticI18n(translations)
+    mock_post_form.side_effect = FormValidationError("", MockEmptyValidationError(), tr=tr)
 
     with pytest.raises(FormValidationError):
         start_process(mock.sentinel.wf_name, None, mock.sentinel.user)

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -6,7 +6,6 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-from pydantic_forms.core.translations import translations
 from pydantic_i18n import PydanticI18n
 from sqlalchemy import select
 
@@ -46,6 +45,7 @@ from orchestrator.workflow import (
     step,
     workflow,
 )
+from pydantic_forms.core.translations import translations
 from pydantic_forms.exceptions import FormValidationError
 from test.unit_tests.workflows import WorkflowInstanceForTests, run_workflow, store_workflow
 


### PR DESCRIPTION
Allow the install of the new, translatable, pydantic forms version.

I am not sure why I needed to lint files I didn't touch.
(black upgraded?)