### PR TITLE
Bump version to 2.9.2rc4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.9.2rc3
+current_version = 2.9.2rc4
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "2.9.2rc3"
+__version__ = "2.9.2rc4"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings


### PR DESCRIPTION
Creating release candidate 2.9.2rc4 so we can run some of the code sprint deliveries through our system tests!