### PR TITLE
Ensure all redis clients retry on connection timeouts/errors

### DIFF
--- a/orchestrator/api/api_v1/endpoints/settings.py
+++ b/orchestrator/api/api_v1/endpoints/settings.py
@@ -28,6 +28,7 @@ from orchestrator.services import processes, settings
 from orchestrator.settings import ExecutorType, app_settings
 from orchestrator.utils.json import json_dumps
 from orchestrator.utils.redis import delete_keys_matching_pattern
+from orchestrator.utils.redis_client import create_redis_asyncio_client
 from orchestrator.websocket import WS_CHANNELS, broadcast_invalidate_cache, websocket_manager
 
 router = APIRouter()
@@ -41,7 +42,7 @@ CACHE_FLUSH_OPTIONS: dict[str, str] = {
 
 @router.delete("/cache/{name}")
 async def clear_cache(name: str) -> int | None:
-    cache: AIORedis = AIORedis.from_url(str(app_settings.CACHE_URI))
+    cache: AIORedis = create_redis_asyncio_client(app_settings.CACHE_URI)
     if name not in CACHE_FLUSH_OPTIONS:
         raise_status(HTTPStatus.BAD_REQUEST, "Invalid cache name")
 

--- a/orchestrator/distlock/managers/redis_distlock_manager.py
+++ b/orchestrator/distlock/managers/redis_distlock_manager.py
@@ -20,6 +20,7 @@ from redis.lock import Lock as SyncLock
 from structlog import get_logger
 
 from orchestrator.settings import app_settings
+from orchestrator.utils.redis_client import create_redis_asyncio_client, create_redis_client
 
 logger = get_logger(__name__)
 
@@ -37,7 +38,7 @@ class RedisDistLockManager:
         self.redis_address = redis_address
 
     async def connect_redis(self) -> None:
-        self.redis_conn = AIORedis.from_url(str(self.redis_address))
+        self.redis_conn = create_redis_asyncio_client(self.redis_address)
 
     async def disconnect_redis(self) -> None:
         if self.redis_conn:
@@ -78,7 +79,7 @@ class RedisDistLockManager:
     def release_sync(self, lock: Lock) -> None:
         redis_conn: Redis | None = None
         try:
-            redis_conn = Redis.from_url(str(app_settings.CACHE_URI))
+            redis_conn = create_redis_client(app_settings.CACHE_URI)
             sync_lock: SyncLock = SyncLock(
                 redis=redis_conn,
                 name=lock.name,  # type: ignore

--- a/orchestrator/graphql/resolvers/settings.py
+++ b/orchestrator/graphql/resolvers/settings.py
@@ -21,6 +21,7 @@ from orchestrator.services.processes import SYSTEM_USER, ThreadPoolWorkerStatus,
 from orchestrator.services.settings import get_engine_settings, get_engine_settings_for_update, post_update_to_slack
 from orchestrator.settings import ExecutorType, app_settings
 from orchestrator.utils.redis import delete_keys_matching_pattern
+from orchestrator.utils.redis_client import create_redis_asyncio_client
 
 logger = structlog.get_logger(__name__)
 
@@ -57,7 +58,7 @@ def resolve_settings(info: OrchestratorInfo) -> StatusType:
 
 # Mutations
 async def clear_cache(info: OrchestratorInfo, name: str) -> CacheClearSuccess | Error:
-    cache: AIORedis = AIORedis.from_url(str(app_settings.CACHE_URI))
+    cache: AIORedis = create_redis_asyncio_client(app_settings.CACHE_URI)
     if name not in CACHE_FLUSH_OPTIONS:
         return Error(message="Invalid cache name")
 

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -16,7 +16,7 @@ import string
 from pathlib import Path
 from typing import Literal
 
-from pydantic import PostgresDsn, RedisDsn
+from pydantic import Field, NonNegativeInt, PostgresDsn, RedisDsn
 from pydantic_settings import BaseSettings
 
 from oauth2_lib.settings import oauth2lib_settings
@@ -57,6 +57,9 @@ class AppSettings(BaseSettings):
     CACHE_URI: RedisDsn = "redis://localhost:6379/0"  # type: ignore
     CACHE_DOMAIN_MODELS: bool = False
     CACHE_HMAC_SECRET: str | None = None  # HMAC signing key, used when pickling results in the cache
+    REDIS_RETRY_COUNT: NonNegativeInt = Field(
+        2, description="Number of retries for redis connection errors/timeouts, 0 to disable"
+    )  # More info: https://redis-py.readthedocs.io/en/stable/retry.html
     ENABLE_DISTLOCK_MANAGER: bool = True
     DISTLOCK_BACKEND: str = "memory"
     CC_NOC: int = 0

--- a/orchestrator/utils/redis_client.py
+++ b/orchestrator/utils/redis_client.py
@@ -1,0 +1,35 @@
+import redis.asyncio
+import redis.client
+import redis.exceptions
+from pydantic import RedisDsn
+from redis import Redis
+from redis.asyncio import Redis as AIORedis
+from redis.asyncio.retry import Retry as AIORetry
+from redis.backoff import EqualJitterBackoff
+from redis.retry import Retry
+
+from orchestrator.settings import app_settings
+
+REDIS_RETRY_ON_ERROR = [redis.exceptions.ConnectionError]
+REDIS_RETRY_ON_TIMEOUT = True
+REDIS_RETRY_BACKOFF = EqualJitterBackoff(base=0.05)
+
+
+def create_redis_client(redis_url: str | RedisDsn) -> redis.client.Redis:
+    """Create sync Redis client for the given Redis DSN with retry handling for connection errors and timeouts."""
+    return Redis.from_url(
+        str(redis_url),
+        retry_on_error=REDIS_RETRY_ON_ERROR,  # type: ignore[arg-type]
+        retry_on_timeout=REDIS_RETRY_ON_TIMEOUT,
+        retry=Retry(REDIS_RETRY_BACKOFF, app_settings.REDIS_RETRY_COUNT),
+    )
+
+
+def create_redis_asyncio_client(redis_url: str | RedisDsn) -> redis.asyncio.client.Redis:
+    """Create async Redis client for the given Redis DSN with retry handling for connection errors and timeouts."""
+    return AIORedis.from_url(
+        str(redis_url),
+        retry_on_error=REDIS_RETRY_ON_ERROR,  # type: ignore[arg-type]
+        retry_on_timeout=REDIS_RETRY_ON_TIMEOUT,
+        retry=AIORetry(REDIS_RETRY_BACKOFF, app_settings.REDIS_RETRY_COUNT),
+    )

--- a/test/unit_tests/api/test_subscriptions.py
+++ b/test/unit_tests/api/test_subscriptions.py
@@ -5,7 +5,6 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-from redis.client import Redis
 
 from nwastdlib.url import URL
 from orchestrator import app_settings
@@ -34,6 +33,7 @@ from orchestrator.services.subscriptions import (
 from orchestrator.targets import Target
 from orchestrator.utils.json import json_dumps, json_loads
 from orchestrator.utils.redis import to_redis
+from orchestrator.utils.redis_client import create_redis_client
 from orchestrator.workflow import ProcessStatus
 from test.unit_tests.config import (
     IMS_CIRCUIT_ID,
@@ -786,7 +786,7 @@ def test_subscription_detail_with_domain_model_cache(test_client, generic_subscr
 
     response = test_client.get(URL("api/subscriptions/domain-model") / generic_subscription_1)
 
-    cache = Redis.from_url(str(app_settings.CACHE_URI))
+    cache = create_redis_client(app_settings.CACHE_URI)
     result = cache.get(f"orchestrator:domain:{generic_subscription_1}")
     cached_model = json_dumps(json_loads(result))
     cached_etag = cache.get(f"orchestrator:domain:etag:{generic_subscription_1}")

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -11,7 +11,6 @@ import structlog
 from alembic import command
 from alembic.config import Config
 from pydantic import BaseModel as PydanticBaseModel
-from redis import Redis
 from sqlalchemy import create_engine, select, text
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm.scoping import scoped_session
@@ -36,6 +35,7 @@ from orchestrator.services.translations import generate_translations
 from orchestrator.settings import app_settings
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.utils.json import json_dumps
+from orchestrator.utils.redis_client import create_redis_client
 from pydantic_forms.core import FormPage
 from test.unit_tests.fixtures.processes import mocked_processes, mocked_processes_resumeall, test_workflow  # noqa: F401
 from test.unit_tests.fixtures.products.product_blocks.product_block_list_nested import (  # noqa: F401
@@ -644,7 +644,7 @@ def cache_fixture(monkeypatch):
     """Fixture to enable domain model caching and cleanup keys added to the list."""
     with monkeypatch.context() as m:
         m.setattr(app_settings, "CACHE_DOMAIN_MODELS", True)
-        cache = Redis.from_url(str(app_settings.CACHE_URI))
+        cache = create_redis_client(app_settings.CACHE_URI)
         # Clear cache before using this fixture
         cache.flushdb()
 

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -2,10 +2,9 @@ import json
 from hashlib import md5
 from http import HTTPStatus
 
-from redis import Redis
-
 from orchestrator import app_settings
 from orchestrator.utils.redis import ONE_WEEK
+from orchestrator.utils.redis_client import create_redis_client
 from test.unit_tests.config import GRAPHQL_ENDPOINT, GRAPHQL_HEADERS
 
 
@@ -106,7 +105,7 @@ def test_clear_cache_mutation_fails_auth(test_client, monkeypatch):
 
 
 def test_success_clear_cache(test_client, cache_fixture):
-    cache = Redis.from_url(str(app_settings.CACHE_URI))
+    cache = create_redis_client(app_settings.CACHE_URI)
     key = "some_model_uuid"
     test_data = {key: {"data": [1, 2, 3]}}
 


### PR DESCRIPTION
This should reduce/resolve errors in the step `Cache Subscription and related subscriptions`.

Retrying is done using [EqualJitterBackoff](https://redis-py.readthedocs.io/en/stable/backoff.html#redis.backoff.EqualJitterBackoff) which is basically exponential backoff with some random deviation to prevent the thundering herd problem.  It was already used for the websocket broadcasting but it's now applied to all redis clients.

Env setting `REDIS_RETRY_COUNT` can be used to change the amount of retries or even disable it by setting to `0`.