### PR TITLE
Consistent database query sorting results in unittests

### DIFF
--- a/test/unit_tests/cli/data/generate/workflows/shared.py
+++ b/test/unit_tests/cli/data/generate/workflows/shared.py
@@ -8,7 +8,7 @@ from pydantic import ConfigDict
 
 
 def summary_form(product_name: str, summary_data: dict) -> Generator:
-    ProductSummary: TypeAlias = cast(type[MigrationSummary], migration_summary(summary_data))
+    ProductSummary: TypeAlias = cast("type[MigrationSummary]", migration_summary(summary_data))
 
     class SummaryForm(FormPage):
         model_config = ConfigDict(title=f"{product_name} summary")

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -223,7 +223,9 @@ def database(db_uri):
         conn.commit()
         conn.execution_options(isolation_level="AUTOCOMMIT").execute(text(f'DROP DATABASE IF EXISTS "{db_to_create}";'))
         conn.commit()
-        conn.execute(text(f'CREATE DATABASE "{db_to_create}";'))
+        conn.execute(
+            text(f'CREATE DATABASE "{db_to_create}" LOCALE_PROVIDER icu ICU_LOCALE "en-US" TEMPLATE template0;')
+        )
 
     run_migrations(db_uri)
     db.wrapped_database.engine = create_engine(db_uri, **ENGINE_ARGUMENTS)


### PR DESCRIPTION
Changes the database unittest fixture so that it creates the test database with locale en-US from ICU. This ensures consistent ordering of queries for both Alpine and Debian builds of Postgres.