### PR TITLE
simplify enrich_product_block

### DIFF
--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -199,8 +199,9 @@ class OrchestratorCore(FastAPI):
 
     def register_graphql(
         self: "OrchestratorCore",
-        query: Any = Query,
-        mutation: Any = Mutation,
+        # mypy 1.9 cannot properly inspect these, fixed in 1.15
+        query: Any = Query,  # type: ignore
+        mutation: Any = Mutation,  # type: ignore
         register_models: bool = True,
         subscription_interface: Any = SubscriptionInterface,
         graphql_models: StrawberryModelType | None = None,

--- a/orchestrator/cli/generator/generator/product_block.py
+++ b/orchestrator/cli/generator/generator/product_block.py
@@ -56,16 +56,10 @@ def get_product_block_path(product_block: dict) -> Path:
 
 
 def enrich_product_block(product_block: dict) -> dict:
-    def to_block_name() -> str:
-        """Separate block name into words."""
-        type = product_block["type"]
-        name = re.sub("(.)([A-Z][a-z]+)", r"\1 \2", type)
-        return re.sub("([a-z0-9])([A-Z])", r"\1 \2", name)
-
     fields = get_all_fields(product_block)
-    block_name = product_block.get("block_name", to_block_name())
-
-    return product_block | {
+    block_name = product_block.get("block_name", product_block.get("type"))
+    return {
+        **product_block,
         "fields": fields,
         "block_name": block_name,
     }

--- a/orchestrator/cli/generator/generator/product_block.py
+++ b/orchestrator/cli/generator/generator/product_block.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from collections import ChainMap
 from collections.abc import Mapping
 from pathlib import Path
@@ -58,8 +57,7 @@ def get_product_block_path(product_block: dict) -> Path:
 def enrich_product_block(product_block: dict) -> dict:
     fields = get_all_fields(product_block)
     block_name = product_block.get("block_name", product_block.get("type"))
-    return {
-        **product_block,
+    return product_block | {
         "fields": fields,
         "block_name": block_name,
     }

--- a/test/unit_tests/cli/data/generate/products/product_blocks/example4sub.py
+++ b/test/unit_tests/cli/data/generate/products/product_blocks/example4sub.py
@@ -3,7 +3,7 @@ from orchestrator.types import SubscriptionLifecycle
 from pydantic import computed_field
 
 
-class Example4SubBlockInactive(ProductBlockModel, product_block_name="Example4 Sub"):
+class Example4SubBlockInactive(ProductBlockModel, product_block_name="Example4Sub"):
     str_val: str | None = None
 
 


### PR DESCRIPTION
closes #785 
simplifies `enrich_product_block` to prevent product block / database name mismatch
ignores Query/Mutation typing error from mypy 1.9