### PR TITLE
Update getting-started docs and init templates

### DIFF
--- a/docs/getting-started/base.md
+++ b/docs/getting-started/base.md
@@ -15,29 +15,47 @@ Flask and Django, you install the core library, initialise it with configuration
 
 
 ### Step 1 - Install the package:
-Install the core.
+
+Create a virtualenv and install the core.
+
 <div class="termy">
-``` console
-$ pip install orchestrator-core
----> 100%
-Successfully installed orchestrator-core
+
+```shell
+python -m venv .venv
+source .venv/bin/activate
+pip install orchestrator-core
 ```
+
 </div>
 
 ### Step 2 - Setup the database:
+
 Create a postgres database:
 
 <div class="termy">
-``` shell
-$ createuser -sP nwa
-$ createdb orchestrator-core -O nwa
+
+```shell
+createuser -sP nwa
+createdb orchestrator-core -O nwa
 ```
+
 </div>
 
+Choose a password and remember it for later steps.
+
+As an example, you can run these docker commands in separate shells to start a temporary postgres instance:
+
+```shell
+docker run --rm --name temp-orch-db -e POSTGRES_PASSWORD=rootpassword -p 5432:5432 postgres:15
+
+docker exec -it temp-orch-db su - postgres -c 'createuser -sP nwa && createdb orchestrator-core -O nwa'
+```
+
 ### Step 3 - Create the main.py:
+
 Create a `main.py` file.
 
-``` python
+```python
 from orchestrator import OrchestratorCore
 from orchestrator.cli.main import app as core_cli
 from orchestrator.settings import AppSettings
@@ -48,37 +66,34 @@ if __name__ == "__main__":
     core_cli()
 ```
 
-
 ### Step 4 - Run the database migrations:
 
-Initialize the migration environment.
+Initialize the migration environment and database tables.
+
 <div class="termy">
-``` console
-$ PYTHONPATH=. python main.py db init
-$ PYTHONPATH=. python main.py db upgrade heads
+
+```shell
+export DATABASE_URI=postgresql://nwa:PASSWORD_FROM_STEP_2@localhost:5432/orchestrator-core
+
+python main.py db init
+python main.py db upgrade heads
 ```
+
 </div>
 
 ### Step 5 - Run the app
 
 <div class="termy">
 
-``` shell
-$ uvicorn --reload --host 127.0.0.1 --port 8080 main:app
-INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)
-INFO:     Started reloader process [62967] using watchgod
-ujson module not found, using json
-msgpack not installed, MsgPackSerializer unavailable
-2021-09-28 09:42:14 [warning  ] Database object configured, all methods referencing `db` should work. [orchestrator.db]
-INFO:     Started server process [62971]
-2021-09-28 09:42:14 [info     ] Started server process [62971] [uvicorn.error]
-INFO:     Waiting for application startup.
-2021-09-28 09:42:14 [info     ] Waiting for application startup. [uvicorn.error]
-INFO:     Application startup complete.
-2021-09-28 09:42:14 [info     ] Application startup complete.  [uvicorn.error]
+```shell
+export DATABASE_URI=postgresql://nwa:PASSWORD_FROM_STEP_2@localhost:5432/orchestrator-core
+export OAUTH2_ACTIVE=False
+
+uvicorn --reload --host 127.0.0.1 --port 8080 main:app
 ```
+
 </div>
 
 ### Step 6 - Profit :boom: :grin:
 
-Visit [the app](http://127.0.0.1:8080/api/redoc) to view the api documentation.
+Visit the [ReDoc](http://127.0.0.1:8080/api/redoc) or [OpenAPI](http://127.0.0.1:8080/api/docs) to view and interact with the API.

--- a/docs/getting-started/orchestration-ui.md
+++ b/docs/getting-started/orchestration-ui.md
@@ -18,15 +18,34 @@ Before running an installation of the Workflow Orchestrator UI make sure to have
 
 ### Installation
 
--   Clone the example ui repository
-    `git clone https://github.com/workfloworchestrator/example-orchestrator-ui`
--   Install the npm packages
-    `npm i`
--   Set the correct env variables. The defaults from .env.example will work out of the box with the example orchestrator backend
-    `cp .env.example .env`
--   Run the application
-    `npm run dev`
--   The orchestrator ui now runs on http://localhost:3000
+Clone the example UI repository:
+
+```
+mkdir orchestrator-ui
+cd orchestrator-ui
+git clone https://github.com/workfloworchestrator/example-orchestrator-ui .
+```
+
+Install the npm packages:
+
+```
+npm i
+```
+
+Set the correct env variables.
+To run the UI against the dockerized example orchestrator setup, it's recommended to use the `orchestrator-ui.env` env-file.
+
+```
+wget -O .env https://raw.githubusercontent.com/workfloworchestrator/example-orchestrator/refs/heads/master/docker/orchestrator-ui/orchestrator-ui.env
+```
+
+Run the application:
+
+```
+npm run dev
+```
+
+The Orchestrator UI now runs on http://localhost:3000
 
 
 

