### PR TITLE
Remove async prefix from new_process endpoint

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -128,7 +128,7 @@ def delete(process_id: UUID) -> None:
     status_code=HTTPStatus.CREATED,
     dependencies=[Depends(check_global_lock, use_cache=False)],
 )
-async def new_process(
+def new_process(
     workflow_key: str,
     request: Request,
     json_data: list[dict[str, Any]] | None = Body(...),


### PR DESCRIPTION
The `new_process` endpoint doesn't use any async functions so there's no reason to run it as async.

By making it a synchronous function, it will be executed in a worker thread allowing formgenerators to run async code again with `anyio`. Right now this is impossible as this will conflict with the event loop that the endpoint is being executed in.

In the future if there is a need to make it async, this will also require making the database session async, and all of the functions that create_process calls. That will be quite the overhaul.


---

Bumps orchestrator-core version to 3.2.1