### PR TITLE
Fix mkdocstrings headings for db commands

### DIFF
--- a/docs/reference-docs/cli.md
+++ b/docs/reference-docs/cli.md
@@ -35,7 +35,6 @@ Interact with the application database. By default, does nothing, specify `main.
         - migrate_tasks
         - revision
         - upgrade
-
       heading_level: 3
 
 ### migrate-domain-models


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/cf933ed8-7526-4e4a-9f91-42f3bb2e1e08)

After:
![image](https://github.com/user-attachments/assets/1612fddb-6eb2-46d3-b35a-f38531ea1a8d)