--- a/docs/getting-started/prepare-source-folder.md
+++ b/docs/getting-started/prepare-source-folder.md
@@ -22,11 +22,10 @@ valid Git repository.
 
 ### Migrations folder and local Alembic head
 
-The `migrations` folder is created when running `python main.py db ini`.  This
-folder is used to store the local Alembic database migrations. The
-orchestrator-core package also contains Alembic database migrations, the Alembic
-head in the core is labeled `schema`.  The local Alembic head should be labeled
-`data`.
+The `migrations` folder is created when running `python main.py db init`.
+This folder is used to store the local Alembic database migrations.
+The orchestrator-core package also contains Alembic database migrations, the Alembic head in the core is labeled `schema`.
+The local Alembic head should be labeled `data`.
 
 When you already have product(s), workflow(s) or product template(s) defined,
 the local Alembic head can be created by running either `python main.py db

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,7 +150,7 @@ nav:
           - Prerequisites: getting-started/versions.md
           - Base Application:
                 - Preparing source folder: getting-started/prepare-source-folder.md
-                - Python Virtualenv: getting-started/base.md
+                - Base application: getting-started/base.md
           - Docker: getting-started/docker.md
           - Orchestrator UI: getting-started/orchestration-ui.md
     - Reference Documentation:

--- a/orchestrator/migrations/templates/alembic.ini.j2
+++ b/orchestrator/migrations/templates/alembic.ini.j2
@@ -6,8 +6,7 @@ file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(rev)s_%%(slug)s
 
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
-# revision_environment = false
-script_location = {{ migrations_dir }}
+script_location = %(here)s/{{ migrations_dir }}
 version_locations = %(here)s/{{ migrations_dir }}/versions/schema
 # Logging configuration
 [loggers]

--- a/orchestrator/migrations/templates/env.py.j2
+++ b/orchestrator/migrations/templates/env.py.j2
@@ -1,9 +1,7 @@
-import logging
-import os
+import structlog
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-import orchestrator
 from orchestrator.db.database import BaseModel
 from orchestrator.settings import app_settings
 
@@ -11,11 +9,10 @@ from orchestrator.settings import app_settings
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-logger = logging.getLogger("alembic.env")
+# Setup logging
+logger = structlog.get_logger()
 
-config.set_main_option("sqlalchemy.url", app_settings.DATABASE_URI)
+config.set_main_option("sqlalchemy.url", str(app_settings.DATABASE_URI))
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/test/unit_tests/cli/data/generate/migrations/env.py
+++ b/test/unit_tests/cli/data/generate/migrations/env.py
@@ -1,9 +1,7 @@
-import logging
-import os
+import structlog
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-import orchestrator
 from orchestrator.db.database import BaseModel
 from orchestrator.settings import app_settings
 
@@ -11,11 +9,10 @@ from orchestrator.settings import app_settings
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-logger = logging.getLogger("alembic.env")
+# Setup logging
+logger = structlog.get_logger()
 
-config.set_main_option("sqlalchemy.url", app_settings.DATABASE_URI)
+config.set_main_option("sqlalchemy.url", str(app_settings.DATABASE_URI))
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
As reported in Discord the template for env.py was out of date. Updated these and other templates to be in line with our own + that of the example-orchestrator (https://github.com/workfloworchestrator/example-orchestrator/pull/31). Also verified and updated the getting-started documentation where needed.