### PR TITLE
add 'Type' notation to Query and Mutation

### DIFF
--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -18,7 +18,7 @@ provides the ability to run the CLI.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Type
 
 import sentry_sdk
 import structlog
@@ -199,8 +199,8 @@ class OrchestratorCore(FastAPI):
 
     def register_graphql(
         self: "OrchestratorCore",
-        query: Any = Query,
-        mutation: Any = Mutation,
+        query: Type[Any] = Query,
+        mutation: Type[Any] = Mutation,
         register_models: bool = True,
         subscription_interface: Any = SubscriptionInterface,
         graphql_models: StrawberryModelType | None = None,


### PR DESCRIPTION
`mypy` seems to (inconsistently?) fail when investigating these particular types:
```
Run mypy .
orchestrator/app.py:202:22: error: Cannot determine type of "Query"  [has-type]
orchestrator/app.py:203:25: error: Cannot determine type of "Mutation"  [has-type]
Found 2 errors in 1 file (checked 3[7](https://github.com/workfloworchestrator/orchestrator-core/actions/runs/13316583868/job/37191980282?pr=833#step:7:8)8 source files)
```

This seems to be due to the fact that we generate them dynamically and import them:
# orchestrator/graphql/schema.py
```
Query = merge_types("Query", (OrchestratorQuery, CustomerQuery))
Mutation = merge_types("Mutation", (SettingsMutation, CustomerSubscriptionDescriptionMutation, ProcessMutation))
```

This change casts those new classes as 'Type' explicitly so that `mypy` at least knows they aren't arbitrary variables