### PR TITLE
Add role based access control to running workflows (#931)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0rc1
+current_version = 4.1.0rc2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/docs/reference-docs/auth-backend-and-frontend.md
+++ b/docs/reference-docs/auth-backend-and-frontend.md
@@ -270,7 +270,10 @@ app.register_graphql_authorization(graphql_authorization_instance)
 ```
 
 ## Authorization and Workflows
-**Role-based access control for workflows is currently in beta. Initial support has been added to the backend, but the feature is not fully communicated through the UI yet.**
+
+!!! Warning
+    Role-based access control for workflows is currently in beta.
+    Initial support has been added to the backend, but the feature is not fully communicated through the UI yet.
 
 Certain `orchestrator-core` decorators accept authorization callbacks of type `type Authorizer = Callable[OIDCUserModel, bool]`, which return True when the input user is authorized, otherwise False.
 

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "4.1.0rc1"
+__version__ = "4.1.0rc2"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/services/celery.py
+++ b/orchestrator/services/celery.py
@@ -18,8 +18,8 @@ from uuid import UUID
 import structlog
 from celery.result import AsyncResult
 from kombu.exceptions import ConnectionError, OperationalError
-from oauth2_lib.fastapi import OIDCUserModel
 
+from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator import app_settings
 from orchestrator.api.error_handling import raise_status
 from orchestrator.db import ProcessTable, db
@@ -47,7 +47,7 @@ def _celery_start_process(
     user_inputs: list[State] | None,
     user: str = SYSTEM_USER,
     user_model: OIDCUserModel | None = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> UUID:
     """Client side call of Celery."""
     from orchestrator.services.tasks import NEW_TASK, NEW_WORKFLOW, get_celery_task

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -412,6 +412,7 @@ def _run_process_async(process_id: UUID, f: Callable) -> UUID:
 def error_message_unauthorized(workflow_key: str) -> str:
     return f"User is not authorized to execute '{workflow_key}' workflow"
 
+
 def create_process(
     workflow_key: str,
     user_inputs: list[State] | None = None,
@@ -574,7 +575,7 @@ def resume_process(
         raise
 
     resume_func = get_execution_context()["resume"]
-    return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
+    return resume_func(process, user_inputs=user_inputs, user=user, user_model=user_model, broadcast_func=broadcast_func)
 
 
 def ensure_correct_callback_token(pstat: ProcessStat, *, token: str) -> None:

--- a/orchestrator/services/processes.py
+++ b/orchestrator/services/processes.py
@@ -41,7 +41,6 @@ from orchestrator.websocket import broadcast_invalidate_status_counts, broadcast
 from orchestrator.workflow import (
     CALLBACK_TOKEN_KEY,
     DEFAULT_CALLBACK_PROGRESS_KEY,
-    Authorizer,
     Failed,
     ProcessStat,
     ProcessStatus,
@@ -575,7 +574,7 @@ def resume_process(
         raise
 
     resume_func = get_execution_context()["resume"]
-    return resume_func(process, user_inputs=user_inputs, user=user, user_model=user_model, broadcast_func=broadcast_func)
+    return resume_func(process, user_inputs=user_inputs, user=user, broadcast_func=broadcast_func)
 
 
 def ensure_correct_callback_token(pstat: ProcessStat, *, token: str) -> None:

--- a/orchestrator/utils/auth.py
+++ b/orchestrator/utils/auth.py
@@ -1,0 +1,10 @@
+
+from collections.abc import Callable
+from typing import TypeAlias
+
+from oauth2_lib.fastapi import OIDCUserModel
+
+# This file is broken out separately to avoid circular imports.
+
+# Can instead use "type Authorizer = ..." in later Python versions.
+Authorizer: TypeAlias = Callable[[OIDCUserModel | None], bool]

--- a/orchestrator/utils/auth.py
+++ b/orchestrator/utils/auth.py
@@ -1,4 +1,3 @@
-
 from collections.abc import Callable
 from typing import TypeAlias
 

--- a/orchestrator/workflow.py
+++ b/orchestrator/workflow.py
@@ -13,21 +13,19 @@
 
 
 from __future__ import annotations
+
 import contextvars
 import functools
 import inspect
 import secrets
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from functools import update_wrapper
-from http import HTTPStatus
 from itertools import dropwhile
 from typing import (
     Any,
     Generic,
     NoReturn,
     Protocol,
-    TypeAlias,
     TypeVar,
     cast,
     overload,
@@ -42,7 +40,6 @@ from structlog.stdlib import BoundLogger
 
 from nwastdlib import const, identity
 from oauth2_lib.fastapi import OIDCUserModel
-from orchestrator.api.error_handling import raise_status
 from orchestrator.config.assignee import Assignee
 from orchestrator.db import db, transactional
 from orchestrator.services.settings import get_engine_settings
@@ -181,7 +178,7 @@ class StepList(list[Step]):
 
 
 def _handle_simple_input_form_generator(f: StateInputStepFunc) -> StateInputFormGenerator:
-    """Processes f into a form generator and injects a pre-hook for user authorization"""
+    """Processes f into a form generator and injects a pre-hook for user authorization."""
     if inspect.isgeneratorfunction(f):
         return cast(StateInputFormGenerator, f)
     if inspect.isgenerator(f):
@@ -219,7 +216,9 @@ def make_workflow(
     wrapping_function.description = description
     wrapping_function.authorize_callback = allow if authorize_callback is None else authorize_callback
     # If no retry auth policy is given, defer to policy for process creation.
-    wrapping_function.retry_auth_callback = wrapping_function.authorize_callback if retry_auth_callback is None else retry_auth_callback
+    wrapping_function.retry_auth_callback = (
+        wrapping_function.authorize_callback if retry_auth_callback is None else retry_auth_callback
+    )
 
     if initial_input_form is None:
         # We always need a form to prevent starting a workflow when no input is needed.
@@ -288,8 +287,15 @@ def retrystep(name: str) -> Callable[[StepFunc], Step]:
     return decorator
 
 
-def inputstep(name: str, assignee: Assignee, resume_auth_callback: Authorizer | None = None, retry_auth_callback: Authorizer | None = None) -> Callable[[InputStepFunc], Step]:
+def inputstep(
+    name: str,
+    assignee: Assignee,
+    resume_auth_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
+) -> Callable[[InputStepFunc], Step]:
     """Add user input step to workflow.
+
+    Any authorization callbacks will be attached to the resulting Step.
 
     IMPORTANT: In contrast to other workflow steps, the `@inputstep` wrapped function will not run in the
     workflow engine! This means that it must be free of side effects!
@@ -317,7 +323,14 @@ def inputstep(name: str, assignee: Assignee, resume_auth_callback: Authorizer | 
         def suspend(state: State) -> Process:
             return Suspend(state)
 
-        return make_step_function(suspend, name, wrapper, assignee, resume_auth_callback=resume_auth_callback, retry_auth_callback=retry_auth_callback)
+        return make_step_function(
+            suspend,
+            name,
+            wrapper,
+            assignee,
+            resume_auth_callback=resume_auth_callback,
+            retry_auth_callback=retry_auth_callback,
+        )
 
     return decorator
 
@@ -497,8 +510,8 @@ def workflow(
     description: str,
     initial_input_form: InputStepFunc | None = None,
     target: Target = Target.SYSTEM,
-    authorize_callback: Authorizer| None = None,
-    retry_auth_callback: Authorizer| None = None,
+    authorize_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow.
 
@@ -519,7 +532,13 @@ def workflow(
 
     def _workflow(f: Callable[[], StepList]) -> Workflow:
         return make_workflow(
-            f, description, initial_input_form_in_form_inject_args, target, f(), authorize_callback=authorize_callback, retry_auth_callback=retry_auth_callback
+            f,
+            description,
+            initial_input_form_in_form_inject_args,
+            target,
+            f(),
+            authorize_callback=authorize_callback,
+            retry_auth_callback=retry_auth_callback,
         )
 
     return _workflow

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -26,6 +26,7 @@ from orchestrator.forms.validators import ProductId
 from orchestrator.services import subscriptions
 from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
+from orchestrator.utils.auth import Authorizer
 from orchestrator.utils.errors import StaleDataError
 from orchestrator.utils.state import form_inject_args
 from orchestrator.utils.validate_data_version import validate_data_version
@@ -201,7 +202,8 @@ def create_workflow(
     initial_input_form: InputStepFunc | None = None,
     status: SubscriptionLifecycle = SubscriptionLifecycle.ACTIVE,
     additional_steps: StepList | None = None,
-    authorize_callback: Callable[[OIDCUserModel | None], bool] | None = None,
+    authorize_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow with a target=Target.CREATE.
 
@@ -234,6 +236,7 @@ def create_workflow(
             Target.CREATE,
             steplist,
             authorize_callback=authorize_callback,
+            retry_auth_callback=retry_auth_callback
         )
 
     return _create_workflow
@@ -243,7 +246,8 @@ def modify_workflow(
     description: str,
     initial_input_form: InputStepFunc | None = None,
     additional_steps: StepList | None = None,
-    authorize_callback: Callable[[OIDCUserModel | None], bool] | None = None,
+    authorize_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow.
 
@@ -278,6 +282,7 @@ def modify_workflow(
             Target.MODIFY,
             steplist,
             authorize_callback=authorize_callback,
+            retry_auth_callback=retry_auth_callback,
         )
 
     return _modify_workflow
@@ -287,7 +292,8 @@ def terminate_workflow(
     description: str,
     initial_input_form: InputStepFunc | None = None,
     additional_steps: StepList | None = None,
-    authorize_callback: Callable[[OIDCUserModel | None], bool] | None = None,
+    authorize_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
     """Transform an initial_input_form and a step list into a workflow.
 
@@ -323,6 +329,7 @@ def terminate_workflow(
             Target.TERMINATE,
             steplist,
             authorize_callback=authorize_callback,
+            retry_auth_callback=retry_auth_callback,
         )
 
     return _terminate_workflow

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -20,7 +20,6 @@ from more_itertools import first_true
 from pydantic import field_validator, model_validator
 from sqlalchemy import select
 
-from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.db import ProductTable, SubscriptionTable, db
 from orchestrator.forms.validators import ProductId
 from orchestrator.services import subscriptions
@@ -236,7 +235,7 @@ def create_workflow(
             Target.CREATE,
             steplist,
             authorize_callback=authorize_callback,
-            retry_auth_callback=retry_auth_callback
+            retry_auth_callback=retry_auth_callback,
         )
 
     return _create_workflow


### PR DESCRIPTION
This PR adds role-based access control to running, resuming and retrying workflows.

Documentation has been added to the `Auth(n|z)` page of the reference documentation.

As noted in the docs, this functionality is still in beta as the UI is not yet adapted to handle authorization rejections, nor does it hide/disable UI elements for starting/resuming workflows when a user isn't allowed to do so. Follow-up stories to implement these things are on the WFO Partner Code Sprint.

Version bumped to 4.1.0rc2.

Closes #931