### PR TITLE
Rename all_pb_names to all_product_block_names and refactor related logic

### DIFF
--- a/test/unit_tests/fixtures/products/product_blocks/product_block_one_nested.py
+++ b/test/unit_tests/fixtures/products/product_blocks/product_block_one_nested.py
@@ -48,6 +48,7 @@ def test_product_block_one_nested_db_in_use_by_block(resource_type_list, resourc
         name="ProductBlockOneNestedForTest", description="Test Block Parent", tag="TEST", status="active"
     )
     in_use_by_block.resource_types = [resource_type_int]
+    in_use_by_block.in_use_by = [in_use_by_block]
 
     db.session.add(in_use_by_block)
     db.session.commit()

--- a/test/unit_tests/fixtures/products/product_types/product_type_one_nested.py
+++ b/test/unit_tests/fixtures/products/product_types/product_type_one_nested.py
@@ -36,16 +36,17 @@ def test_product_type_one_nested():
 
 
 @pytest.fixture
-def test_product_one_nested(test_product_block_one_nested_db_in_use_by_block):
+def test_product_one_nested(test_product_block_one_nested_db_in_use_by_block, generic_product_block_chain):
     product = ProductTable(
         name="TestProductOneNested", description="Test ProductTable", product_type="Test", tag="TEST", status="active"
     )
 
     fixed_input = FixedInputTable(name="test_fixed_input", value="False")
 
-    product_block = test_product_block_one_nested_db_in_use_by_block
+    pb_1 = test_product_block_one_nested_db_in_use_by_block
+    pb_2, pb_3 = generic_product_block_chain
     product.fixed_inputs = [fixed_input]
-    product.product_blocks = [product_block]
+    product.product_blocks = [pb_1, pb_2, pb_3]
 
     db.session.add(product)
     db.session.commit()

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -85,7 +85,7 @@ def get_all_product_names_query(
 query ProductQuery($filterBy: [GraphqlFilter!]) {
   products(filterBy: $filterBy) {
     page {
-      allPbNames
+      allProductBlockNames
     }
     pageInfo {
       endCursor
@@ -235,7 +235,7 @@ def test_all_product_block_names(test_client, generic_product_4):
     result = response.json()
     products_data = result["data"]["products"]
     products = products_data["page"]
-    names = products[0]["allPbNames"]
+    names = products[0]["allProductBlockNames"]
 
     assert len(names) == 2
 

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -226,8 +226,8 @@ def test_product_query(
     }
 
 
-def test_all_product_block_names(test_client, generic_product_4):
-    filter_by = {"filter_by": {"field": "name", "value": "Product 4"}}
+def test_all_product_block_names(test_client, test_product_one_nested):
+    filter_by = {"filter_by": {"field": "name", "value": "TestProductOneNested"}}
     data = get_all_product_names_query(**filter_by)
     response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
 
@@ -237,7 +237,7 @@ def test_all_product_block_names(test_client, generic_product_4):
     products = products_data["page"]
     names = products[0]["allProductBlockNames"]
 
-    assert len(names) == 2
+    assert len(names) == 1
 
 
 def test_product_has_previous_page(test_client, generic_product_1, generic_product_2, generic_product_3):

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -237,7 +237,7 @@ def test_all_product_block_names(test_client, test_product_one_nested):
     products = products_data["page"]
     names = products[0]["allProductBlockNames"]
 
-    assert len(names) == 1
+    assert names == ["PB_Chained_1", "PB_Chained_2", "ProductBlockOneNestedForTest"]
 
 
 def test_product_has_previous_page(test_client, generic_product_1, generic_product_2, generic_product_3):


### PR DESCRIPTION
Renames the `all_pb_names` field in the `subscriptions` GQL query to `all_product_block_names`.

Closes #914 