### PR TITLE
294 detect usage of basemodel

### DIFF
--- a/orchestrator/domain/__init__.py
+++ b/orchestrator/domain/__init__.py
@@ -11,11 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from orchestrator.domain.base import SubscriptionModel
+from orchestrator.domain.base import SubscriptionModel, SubscriptionModelRegistry
 from orchestrator.utils.docs import make_product_type_index_doc
 
-SUBSCRIPTION_MODEL_REGISTRY: dict[str, type[SubscriptionModel]] = {}
+SUBSCRIPTION_MODEL_REGISTRY: SubscriptionModelRegistry = SubscriptionModelRegistry()
 
 __doc__ = make_product_type_index_doc(SUBSCRIPTION_MODEL_REGISTRY)
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -21,7 +21,6 @@ from typing import (
     Callable,
     ClassVar,
     Iterable,
-    Literal,
     Mapping,
     Optional,
     TypeVar,
@@ -36,7 +35,6 @@ import structlog
 from more_itertools import bucket, first, flatten, one, only
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.fields import PrivateAttr
-from pydantic.main import IncEx
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
@@ -90,35 +88,6 @@ class DomainModel(BaseModel):
 
     Contains all common Product block/Subscription instance code
     """
-
-    def model_dump_json(
-        self,
-        *,
-        indent: int | None = None,
-        include: IncEx | None = None,
-        exclude: IncEx | None = None,
-        context: Any | None = None,
-        by_alias: bool = False,
-        exclude_unset: bool = False,
-        exclude_defaults: bool = False,
-        exclude_none: bool = False,
-        round_trip: bool = False,
-        warnings: bool | Literal["none", "warn", "error"] = True,
-        serialize_as_any: bool = False,
-    ) -> str:
-        return super().model_dump_json(
-            indent=indent,
-            include=include,
-            exclude=exclude,
-            context=context,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-            round_trip=round_trip,
-            warnings=warnings,
-            serialize_as_any=serialize_as_any,
-        )
 
     model_config = ConfigDict(validate_assignment=True, validate_default=True)
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -1462,13 +1462,11 @@ class SubscriptionModelRegistry(dict[str, type[SubscriptionModel]]):
                     self[key] = value
             elif isinstance(m, Iterable):
                 for index, item in enumerate(m):
-                    if not isinstance(item, tuple):
-                        raise TypeError(f"cannot convert dictionary update sequence " f"element #{index} to a sequence")
-                    if length := len(item) != 2:
-                        raise TypeError(
-                            f"dictionary update sequence element #{index} has " f"length {length}; 2 is required"
-                        )
-                    self[item[0]] = item[1]
+                    try:
+                        key, value = item
+                    except ValueError:
+                        raise TypeError(f"dictionary update sequence element #{index} is not an iterable of length 2")
+                    self[key] = value
         for key, value in kwargs.items():
             self[key] = value
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -1455,7 +1455,7 @@ class SubscriptionModelRegistry(dict[str, type[SubscriptionModel]]):
         /,
         **kwargs: type[SubscriptionModel],
     ) -> None:
-        """Update dictionary and/or keyword arguments using `__setitem__`."""
+        """Update dictionary with mapping and/or kwargs using `__setitem__`."""
         if m:
             if isinstance(m, Mapping):
                 for key, value in m.items():

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -1438,22 +1438,9 @@ class SubscriptionModel(DomainModel):
 
 
 def validate_base_model(
-    name: str,
-    cls: type[Any],
-    base_model: type[BaseModel] = DomainModel,
-    errors: list[str] | None = None
+    name: str, cls: type[Any], base_model: type[BaseModel] = DomainModel, errors: list[str] | None = None
 ) -> None:
-    """Validates that the given class is not Pydantic BaseModel or its direct subclass.
-
-    Args:
-        name: The name of the field to be validated.
-        cls: The class to be validated.
-        base_model: The base model to validate against, default is DomainModel.
-        errors: A list to store error messages, if any. Defaults to None.
-
-    Returns: None
-
-    """
+    """Validates that the given class is not Pydantic BaseModel or its direct subclass."""
     # Instantiate errors list if not provided and avoid mutating default
     if errors is None:
         errors = []
@@ -1489,12 +1476,7 @@ class SubscriptionModelRegistry(dict[str, type[SubscriptionModel]]):
     """A registry for all subscription models."""
 
     def __setitem__(self, __key: str, __value: type[SubscriptionModel]) -> None:
-        """Set the value for the given key in the registry while validating against Pydantic BaseModel.
-
-        Args:
-            __key: The key to be set in the registry.
-            __value: The value to be set in the registry, which must be a subclass of SubscriptionModel.
-        """
+        """Set the value for the given key in the registry while validating against Pydantic BaseModel."""
         validate_base_model(__key, __value)
         super().__setitem__(__key, __value)
 

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -166,12 +166,45 @@ def test_subscription_model_registry(clean_registry):
         "uncommon_subscription": UncommonSubscription,
     }
 
-    # These should register successfully
+    # These must register successfully when done individually
     for name, model in valid_subscriptions.items():
         try:
             SUBSCRIPTION_MODEL_REGISTRY.update({name: model})
         except TypeError:
             pytest.fail(f"Subscription {model.__name__} registered as " f"{name} should be valid but raised TypeError.")
+
+    # Test every signature the update method takes and reset using clear
+    try:
+        SUBSCRIPTION_MODEL_REGISTRY.update(valid_subscriptions)
+        SUBSCRIPTION_MODEL_REGISTRY.clear()
+    except TypeError:
+        pytest.fail(f"{valid_subscriptions} failed to register using the mapping signature of the update method.")
+    try:
+        SUBSCRIPTION_MODEL_REGISTRY.update(valid_subscriptions.items())
+        SUBSCRIPTION_MODEL_REGISTRY.clear()
+    except TypeError:
+        pytest.fail(f"{valid_subscriptions} failed to register using the iterable of tuples signature.")
+    try:
+        SUBSCRIPTION_MODEL_REGISTRY.update(**{name: model})
+        SUBSCRIPTION_MODEL_REGISTRY.clear()
+    except TypeError:
+        pytest.fail(f"{valid_subscriptions} failed to register using the keyword arguments signature.")
+    try:
+        SUBSCRIPTION_MODEL_REGISTRY.update(
+            {"common_subscription": CommonSubscription}, uncommon_subscription=UncommonSubscription
+        )
+        SUBSCRIPTION_MODEL_REGISTRY.clear()
+    except TypeError:
+        pytest.fail(f"{valid_subscriptions} failed to register using the mixed mapping and kwargs signature.")
+    try:
+        SUBSCRIPTION_MODEL_REGISTRY.update(
+            [("common_subscription", CommonSubscription)], uncommon_subscription=UncommonSubscription
+        )
+        SUBSCRIPTION_MODEL_REGISTRY.clear()
+    except TypeError:
+        pytest.fail(
+            f"{valid_subscriptions} failed to register using the mixed iterable of tuples and kwargs signature."
+        )
 
 
 def test_product_block_one_nested(

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -54,7 +54,13 @@ def test_product_block_metadata(test_product_block_one, test_product_one, test_p
     assert ProductBlockOneForTestInactive.tag == "TEST"
 
 
-def test_subscription_model_registry():
+@pytest.fixture
+def clean_registry():
+    with mock.patch.dict(SUBSCRIPTION_MODEL_REGISTRY):
+        yield
+
+
+def test_subscription_model_registry(clean_registry):
     """Test the behavior of the subscription model registry."""
 
     # This is a Product Block model that should not be registered


### PR DESCRIPTION
Also prevent using BaseModel itself in places where a SubscriptionModel or ProductBlockModel is needed to be used. Raises a TypeError during validation in the __setitem__ method of the
SubsubscriptionModelRegistry, which is a new specialized class to include the validation at the point of entry into its mapping.