### PR TITLE
[#724] Exclude subscriptions_search materialized view from Alembic au…

### DIFF
--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -651,6 +651,8 @@ class SubscriptionMetadataTable(BaseModel):
 
 class SubscriptionSearchView(BaseModel):
     __tablename__ = "subscriptions_search"
+    __table_args__ = {"info": {"materialized_view": True}}
+
     subscription_id = mapped_column(
         UUIDType, ForeignKey("subscriptions.subscription_id"), nullable=False, index=True, primary_key=True
     )

--- a/orchestrator/migrations/env.py
+++ b/orchestrator/migrations/env.py
@@ -41,6 +41,14 @@ target_metadata = BaseModel.metadata
 # ... etc.
 
 
+def include_object(object, name, type_, reflected, compare_to):  # type: ignore
+    """Exclude tables with the 'materialized_view' flag in their info."""
+
+    if type_ == "table" and object.info.get("materialized_view", False):
+        return False
+    return True
+
+
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.
 
@@ -55,7 +63,11 @@ def run_migrations_offline() -> None:
     """
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"}
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_object=include_object,
     )
 
     with context.begin_transaction():
@@ -90,6 +102,7 @@ def run_migrations_online() -> None:
         target_metadata=target_metadata,
         process_revision_directives=process_revision_directives,
         compare_type=True,
+        include_object=include_object,
     )
 
     try:

--- a/orchestrator/migrations/env.py
+++ b/orchestrator/migrations/env.py
@@ -42,7 +42,7 @@ target_metadata = BaseModel.metadata
 
 
 def include_object(object, name, type_, reflected, compare_to):  # type: ignore
-    """Exclude tables with the 'materialized_view' flag in their info."""
+    """Determines if an object should be included."""
 
     if type_ == "table" and object.info.get("materialized_view", False):
         return False


### PR DESCRIPTION
The `subscriptions_search` view is a manually created materialized view and should not be managed by Alembic. This PR adds an info flag to the view’s table definition and updates the `include_object` logic to skip any table marked as a materialized view. This prevents erroneous migration generation for `subscriptions_search`. 
Resolves #724.