### PR TITLE
Address performance regression in GQL subscriptions when using productBlockInstances

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.1
+current_version = 3.2.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/domain/context_cache.py
+++ b/orchestrator/domain/context_cache.py
@@ -38,6 +38,13 @@ def cache_subscription_models() -> Iterator:
         with cache_subscription_models():
            subscription_dict = subscription.model_dump()
     """
+    if __subscription_model_cache.get() is not None:
+        # If it's already active in the current context, we do nothing.
+        # This makes the contextmanager reentrant.
+        # The outermost contextmanager will eventually reset the context.
+        yield
+        return
+
     before = __subscription_model_cache.set({})
     try:
         yield

--- a/orchestrator/graphql/extensions/model_cache.py
+++ b/orchestrator/graphql/extensions/model_cache.py
@@ -1,0 +1,29 @@
+# Copyright 2022-2025 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Iterator
+
+from strawberry.extensions import SchemaExtension
+
+from orchestrator.domain.context_cache import cache_subscription_models
+
+
+class ModelCacheExtension(SchemaExtension):
+    """Wraps the GraphQL operation in a cache_subscription_models context.
+
+    For more background, please refer to the documentation of the contextmanager.
+    """
+
+    def on_operation(self, *args, **kwargs) -> Iterator[None]:  # type: ignore
+
+        with cache_subscription_models():
+            yield

--- a/orchestrator/graphql/schema.py
+++ b/orchestrator/graphql/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 SURF, GÉANT.
+# Copyright 2022-2025 SURF, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -32,6 +32,7 @@ from oauth2_lib.fastapi import AuthManager
 from oauth2_lib.strawberry import authenticated_field
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.graphql.autoregistration import create_subscription_strawberry_type, register_domain_models
+from orchestrator.graphql.extensions.model_cache import ModelCacheExtension
 from orchestrator.graphql.extensions.stats import StatsExtension
 from orchestrator.graphql.mutations.customer_description import CustomerSubscriptionDescriptionMutation
 from orchestrator.graphql.mutations.start_process import ProcessMutation
@@ -160,6 +161,7 @@ def default_context_getter(
 
 
 def get_extensions(mutation: Any, query: Any) -> Iterable[type[SchemaExtension]]:
+    yield ModelCacheExtension
     yield ErrorHandlerExtension
     if app_settings.ENABLE_GRAPHQL_DEPRECATION_CHECKER:
         yield make_deprecation_checker_extension(query=query, mutation=mutation)

--- a/orchestrator/graphql/schemas/subscription.py
+++ b/orchestrator/graphql/schemas/subscription.py
@@ -101,9 +101,9 @@ class SubscriptionInterface:
 
     @strawberry.field(description="Return all products block instances of a subscription")  # type: ignore
     async def product_block_instances(
-        self, tags: list[str] | None = None, resource_types: list[str] | None = None
+        self, info: OrchestratorInfo, tags: list[str] | None = None, resource_types: list[str] | None = None
     ) -> list[ProductBlockInstance]:
-        return await get_subscription_product_blocks(self.subscription_id, tags, resource_types)
+        return await get_subscription_product_blocks(info, self.subscription_id, tags, resource_types)
 
     @strawberry.field(description="Return fixed inputs")  # type: ignore
     async def fixed_inputs(self) -> strawberry.scalars.JSON:

--- a/orchestrator/graphql/utils/get_subscription_product_blocks.py
+++ b/orchestrator/graphql/utils/get_subscription_product_blocks.py
@@ -21,6 +21,8 @@ from pydantic.alias_generators import to_camel as to_lower_camel
 from strawberry.scalars import JSON
 
 from orchestrator.graphql.schemas.product_block import owner_subscription_resolver
+from orchestrator.graphql.types import OrchestratorInfo
+from orchestrator.graphql.utils.get_selected_paths import get_selected_paths
 from orchestrator.utils.get_subscription_dict import get_subscription_dict
 
 if TYPE_CHECKING:
@@ -81,9 +83,13 @@ pb_instance_property_keys = (
 
 
 async def get_subscription_product_blocks(
-    subscription_id: UUID, tags: list[str] | None = None, product_block_instance_values: list[str] | None = None
+    info: OrchestratorInfo,
+    subscription_id: UUID,
+    tags: list[str] | None = None,
+    product_block_instance_values: list[str] | None = None,
 ) -> list[ProductBlockInstance]:
-    subscription, _ = await get_subscription_dict(subscription_id)
+    inject_inuseby = "in_use_by_relations" in get_selected_paths(info)
+    subscription, _ = await get_subscription_dict(subscription_id, inject_inuseby=inject_inuseby)
 
     def to_product_block(product_block: dict[str, Any]) -> ProductBlockInstance:
         def is_resource_type(candidate: Any) -> bool:

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -597,6 +597,12 @@ def convert_to_in_use_by_relation(obj: Any) -> dict[str, str]:
     return {"subscription_instance_id": str(obj.subscription_instance_id), "subscription_id": str(obj.subscription_id)}
 
 
+def build_domain_model(subscription_model: SubscriptionModel) -> dict:
+    """Create a subscription dict from the SubscriptionModel."""
+    with cache_subscription_models():
+        return subscription_model.model_dump()
+
+
 def build_extended_domain_model(subscription_model: SubscriptionModel) -> dict:
     """Create a subscription dict from the SubscriptionModel with additional keys."""
     from orchestrator.settings import app_settings

--- a/orchestrator/utils/get_subscription_dict.py
+++ b/orchestrator/utils/get_subscription_dict.py
@@ -1,17 +1,21 @@
 from uuid import UUID
 
 from orchestrator.domain.base import SubscriptionModel
-from orchestrator.services.subscriptions import _generate_etag, build_extended_domain_model
+from orchestrator.services.subscriptions import _generate_etag, build_domain_model, build_extended_domain_model
 from orchestrator.utils.redis import from_redis
 
 
-async def get_subscription_dict(subscription_id: UUID) -> tuple[dict, str]:
+async def get_subscription_dict(subscription_id: UUID, inject_inuseby: bool = True) -> tuple[dict, str]:
     """Helper function to get subscription dict by uuid from db or cache."""
 
     if cached_model := from_redis(subscription_id):
         return cached_model  # type: ignore
 
     subscription_model = SubscriptionModel.from_subscription(subscription_id)
-    subscription = build_extended_domain_model(subscription_model)
+
+    if not inject_inuseby:
+        subscription = build_domain_model(subscription_model)
+    else:
+        subscription = build_extended_domain_model(subscription_model)
     etag = _generate_etag(subscription)
     return subscription, etag

--- a/orchestrator/utils/redis.py
+++ b/orchestrator/utils/redis.py
@@ -58,7 +58,7 @@ def from_redis(subscription_id: UUID) -> tuple[PY_JSON_TYPES, str] | None:
 
     if app_settings.ENABLE_SUBSCRIPTION_MODEL_OPTIMIZATIONS:
         # TODO #900 remove toggle and remove usage of this function in get_subscription_dict
-        log.warning("Using SubscriptionModel optimization, not loading subscription from cache")
+        log.info("Using SubscriptionModel optimization, not loading subscription from redis cache")
         return None
 
     if caching_models_enabled():


### PR DESCRIPTION
The new SubscriptionModel querying from 3.2.0 turns out to have some adverse effects on the performance of the `subscriptions` GQL query, specifically when using the `productBlockInstances` field. This particularly affects the [`SubscriptionDropdownOptions`](https://github.com/workfloworchestrator/orchestrator-ui-library/blob/45c1fa9a61528b55cbce2ad3283391e9467f53ff/packages/orchestrator-ui-components/src/rtk/endpoints/subscriptionsDropdownOptions.ts) query.

This PR mitigates this partially by:
* Only loading the "extended" domain model if `productBlockInstances { ... }` contains field `inUseByRelations`
* Adding a `ModelCacheExtension` to reuse loaded subscription models throughout each GQL query operation

Which, at least for the `SubscriptionDropdownOptions` query, reduces the execution time by 2/3rd.

Bumps version to 3.2.2

---

Related orchestrator-ui-library PR: https://github.com/workfloworchestrator/orchestrator-ui-library/pull/1872