### PR TITLE
Adds support for pydantic-forms 1.4.0-2.0.0

### DIFF
--- a/orchestrator/cli/generator/templates/modify_product.j2
+++ b/orchestrator/cli/generator/templates/modify_product.j2
@@ -7,7 +7,12 @@ from typing import Annotated
 import structlog
 from pydantic import AfterValidator, ConfigDict, model_validator
 from pydantic_forms.types import FormGenerator, State, UUIDstr
+
+{%- if use_updated_readonly_field is true  %}
+from pydantic_forms.validators import read_only_field
+{%- else %}
 from pydantic_forms.validators import ReadOnlyField
+{%- endif %}
 
 from orchestrator.forms import FormPage
 from orchestrator.forms.validators import CustomerId, Divider
@@ -52,7 +57,11 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         divider_1: Divider
 
         {% for field in fields if not field.modifiable is defined -%}
+        {% if use_updated_readonly_field is true  %}
+        {{ field.name }}: read_only_field({{ product_block.name }}.{{ field.name }})
+        {% else %}
         {{ field.name }}: ReadOnlyField({{ product_block.name }}.{{ field.name }})
+        {% endif %}
         {% endfor -%}
 
         {% for field in fields if field.modifiable is defined -%}

--- a/orchestrator/cli/generator/templates/modify_product.j2
+++ b/orchestrator/cli/generator/templates/modify_product.j2
@@ -57,11 +57,11 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         divider_1: Divider
 
         {% for field in fields if not field.modifiable is defined -%}
-        {% if use_updated_readonly_field is true  %}
+        {% if use_updated_readonly_field is true  -%}
         {{ field.name }}: read_only_field({{ product_block.name }}.{{ field.name }})
-        {% else %}
+        {% else -%}
         {{ field.name }}: ReadOnlyField({{ product_block.name }}.{{ field.name }})
-        {% endif %}
+        {% endif -%}
         {% endfor -%}
 
         {% for field in fields if field.modifiable is defined -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "pytz==2025.2",
     "redis==5.1.1",
     "schedule==1.1.0",
+    "semver==3.0.4",
     "sentry-sdk[fastapi]~=2.25.1",
     "SQLAlchemy==2.0.40",
     "SQLAlchemy-Utils==0.41.2",
@@ -65,7 +66,7 @@ dependencies = [
     "oauth2-lib~=2.4.0",
     "tabulate==0.9.0",
     "strawberry-graphql>=0.246.2",
-    "pydantic-forms~=1.4.0",
+    "pydantic-forms>=1.4.0, <=2.0.0",
 ]
 
 description-file = "README.md"

--- a/test/unit_tests/cli/data/generate/workflows/example1/modify_example1.py
+++ b/test/unit_tests/cli/data/generate/workflows/example1/modify_example1.py
@@ -10,7 +10,7 @@ from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow
 from pydantic import AfterValidator
 from pydantic_forms.types import FormGenerator, State, UUIDstr
-from pydantic_forms.validators import ReadOnlyField
+from pydantic_forms.validators import read_only_field
 
 from products.product_blocks.example1 import ExampleStrEnum1
 from products.product_types.example1 import Example1, Example1Provisioning
@@ -41,8 +41,8 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
 
         divider_1: Divider
 
-        unmodifiable_str: ReadOnlyField(example1.unmodifiable_str)
-        annotated_int: ReadOnlyField(example1.annotated_int)
+        unmodifiable_str: read_only_field(example1.unmodifiable_str)
+        annotated_int: read_only_field(example1.annotated_int)
         example_str_enum_1: validated_example_str_enum_1 = example1.example_str_enum_1
         modifiable_boolean: bool = example1.modifiable_boolean
         always_optional_str: str | None = example1.always_optional_str

--- a/test/unit_tests/cli/data/generate/workflows/example4/modify_example4.py
+++ b/test/unit_tests/cli/data/generate/workflows/example4/modify_example4.py
@@ -7,7 +7,7 @@ from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import set_status
 from orchestrator.workflows.utils import modify_workflow
 from pydantic_forms.types import FormGenerator, State, UUIDstr
-from pydantic_forms.validators import ReadOnlyField
+from pydantic_forms.validators import read_only_field
 
 from products.product_types.example4 import Example4, Example4Provisioning
 
@@ -33,7 +33,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
 
         divider_1: Divider
 
-        num_val: ReadOnlyField(example4.num_val)
+        num_val: read_only_field(example4.num_val)
 
     user_input = yield ModifyExample4Form
     user_input_dict = user_input.dict()


### PR DESCRIPTION
Code generation will now correctly use `ReadOnlyField` or `read_only_field` from `pydantic-forms` conditionally based on the installed version.

Resolves [#908]