### PR TITLE
Remove workaround for supporting postgres vers <14

### DIFF
--- a/test/unit_tests/test_db.py
+++ b/test/unit_tests/test_db.py
@@ -180,4 +180,4 @@ def test_str_method():
 def test_get_postgres_version():
     pg_version = get_postgres_version()
     assert isinstance(pg_version, int)
-    assert 0 < pg_version < 20
+    assert 13 < pg_version < 20


### PR DESCRIPTION
Removes the no-longer-needed workaround in `TSVisitorQuery` that was supporting `postgresql` versions older than `postgresql@14`.