### PR TITLE
[376] build and push container image action fails

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -56,5 +56,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /tmp/orchestrator-core
 COPY . .
 RUN pip install .
 RUN pip uninstall setup-tools -y
+RUN rm -rf /tmp/*
 
 RUN useradd orchestrator
 USER orchestrator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM python:3.11-slim
 
-ARG VERSION
-
 ENV PIP_ROOT_USER_ACTION=ignore
 
 RUN apt-get update && apt-get install --yes git
 
-RUN pip install pip --upgrade
-RUN pip install orchestrator-core==${VERSION}
-RUN pip uninstall setup-tools
+RUN pip install --upgrade pip
+
+WORKDIR /tmp/orchestrator-core
+COPY . .
+RUN pip install .
+RUN pip uninstall setup-tools -y
 
 RUN useradd orchestrator
 USER orchestrator


### PR DESCRIPTION
`docker build` now installs library from local filesystem rather than pulling from pypi