### PR TITLE
Instrument more unittests with codspeed

### DIFF
--- a/test/unit_tests/domain/test_base_performance.py
+++ b/test/unit_tests/domain/test_base_performance.py
@@ -79,7 +79,9 @@ def subscription_with_100_horizontal_blocks(create_horizontal_subscription):
 
 
 @pytest.mark.benchmark
-def test_subscription_model_horizontal_references(subscription_with_100_horizontal_blocks, test_product_type_one):
+def test_subscription_model_horizontal_references(
+    subscription_with_100_horizontal_blocks, test_product_type_one, monitor_sqlalchemy
+):
     # Note: fixtures only execute once per benchmark and are excluded from the measurement
 
     # given
@@ -90,8 +92,8 @@ def test_subscription_model_horizontal_references(subscription_with_100_horizont
 
     # when
 
-    # Include the `monitor_sqlalchemy` fixture and use it as a context manager to see the number of real queries
-    subscription = ProductTypeOneForTest.from_subscription(subscription_id)
+    with monitor_sqlalchemy():  # Context does nothing unless you set CLI_OPT_MONITOR_SQLALCHEMY
+        subscription = ProductTypeOneForTest.from_subscription(subscription_id)
 
     # then
     assert len(subscription.block.sub_block_list) == 100
@@ -103,7 +105,9 @@ def subscription_with_10_vertical_blocks(create_vertical_subscription):
 
 
 @pytest.mark.benchmark
-def test_subscription_model_vertical_references(subscription_with_10_vertical_blocks, test_product_type_one_nested):
+def test_subscription_model_vertical_references(
+    subscription_with_10_vertical_blocks, test_product_type_one_nested, monitor_sqlalchemy
+):
     # Note: fixtures only execute once per benchmark and are excluded from the measurement
 
     # given
@@ -114,8 +118,8 @@ def test_subscription_model_vertical_references(subscription_with_10_vertical_bl
 
     # when
 
-    # Include the `monitor_sqlalchemy` fixture and use it as a context manager to see the number of real queries
-    subscription = ProductTypeOneNestedForTest.from_subscription(subscription_id)
+    with monitor_sqlalchemy():  # Context does nothing unless you set CLI_OPT_MONITOR_SQLALCHEMY
+        subscription = ProductTypeOneNestedForTest.from_subscription(subscription_id)
 
     # then
     assert subscription.block is not None

--- a/test/unit_tests/graphql/test_subscription.py
+++ b/test/unit_tests/graphql/test_subscription.py
@@ -60,19 +60,27 @@ def build_complex_query(subscription_id):
     ).encode("utf-8")
 
 
-def test_single_simple_subscription(fastapi_app_graphql, test_client, product_sub_list_union_subscription_1):
+def test_single_simple_subscription(fastapi_app_graphql, test_client, product_sub_list_union_subscription_1, benchmark):
     test_query = build_simple_query(subscription_id=product_sub_list_union_subscription_1)
-    response = test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data": {"subscription": {"insync": True, "status": "ACTIVE"}}}
 
 
 def test_single_complex_subscription(
-    fastapi_app_graphql, test_client, product_sub_list_union_subscription_1, test_product_type_sub_list_union
+    fastapi_app_graphql, test_client, product_sub_list_union_subscription_1, test_product_type_sub_list_union, benchmark
 ):
     _, _, ProductSubListUnion = test_product_type_sub_list_union
     test_query = build_complex_query(subscription_id=product_sub_list_union_subscription_1)
-    response = test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {
         "data": {
@@ -86,8 +94,12 @@ def test_single_complex_subscription(
     }
 
 
-def test_subscription_does_not_exist(fastapi_app_graphql, test_client):
+def test_subscription_does_not_exist(fastapi_app_graphql, test_client, benchmark):
     test_query = build_simple_query(uuid4())
-    response = test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data": {"subscription": None}}

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -413,12 +413,15 @@ def get_subscriptions_with_metadata_and_schema_query(
     ).encode("utf-8")
 
 
-def test_subscriptions_single_page(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_single_page(test_client, product_type_1_subscriptions_factory, benchmark):
     # when
 
     product_type_1_subscriptions_factory(4)
     data = get_subscriptions_query()
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1076,6 +1079,7 @@ def test_single_subscription_with_depends_on_subscriptions(
     sub_one_subscription_1,
     sub_two_subscription_1,
     product_sub_list_union_subscription_1,
+    benchmark,
 ):
     # when
 
@@ -1085,7 +1089,10 @@ def test_single_subscription_with_depends_on_subscriptions(
 
     subscription_id = str(product_sub_list_union_subscription_1)
     data = get_subscriptions_query_with_relations(query_string=subscription_id)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
     expected_depends_on_ids = {
         str(subscription.subscription_id) for subscription in [sub_one_subscription_1, sub_two_subscription_1]
@@ -1183,6 +1190,7 @@ def test_single_subscription_schema(
     sub_one_subscription_1,
     sub_two_subscription_1,
     product_sub_list_union_subscription_1,
+    benchmark,
 ):
     # when
 
@@ -1191,7 +1199,11 @@ def test_single_subscription_schema(
     data = get_subscriptions_product_block_json_schema_query(
         filter_by=[{"field": "subscriptionId", "value": subscription_id}]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
+    @benchmark
+    def response():
+        return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+
     # then
 
     assert HTTPStatus.OK == response.status_code


### PR DESCRIPTION
Add codspeed instrumentation for unittests to benchmark:
* SubscriptionModel.save()
* REST endpoint /domain-model/
* GQL resolve_subscription and resolve_subscriptions