### PR TITLE
Fix TypeError when resuming process through the callback endpoint

### DIFF
--- a/orchestrator/services/celery.py
+++ b/orchestrator/services/celery.py
@@ -72,8 +72,8 @@ def _celery_start_process(
 def _celery_resume_process(
     process: ProcessTable,
     *,
-    user_inputs: list[State] | None,
-    user: str | None,
+    user_inputs: list[State] | None = None,
+    user: str | None = None,
     **kwargs: Any,
 ) -> UUID:
     """Client side call of Celery."""


### PR DESCRIPTION
Getting a TypeError: _celery_resume_process() missing 2 required keyword-only arguments: 'user_inputs' and 'user'. Scenario is when using callback in combination with Celery. When using threadpool execution context the issue is not seen as there a default (None) is set.

![image](https://github.com/user-attachments/assets/de1dda21-e6bd-4110-b078-654ac40ea3a5)
