### PR TITLE
Add process_id to workflow @step logging

### DIFF
--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -223,7 +223,11 @@ def step(name: str) -> Callable[[StepFunc], Step]:
     def decorator(func: StepFunc) -> Step:
         @functools.wraps(func)
         def wrapper(state: State) -> Process:
-            with bound_contextvars(func=func.__qualname__):
+            with bound_contextvars(
+                func=func.__qualname__,
+                workflow_name=state.get("workflow_name"),
+                process_id=state.get("process_id"),
+            ):
                 step_in_inject_args = inject_args(func)
                 try:
                     with transactional(db, logger):


### PR DESCRIPTION
When we log from a workflow `@step` we want to know which `process_id` the logs belong to. We have created our local version of the `@step` decorator for this but I think it makes sense to add this to the main WFO project.