### PR TITLE
Deprecate workflow_target in ProcessSubscriptionTable and store_process_subscription()

### DIFF
--- a/docs/architecture/application/workflow.md
+++ b/docs/architecture/application/workflow.md
@@ -36,7 +36,7 @@ def create_node_enrollment() -> StepList:
     return (
         begin
         >> construct_node_enrollment_model
-        >> store_process_subscription(Target.CREATE)
+        >> store_process_subscription()
         ...
         ...
         ...
@@ -82,7 +82,7 @@ def construct_node_enrollment_model(
 After that the the subscription is created and registered with the orchestrator:
 
 ```python
-    >> store_process_subscription(Target.CREATE)
+    >> store_process_subscription()
 ```
 
 The subsequent steps are the actual logic being executed by the workflow. It's a best practice to have each step execute one discrete operation so in case a step fails it can be restarted. To wit if a step contained:

--- a/docs/architecture/product_modelling/imports.md
+++ b/docs/architecture/product_modelling/imports.md
@@ -40,7 +40,7 @@ def create_imported_node() -> StepList:
     return (
         begin
         >> create_subscription
-        >> store_process_subscription(Target.CREATE)
+        >> store_process_subscription()
         >> initialize_subscription
     )
 ```

--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -163,7 +163,7 @@ def create_l2vpn() -> StepList:
     return (
         begin
         >> construct_model
-        >> store_process_subscription(Target.CREATE)
+        >> store_process_subscription()
         >> callback_interaction(call_ansible_playbook)
         >> set_status(SubscriptionLifecycle.ACTIVE)
     )

--- a/docs/workshops/beginner/create-user-group.md
+++ b/docs/workshops/beginner/create-user-group.md
@@ -8,7 +8,7 @@ UserGroup product. This is done by executing the following workflow steps:
 ```python
 init
 >> create_subscription
->> store_process_subscription(Target.CREATE)
+>> store_process_subscription()
 >> initialize_subscription
 >> provision_user_group
 >> set_status(SubscriptionLifecycle.ACTIVE)

--- a/docs/workshops/beginner/create-user.md
+++ b/docs/workshops/beginner/create-user.md
@@ -9,7 +9,7 @@ initialize the subscription. This workflow uses the following steps:
 ```python
 init
 >> create_subscription
->> store_process_subscription(Target.CREATE)
+>> store_process_subscription()
 >> initialize_subscription
 >> provision_user
 >> set_status(SubscriptionLifecycle.ACTIVE)

--- a/docs/workshops/beginner/modify-user-group.md
+++ b/docs/workshops/beginner/modify-user-group.md
@@ -8,7 +8,7 @@ used:
 
 ```python
 init
->> store_process_subscription(Target.MODIFY)
+>> store_process_subscription()
 >> unsync
 >> modify_user_group_subscription
 >> resync

--- a/docs/workshops/beginner/modify-user.md
+++ b/docs/workshops/beginner/modify-user.md
@@ -8,7 +8,7 @@ This workflow uses the following steps:
 
 ```python
 init
->> store_process_subscription(Target.MODIFY)
+>> store_process_subscription()
 >> unsync
 >> modify_user_subscription
 >> resync

--- a/docs/workshops/beginner/terminate-user-group.md
+++ b/docs/workshops/beginner/terminate-user-group.md
@@ -8,7 +8,7 @@ customer, releasing all provisioned resources.  The terminate workflow for the
 
 ```python
 init
->> store_process_subscription(Target.TERMINATE)
+>> store_process_subscription()
 >> unsync
 >> deprovision_user_group
 >> set_status(SubscriptionLifecycle.TERMINATED)

--- a/docs/workshops/beginner/terminate-user.md
+++ b/docs/workshops/beginner/terminate-user.md
@@ -9,7 +9,7 @@ steps:
 
 ```python
 init
->> store_process_subscription(Target.TERMINATE)
+>> store_process_subscription()
 >> unsync
 >> deprovision_user
 >> set_status(SubscriptionLifecycle.TERMINATED)

--- a/orchestrator/cli/generator/templates/create_product.j2
+++ b/orchestrator/cli/generator/templates/create_product.j2
@@ -11,7 +11,6 @@ from pydantic_forms.types import FormGenerator, State, UUIDstr
 
 from orchestrator.forms import FormPage
 from orchestrator.forms.validators import Divider, Label, CustomerId, MigrationSummary
-from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
@@ -119,6 +118,6 @@ def create_{{ product.variable }}() -> StepList:
     return (
         begin
         >> construct_{{ product.variable }}_model
-        >> store_process_subscription(Target.CREATE)
+        >> store_process_subscription()
         # TODO add provision step(s)
     )

--- a/orchestrator/db/models.py
+++ b/orchestrator/db/models.py
@@ -154,7 +154,9 @@ class ProcessSubscriptionTable(BaseModel):
     )
     subscription_id = mapped_column(UUIDType, ForeignKey("subscriptions.subscription_id"), nullable=False, index=True)
     created_at = mapped_column(UtcTimestamp, server_default=text("current_timestamp()"), nullable=False)
-    workflow_target = mapped_column(String(255), nullable=False, server_default=Target.CREATE)
+
+    # FIXME: workflow_target is already stored in the workflow table, this column should get removed in a later release.
+    workflow_target = mapped_column(String(255), nullable=True)
 
     process = relationship("ProcessTable", back_populates="process_subscriptions")
     subscription = relationship("SubscriptionTable", back_populates="processes")

--- a/orchestrator/migrations/versions/schema/2025-07-04_4b58e336d1bf_deprecating_workflow_target_in_.py
+++ b/orchestrator/migrations/versions/schema/2025-07-04_4b58e336d1bf_deprecating_workflow_target_in_.py
@@ -1,0 +1,30 @@
+"""Deprecating workflow target in ProcessSubscriptionTable.
+
+Revision ID: 4b58e336d1bf
+Revises: 161918133bec
+Create Date: 2025-07-04 15:27:23.814954
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4b58e336d1bf"
+down_revision = "161918133bec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("processes_subscriptions", "workflow_target", existing_type=sa.VARCHAR(length=255), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "processes_subscriptions",
+        "workflow_target",
+        existing_type=sa.VARCHAR(length=255),
+        nullable=False,
+        existing_server_default=sa.text("'CREATE'::character varying"),
+    )

--- a/orchestrator/utils/enrich_process.py
+++ b/orchestrator/utils/enrich_process.py
@@ -103,7 +103,7 @@ def enrich_process(process: ProcessTable, p_stat: ProcessStat | None = None) -> 
         "is_task": process.is_task,
         "workflow_id": process.workflow_id,
         "workflow_name": process.workflow.name,
-        "workflow_target": process.process_subscriptions[0].workflow_target if process.process_subscriptions else None,
+        "workflow_target": process.workflow.target,
         "failed_reason": process.failed_reason,
         "created_by": process.created_by,
         "started_at": process.started_at,

--- a/orchestrator/workflows/modify_note.py
+++ b/orchestrator/workflows/modify_note.py
@@ -53,4 +53,4 @@ def store_subscription_note(subscription_id: UUIDstr, note: str) -> State:
 
 @workflow("Modify Note", initial_input_form=wrap_modify_initial_input_form(initial_input_form), target=Target.MODIFY)
 def modify_note() -> StepList:
-    return init >> store_process_subscription(Target.MODIFY) >> store_subscription_note >> done
+    return init >> store_process_subscription() >> store_subscription_note >> done

--- a/orchestrator/workflows/steps.py
+++ b/orchestrator/workflows/steps.py
@@ -108,20 +108,23 @@ def unsync_unchecked(subscription_id: UUIDstr) -> State:
     return {"subscription": subscription}
 
 
-def store_process_subscription_relationship(
-    process_id: UUIDstr, subscription_id: UUIDstr, workflow_target: str
-) -> ProcessSubscriptionTable:
-    process_subscription = ProcessSubscriptionTable(
-        process_id=process_id, subscription_id=subscription_id, workflow_target=workflow_target
-    )
+def store_process_subscription_relationship(process_id: UUIDstr, subscription_id: UUIDstr) -> ProcessSubscriptionTable:
+    process_subscription = ProcessSubscriptionTable(process_id=process_id, subscription_id=subscription_id)
     db.session.add(process_subscription)
     return process_subscription
 
 
-def store_process_subscription(workflow_target: Target) -> Step:
+def store_process_subscription(workflow_target: Target | None = None) -> Step:
+    if workflow_target:
+        deprecation_warning = (
+            "Providing a workflow target to function store_process_subscription() is deprecated. "
+            "This information is already stored in the workflow table."
+        )
+        logger.warning(deprecation_warning)
+
     @step("Create Process Subscription relation")
     def _store_process_subscription(process_id: UUIDstr, subscription_id: UUIDstr) -> None:
-        store_process_subscription_relationship(process_id, subscription_id, workflow_target)
+        store_process_subscription_relationship(process_id, subscription_id)
 
     return _store_process_subscription
 

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -265,7 +265,7 @@ def modify_workflow(
     def _modify_workflow(f: Callable[[], StepList]) -> Workflow:
         steplist = (
             init
-            >> store_process_subscription(Target.MODIFY)
+            >> store_process_subscription()
             >> unsync
             >> f()
             >> (additional_steps or StepList())
@@ -311,7 +311,7 @@ def terminate_workflow(
     def _terminate_workflow(f: Callable[[], StepList]) -> Workflow:
         steplist = (
             init
-            >> store_process_subscription(Target.TERMINATE)
+            >> store_process_subscription()
             >> unsync
             >> f()
             >> (additional_steps or StepList())
@@ -348,7 +348,7 @@ def validate_workflow(description: str) -> Callable[[Callable[[], StepList]], Wo
     """
 
     def _validate_workflow(f: Callable[[], StepList]) -> Workflow:
-        steplist = init >> store_process_subscription(Target.SYSTEM) >> unsync_unchecked >> f() >> resync >> done
+        steplist = init >> store_process_subscription() >> unsync_unchecked >> f() >> resync >> done
 
         return make_workflow(f, description, validate_initial_input_form_generator, Target.VALIDATE, steplist)
 

--- a/test/acceptance_tests/fixtures/test_orchestrator/workflows/create_test_product.py
+++ b/test/acceptance_tests/fixtures/test_orchestrator/workflows/create_test_product.py
@@ -19,7 +19,6 @@ from pydantic import ConfigDict
 from structlog import get_logger
 
 from orchestrator.forms.validators import CustomerId
-from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, done, step, workflow
 from orchestrator.workflows.steps import store_process_subscription
@@ -81,4 +80,4 @@ def construct_subscription_model(
 
 @workflow("Create a test product", initial_input_form=wrap_create_initial_input_form(initial_input_form_generator))
 def create_test_product() -> StepList:
-    return begin >> construct_subscription_model >> store_process_subscription(Target.CREATE) >> done
+    return begin >> construct_subscription_model >> store_process_subscription() >> done

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -439,7 +439,7 @@ def test_processes_filterable_response_model(
         "current_state": None,
         "steps": None,
         "form": None,
-        "workflow_target": "CREATE",
+        "workflow_target": "SYSTEM",
     }
 
 

--- a/test/unit_tests/cli/data/generate/workflows/example1/create_example1.py
+++ b/test/unit_tests/cli/data/generate/workflows/example1/create_example1.py
@@ -4,7 +4,6 @@ import structlog
 from orchestrator.domain import SubscriptionModel
 from orchestrator.forms import FormPage
 from orchestrator.forms.validators import CustomerId, Divider, Label
-from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
@@ -105,6 +104,6 @@ additional_steps = begin
 @create_workflow("Create example1", initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example1() -> StepList:
     return (
-        begin >> construct_example1_model >> store_process_subscription(Target.CREATE)
+        begin >> construct_example1_model >> store_process_subscription()
         # TODO add provision step(s)
     )

--- a/test/unit_tests/cli/data/generate/workflows/example2/create_example2.py
+++ b/test/unit_tests/cli/data/generate/workflows/example2/create_example2.py
@@ -2,7 +2,6 @@ import structlog
 from orchestrator.domain import SubscriptionModel
 from orchestrator.forms import FormPage
 from orchestrator.forms.validators import CustomerId, Divider, Label
-from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
@@ -74,6 +73,6 @@ additional_steps = begin
 @create_workflow("Create example2", initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example2() -> StepList:
     return (
-        begin >> construct_example2_model >> store_process_subscription(Target.CREATE)
+        begin >> construct_example2_model >> store_process_subscription()
         # TODO add provision step(s)
     )

--- a/test/unit_tests/cli/data/generate/workflows/example4/create_example4.py
+++ b/test/unit_tests/cli/data/generate/workflows/example4/create_example4.py
@@ -2,7 +2,6 @@ import structlog
 from orchestrator.domain import SubscriptionModel
 from orchestrator.forms import FormPage
 from orchestrator.forms.validators import CustomerId, Divider, Label
-from orchestrator.targets import Target
 from orchestrator.types import SubscriptionLifecycle
 from orchestrator.workflow import StepList, begin, step
 from orchestrator.workflows.steps import store_process_subscription
@@ -73,6 +72,6 @@ additional_steps = begin
 @create_workflow("Create example4", initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example4() -> StepList:
     return (
-        begin >> construct_example4_model >> store_process_subscription(Target.CREATE)
+        begin >> construct_example4_model >> store_process_subscription()
         # TODO add provision step(s)
     )

--- a/test/unit_tests/fixtures/processes.py
+++ b/test/unit_tests/fixtures/processes.py
@@ -26,7 +26,7 @@ def test_workflow(generic_subscription_1: UUIDstr, generic_product_type_1) -> Ge
 
     @step("Test that it is a string now")
     def check_object(subscription_id: Any, model: dict) -> None:
-        # This is actually a test. It would be nicer to have this in a proper test but that takes to much setup that
+        # This is actually a test. It would be nicer to have this in a proper test but that takes too much setup that
         # already happens here. So we hijack this fixture and run this test for all tests that use this fixture
         # (which should not be an issue)
         assert isinstance(subscription_id, str)


### PR DESCRIPTION
Closes #974

Workflow target is fetched from the workflow table, and the equivalent column in the `ProcessSubscription` table is now deprecated.

It is now deprecated to call `store_process_subscription()` with a target parameter.