### PR TITLE
Add unit tests for thread and celery executors

### DIFF
--- a/orchestrator/api/api_v1/endpoints/processes.py
+++ b/orchestrator/api/api_v1/endpoints/processes.py
@@ -48,6 +48,7 @@ from orchestrator.services.processes import (
     _async_resume_processes,
     _get_process,
     abort_process,
+    can_be_resumed,
     continue_awaiting_process,
     load_process,
     resume_process,
@@ -118,16 +119,6 @@ def get_auth_callbacks(steps: StepList, workflow: Workflow) -> tuple[Authorizer 
         filter(None, (step.retry_auth_callback or step.resume_auth_callback for step in steps)), auth_retry
     )
     return auth_resume, auth_retry
-
-
-def can_be_resumed(status: ProcessStatus) -> bool:
-    return status in (
-        ProcessStatus.SUSPENDED,  # Can be resumed
-        ProcessStatus.WAITING,  # Can be retried
-        ProcessStatus.FAILED,  # Can be retried
-        ProcessStatus.API_UNAVAILABLE,  # subtype of FAILED
-        ProcessStatus.INCONSISTENT_DATA,  # subtype of FAILED
-    )
 
 
 def resolve_user_name(

--- a/orchestrator/services/executors/__init__.py
+++ b/orchestrator/services/executors/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2019-2020 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/orchestrator/services/tasks.py
+++ b/orchestrator/services/tasks.py
@@ -94,13 +94,13 @@ def initialise_celery(celery: Celery) -> None:  # noqa: C901
     celery_task = partial(celery.task, log=local_logger, serializer="orchestrator-json")
 
     @celery_task(name=NEW_TASK)  # type: ignore
-    def new_task(process_id: UUID, workflow_key: str, user: str) -> UUID | None:
-        local_logger.info("Start task", process_id=process_id, workflow_key=workflow_key)
+    def new_task(process_id: UUID, user: str) -> UUID | None:
+        local_logger.info("Start task", process_id=process_id)
         return start_process(process_id, user=user)
 
     @celery_task(name=NEW_WORKFLOW)  # type: ignore
-    def new_workflow(process_id: UUID, workflow_key: str, user: str) -> UUID | None:
-        local_logger.info("Start workflow", process_id=process_id, workflow_key=workflow_key)
+    def new_workflow(process_id: UUID, user: str) -> UUID | None:
+        local_logger.info("Start workflow", process_id=process_id)
         return start_process(process_id, user=user)
 
     @celery_task(name=RESUME_TASK)  # type: ignore

--- a/test/unit_tests/api/test_processes.py
+++ b/test/unit_tests/api/test_processes.py
@@ -19,7 +19,7 @@ from orchestrator.db import (
     db,
 )
 from orchestrator.security import authenticate
-from orchestrator.services.processes import shutdown_thread_pool
+from orchestrator.services.processes import RESUME_WORKFLOW_REMOVED_ERROR_MSG, can_be_resumed, shutdown_thread_pool
 from orchestrator.services.settings import get_engine_settings
 from orchestrator.settings import app_settings
 from orchestrator.targets import Target
@@ -372,23 +372,15 @@ def test_resume_with_incorrect_workflow_status(test_client, started_process):
     assert process_info_after["last_status"] == "running"
 
 
-def test_try_resume_completed_workflow(test_client, started_process):
-    process = db.session.get(ProcessTable, started_process)
-    assert process
-    # setup DB so it looks like this workflow is already completed
-    process.last_status = ProcessStatus.COMPLETED
-    process.failed_reason = ""
-    db.session.commit()
-
-    response = test_client.put(f"/api/processes/{started_process}/resume", json=[{}])
-    assert 409 == response.status_code
-
-
-def test_try_resume_resumed_workflow(test_client, started_process):
+@pytest.mark.parametrize(
+    "process_status",
+    [status for status in ProcessStatus if not can_be_resumed(status)],
+)
+def test_try_resume_workflow_with_incorrect_status(test_client, started_process, process_status):
     process = db.session.get(ProcessTable, started_process)
     assert process
     # setup DB so it looks like this workflow has already been resumed
-    process.last_status = ProcessStatus.RESUMED
+    process.last_status = process_status
     process.failed_reason = ""
     db.session.add(process)
     db.session.commit()
@@ -517,7 +509,7 @@ def test_resume_all_processes_value_error(test_client, mocked_processes_resumeal
     with mock.patch("orchestrator.services.processes.resume_process") as mocked_resume:
         mocked_resume.side_effect = [
             None,
-            ValueError("This workflow cannot be resumed because it has been removed"),
+            ValueError(RESUME_WORKFLOW_REMOVED_ERROR_MSG),
             None,
         ]
         response = test_client.put("/api/processes/resume-all")

--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -127,6 +127,11 @@ from test.unit_tests.fixtures.products.resource_types import (  # noqa: F401
     resource_type_list,
     resource_type_str,
 )
+from test.unit_tests.fixtures.workflows import (  # noqa: F401
+    mock_pstat_with_removed_workflow,
+    sample_workflow,
+    sample_workflow_with_suspend,
+)
 from test.unit_tests.workflows import WorkflowInstanceForTests
 from test.unit_tests.workflows.shared.test_validate_subscriptions import validation_workflow
 

--- a/test/unit_tests/fixtures/workflows.py
+++ b/test/unit_tests/fixtures/workflows.py
@@ -1,8 +1,89 @@
+from unittest.mock import MagicMock
+
 import pytest
 
+from orchestrator.config.assignee import Assignee
 from orchestrator.db import WorkflowTable, db
 from orchestrator.targets import Target
 from orchestrator.utils.datetime import nowtz
+from orchestrator.workflow import (
+    ProcessStat,
+    done,
+    init,
+    inputstep,
+    retrystep,
+    step,
+    workflow,
+)
+from orchestrator.workflows.removed_workflow import removed_workflow
+from pydantic_forms.core import FormPage
+
+
+@step("Step 1")
+def step1(test_field):
+    return {"steps": [1], "has_test_field": test_field}
+
+
+@step("Step 2")
+def step2(steps):
+    return {"steps": [*steps, 2]}
+
+
+@step("Step 3")
+def step3(steps):
+    return {"steps": [*steps, 3]}
+
+
+@inputstep("Input step", assignee=Assignee.SYSTEM)
+def input_step():
+    class TestForm(FormPage):
+        test_field_2: str
+
+    input = yield TestForm
+    return input.model_dump()
+
+
+@step("Input step")
+def check_input_data_step(test_field_2):
+    return {"has_test_field_2": test_field_2}
+
+
+@retrystep("Waiting step")
+def fail_retry_step():
+    raise ValueError("Failure Message")
+
+
+@step("Fail")
+def fail_step():
+    raise ValueError("Failure Message")
+
+
+def initial_input_form():
+    class TestForm(FormPage):
+        test_field: str
+
+    input = yield TestForm
+    return input.model_dump()
+
+
+@workflow("Sample workflow", initial_input_form=initial_input_form)
+def _sample_workflow():
+    return init >> step1 >> step2 >> step3 >> done
+
+
+@pytest.fixture
+def sample_workflow():
+    return _sample_workflow
+
+
+@workflow("Sample workflow with suspend", initial_input_form=initial_input_form)
+def _sample_workflow_with_suspend():
+    return init >> step1 >> input_step >> check_input_data_step >> done
+
+
+@pytest.fixture
+def sample_workflow_with_suspend():
+    return _sample_workflow_with_suspend
 
 
 @pytest.fixture
@@ -20,3 +101,10 @@ def add_soft_deleted_workflows():
         db.session.commit()
 
     return _add_soft_deleted_workflow
+
+
+@pytest.fixture()
+def mock_pstat_with_removed_workflow():
+    pstat = MagicMock(spec=ProcessStat)
+    pstat.workflow = removed_workflow
+    return pstat

--- a/test/unit_tests/services/executors/test_celery.py
+++ b/test/unit_tests/services/executors/test_celery.py
@@ -1,0 +1,119 @@
+from unittest import mock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from kombu.exceptions import ConnectionError
+
+from orchestrator.db.models import ProcessTable
+from orchestrator.services.executors.celery import (
+    _celery_resume_process,
+    _celery_set_process_status_resumed,
+    _celery_start_process,
+)
+from orchestrator.services.processes import RESUMABLE_STATUSES
+from orchestrator.services.tasks import NEW_TASK, RESUME_WORKFLOW
+from orchestrator.workflow import ProcessStatus
+
+
+@mock.patch("orchestrator.services.tasks.get_celery_task")
+@mock.patch("orchestrator.services.executors.celery.get_workflow_by_name")
+@mock.patch("orchestrator.services.executors.celery.delete_process")
+@mock.patch("orchestrator.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
+def test_celery_start_process(mock_db, mock_delete_process, mock_get_workflow_by_name, mock_get_celery_task):
+    pstat = MagicMock()
+    trigger_task = MagicMock()
+
+    delay_result = MagicMock()
+    delay_result.get = MagicMock()
+    delay_result.get.return_value = uuid4()
+
+    trigger_task.delay.return_value = delay_result
+    mock_get_celery_task.return_value = trigger_task
+
+    process_id = _celery_start_process(pstat)
+
+    assert process_id == pstat.process_id
+    mock_get_celery_task.assert_called_once_with(NEW_TASK)
+    trigger_task.delay.assert_called_once()
+    mock_get_workflow_by_name.assert_called_once()
+
+
+@mock.patch("orchestrator.services.tasks.get_celery_task")
+@mock.patch("orchestrator.services.executors.celery.get_workflow_by_name")
+@mock.patch("orchestrator.services.executors.celery.delete_process")
+@mock.patch("orchestrator.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
+def test_celery_start_process_connection_error_should_delete_process(
+    mock_db, mock_delete_process, mock_get_workflow_by_name, mock_get_celery_task
+):
+    pstat = MagicMock()
+    trigger_task = MagicMock()
+
+    def raise_connection_error(x, y):
+        raise ConnectionError()
+
+    trigger_task.delay = raise_connection_error
+
+    mock_get_celery_task.return_value = trigger_task
+
+    with pytest.raises(ConnectionError):
+        _celery_start_process(pstat)
+
+    mock_delete_process.assert_called_once_with(pstat.process_id)
+    mock_get_workflow_by_name.assert_called_once()
+
+
+@mock.patch("orchestrator.services.tasks.get_celery_task")
+@mock.patch("orchestrator.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
+def test_celery_resume_process(mock_db, mock_get_celery_task):
+    process = MagicMock()
+    process.last_status = ProcessStatus.FAILED
+    process.workflow.is_task = False
+    trigger_task = MagicMock()
+
+    delay_result = MagicMock()
+    delay_result.get = MagicMock()
+    delay_result.get.return_value = uuid4()
+
+    trigger_task.delay.return_value = delay_result
+    mock_get_celery_task.return_value = trigger_task
+
+    process_id = _celery_resume_process(process)
+
+    assert process_id == process.process_id
+    mock_get_celery_task.assert_called_once_with(RESUME_WORKFLOW)
+    trigger_task.delay.assert_called_once()
+    assert process.last_status == ProcessStatus.RESUMED
+
+
+@mock.patch("orchestrator.services.tasks.get_celery_task")
+@mock.patch("orchestrator.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
+def test_celery_resume_process_connection_error_should_revert_process_status(mock_db, mock_get_celery_task):
+    process = MagicMock()
+    process.last_status = ProcessStatus.FAILED
+
+    trigger_task = MagicMock()
+
+    def raise_connection_error(x, y):
+        raise ConnectionError()
+
+    trigger_task.delay = raise_connection_error
+
+    mock_get_celery_task.return_value = trigger_task
+
+    with pytest.raises(ConnectionError):
+        _celery_resume_process(process)
+
+    assert process.last_status == ProcessStatus.FAILED
+
+
+@mock.patch("orchestrator.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
+@pytest.mark.parametrize(
+    "process_status,expected_status",
+    [(status, status if status not in RESUMABLE_STATUSES else ProcessStatus.RESUMED) for status in ProcessStatus],
+)
+def test_celery_set_process_status_resumed_valid_statuses(mock_db, process_status, expected_status):
+    process = MagicMock(spec=ProcessTable)
+    process.last_status = process_status
+    _celery_set_process_status_resumed(process)
+    assert process.last_status == expected_status

--- a/test/unit_tests/services/executors/test_threadpool.py
+++ b/test/unit_tests/services/executors/test_threadpool.py
@@ -1,0 +1,151 @@
+from unittest import mock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orchestrator.db import ProcessTable
+from orchestrator.db.models import InputStateTable
+from orchestrator.services.executors.threadpool import (
+    thread_resume_process,
+    thread_start_process,
+)
+from orchestrator.services.processes import RESUME_WORKFLOW_REMOVED_ERROR_MSG, START_WORKFLOW_REMOVED_ERROR_MSG
+from orchestrator.targets import Target
+from orchestrator.workflow import (
+    ProcessStat,
+    ProcessStatus,
+    Success,
+    make_workflow,
+    step,
+)
+
+
+def mock_process_data():
+    @step("test step")
+    def test_step():
+        pass
+
+    wf = make_workflow(lambda: None, "description", None, Target.SYSTEM, [test_step])
+    wf.name = "name"
+
+    process_id = uuid4()
+    initial_state_dict = {
+        "process_id": process_id,
+        "reporter": mock.sentinel.user,
+        "workflow_name": mock.sentinel.wf_name,
+        "workflow_target": Target.SYSTEM,
+    }
+    initial_state = Success(dict(initial_state_dict))
+    mock_update_pstat = MagicMock()
+    pstat = ProcessStat(process_id, wf, initial_state, wf.steps, current_user=mock.sentinel.user)
+    pstat.update = mock_update_pstat
+
+    process = MagicMock(spec=ProcessTable)
+    return pstat, process, wf, mock_update_pstat, initial_state_dict
+
+
+@mock.patch("orchestrator.services.executors.threadpool.db")
+@mock.patch("orchestrator.services.executors.threadpool._get_process")
+@mock.patch("orchestrator.services.executors.threadpool.retrieve_input_state")
+@mock.patch("orchestrator.services.executors.threadpool._run_process_async")
+@mock.patch("orchestrator.services.processes.get_workflow")
+def test_thread_start_process(
+    mock_get_workflow,
+    mock_run_process_async,
+    mock_retrieve_input_state,
+    mock_get_process,
+    mock_db,
+):
+    pstat, process, wf, mock_update_pstat, initial_state_dict = mock_process_data()
+
+    input_state = {"key": "value"}
+
+    mock_get_workflow.return_value = wf
+    mock_get_process.return_value = process
+    mock_db.return_value = MagicMock(session=MagicMock())
+    mock_retrieve_input_state.return_value = InputStateTable(
+        process_id=process.process_id, input_state=input_state, input_type="initial_state"
+    )
+
+    expected_updated_state = Success(initial_state_dict | input_state)
+
+    assert process.last_status != ProcessStatus.RUNNING
+
+    thread_start_process(pstat)
+
+    assert process.last_status == ProcessStatus.RUNNING
+    mock_retrieve_input_state.assert_called_once_with(mock.ANY, "initial_state")
+    mock_update_pstat.assert_called_once_with(state=expected_updated_state)
+    mock_run_process_async.assert_called_once()
+
+
+def test_thread_start_process_errors_workflow_removed(mock_pstat_with_removed_workflow):
+    with pytest.raises(ValueError, match=START_WORKFLOW_REMOVED_ERROR_MSG):
+        thread_start_process(mock_pstat_with_removed_workflow)
+
+
+@mock.patch("orchestrator.services.executors.threadpool.db")
+@mock.patch("orchestrator.services.executors.threadpool.retrieve_input_state")
+@mock.patch("orchestrator.services.executors.threadpool._run_process_async")
+@mock.patch("orchestrator.services.executors.threadpool.load_process")
+def test_thread_resume_process_suspended(
+    mock_load_process,
+    mock_run_process_async,
+    mock_retrieve_input_state,
+    mock_db,
+):
+    pstat, process, wf, mock_update_pstat, initial_state_dict = mock_process_data()
+    process.last_status = ProcessStatus.SUSPENDED
+    input_state = {"key": "value"}
+
+    mock_load_process.return_value = pstat
+    mock_db.return_value = MagicMock(session=MagicMock())
+    mock_retrieve_input_state.return_value = InputStateTable(
+        process_id=process.process_id, input_state=input_state, input_type="user_input"
+    )
+
+    expected_updated_state = Success(initial_state_dict | input_state)
+
+    assert process.last_status != ProcessStatus.RUNNING
+
+    thread_resume_process(process)
+
+    mock_retrieve_input_state.assert_called_once_with(process.process_id, "user_input")
+    mock_update_pstat.assert_called_once_with(state=expected_updated_state)
+    mock_run_process_async.assert_called_once()
+    assert process.last_status == ProcessStatus.RUNNING
+
+
+@mock.patch("orchestrator.services.executors.threadpool.db")
+@mock.patch("orchestrator.services.executors.threadpool.retrieve_input_state")
+@mock.patch("orchestrator.services.executors.threadpool._run_process_async")
+@mock.patch("orchestrator.services.executors.threadpool.load_process")
+def test_thread_resume_process_failed(
+    mock_load_process,
+    mock_run_process_async,
+    mock_retrieve_input_state,
+    mock_db,
+):
+    pstat, process, _, _, _ = mock_process_data()
+    process.last_status = ProcessStatus.FAILED
+
+    mock_load_process.return_value = pstat
+    mock_db.return_value = MagicMock(session=MagicMock())
+
+    assert process.last_status != ProcessStatus.RUNNING
+
+    thread_resume_process(process)
+
+    mock_retrieve_input_state.assert_not_called()
+    mock_run_process_async.assert_called_once()
+    assert process.last_status == ProcessStatus.RUNNING
+
+
+@mock.patch("orchestrator.services.executors.threadpool.load_process")
+def test_thread_resume_process_errors_workflow_removed(mock_load_process, mock_pstat_with_removed_workflow):
+    process = MagicMock()
+    mock_load_process.return_value = mock_pstat_with_removed_workflow
+
+    with pytest.raises(ValueError, match=RESUME_WORKFLOW_REMOVED_ERROR_MSG):
+        thread_resume_process(process)

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -10,16 +10,20 @@ import pytest
 from pydantic_i18n import PydanticI18n
 from sqlalchemy import select
 
+from orchestrator.api.error_handling import ProblemDetailException
 from orchestrator.config.assignee import Assignee
 from orchestrator.db import ProcessStepTable, ProcessTable, db
 from orchestrator.services.processes import (
+    RESUME_WORKFLOW_REMOVED_ERROR_MSG,
     SYSTEM_USER,
     _async_resume_processes,
     _db_create_process,
     _db_log_process_ex,
     _db_log_step,
+    _get_process,
     _run_process_async,
     load_process,
+    resume_process,
     safe_logstep,
     start_process,
 )
@@ -48,6 +52,7 @@ from orchestrator.workflow import (
 )
 from pydantic_forms.core.translations import translations
 from pydantic_forms.exceptions import FormValidationError
+from test.unit_tests.fixtures.workflows import initial_input_form, step1, step2
 from test.unit_tests.workflows import WorkflowInstanceForTests, run_workflow, store_workflow
 
 
@@ -720,7 +725,7 @@ def test_async_resume_processes(mock_resume_process, mock_get_process, caplog):
     mock_get_process.side_effect = processes
 
     # resume_process() should be called 2 times for the non-running / non-resumed processes; let 1 call fail
-    mock_resume_process.side_effect = [None, ValueError("This workflow cannot be resumed because it has been removed")]
+    mock_resume_process.side_effect = [None, ValueError(RESUME_WORKFLOW_REMOVED_ERROR_MSG)]
 
     # Don't set app_settings.TESTING=False because we want to await the result
     asyncio.run(_async_resume_processes(processes, "testusername"))
@@ -803,6 +808,7 @@ def test_run_process_async_exception(mock_db_log_process_ex):
 
 @mock.patch("orchestrator.services.executors.threadpool.db")
 @mock.patch("orchestrator.services.executors.threadpool._get_process")
+@mock.patch("orchestrator.services.executors.threadpool.retrieve_input_state")
 @mock.patch("orchestrator.services.processes.store_input_state")
 @mock.patch("orchestrator.services.executors.threadpool._run_process_async", return_value=(mock.sentinel.process_id))
 @mock.patch("orchestrator.services.processes._db_create_process")
@@ -814,6 +820,7 @@ def test_start_process(
     mock_db_create_process,
     mock_run_process_async,
     mock_store_input_state,
+    mock_retrieve_input_state,
     mock_get_process,
     mock_db,
 ):
@@ -839,6 +846,7 @@ def test_start_process(
         "workflow_target": Target.SYSTEM,
     }
     mock_store_input_state.assert_called_once_with(mock.ANY, initial_state, "initial_state")
+    mock_retrieve_input_state.assert_called_once_with(mock.ANY, "initial_state")
     pstat = mock_db_create_process.call_args[0][0]
     assert result == mock.sentinel.process_id
     assert pstat.current_user == mock.sentinel.user
@@ -862,9 +870,19 @@ def test_start_process(
         },
         [{"a": 2}],
     )
-    mock_get_workflow.assert_called_once_with(mock.sentinel.wf_name)
+    assert mock_get_workflow.call_count == 1
 
-    mock_post_form.reset_mock()
+
+@mock.patch("orchestrator.services.processes.post_form")
+@mock.patch("orchestrator.services.processes.get_workflow")
+def test_start_process_form_error(mock_get_workflow, mock_post_form):
+    @step("test step")
+    def test_step():
+        pass
+
+    wf = make_workflow(lambda: None, "description", None, Target.SYSTEM, [test_step])
+    wf.name = "name"
+    mock_get_workflow.return_value = wf
 
     class MockEmptyValidationError:
         def errors(self):
@@ -887,14 +905,89 @@ def test_start_process(
     )
 
 
-@step("Step 1")
-def step1():
-    return {"value": 1}
+@mock.patch("orchestrator.services.processes.get_workflow")
+def test_start_process_workflow_removed(mock_get_workflow):
+    mock_get_workflow.return_value = None
+
+    with pytest.raises(ProblemDetailException, match=r"Workflow does not exist"):
+        start_process(mock.sentinel.wf_name, None, mock.sentinel.user)
 
 
-@step("Step 2")
-def step2():
-    return {"value": 2}
+@mock.patch("orchestrator.services.processes.post_form")
+@mock.patch("orchestrator.services.processes.load_process")
+@mock.patch("orchestrator.services.processes.store_input_state")
+@mock.patch("orchestrator.services.processes.get_execution_context")
+def test_resume_process(mock_get_execution_context, mock_store_input_state, mock_load_process, mock_post_form):
+    wf = workflow("Workflow")(lambda: init >> step1 >> step2)
+    process_id = uuid4()
+    state = Waiting({"steps": [1]})
+    pstat = ProcessStat(process_id, wf, state, wf.steps[1:], current_user="user")
+    process = ProcessTable(
+        process_id=process_id,
+        workflow_id=uuid4(),
+        last_status=ProcessStatus.SUSPENDED,
+        created_by=SYSTEM_USER,
+    )
+    user_input = {"a": 5}
+
+    mock_load_process.return_value = pstat
+    mock_post_form.return_value = user_input
+
+    resume_fn = MagicMock()
+    mock_get_execution_context.return_value = {"resume": resume_fn}
+
+    process_id = resume_process(process, user_inputs=[user_input], user=mock.sentinel.user)
+
+    mock_post_form.assert_called_once_with(
+        mock.ANY,
+        state.unwrap(),
+        user_inputs=[{"a": 5}],
+    )
+    mock_store_input_state.assert_called_once_with(mock.ANY, user_input, "user_input")
+    resume_fn.assert_called_once_with(process, user=mock.sentinel.user, broadcast_func=None)
+
+
+@mock.patch("orchestrator.services.processes.post_form")
+@mock.patch("orchestrator.services.processes.load_process")
+def test_resume_process_form_error(mock_load_process, mock_post_form):
+    wf = workflow("Workflow")(lambda: init >> step1 >> step2)
+    process_id = uuid4()
+    state = Waiting({"steps": [1]})
+    pstat = ProcessStat(process_id, wf, state, wf.steps[1:], current_user="user")
+    process = ProcessTable(
+        process_id=process_id,
+        workflow_id=uuid4(),
+        last_status=ProcessStatus.SUSPENDED,
+        created_by=SYSTEM_USER,
+    )
+
+    mock_load_process.return_value = pstat
+
+    class MockEmptyValidationError:
+        def errors(self):
+            return []
+
+    tr = PydanticI18n(translations)
+    mock_post_form.side_effect = FormValidationError("", MockEmptyValidationError(), tr=tr)
+
+    with pytest.raises(FormValidationError):
+        resume_process(process, user_inputs=None, user=mock.sentinel.user)
+
+    mock_post_form.assert_called_once_with(
+        mock.ANY,
+        state.unwrap(),
+        user_inputs=[{}],
+    )
+
+
+@mock.patch("orchestrator.services.processes.load_process")
+def test_resume_process_workflow_removed(mock_load_process, mock_pstat_with_removed_workflow):
+    process = MagicMock(spec=ProcessTable)
+    process.last_status = ProcessStatus.SUSPENDED
+    mock_load_process.return_value = mock_pstat_with_removed_workflow
+
+    with pytest.raises(ValueError, match=RESUME_WORKFLOW_REMOVED_ERROR_MSG):
+        resume_process(process, user_inputs=None, user=mock.sentinel.user)
 
 
 def get_step_names(process):
@@ -911,10 +1004,12 @@ def get_step_names(process):
     ],
 )
 def test_load_process_with_altered_steps(num_steps_finished, step_names):
+    workflow_decorator = workflow("Test wf", initial_input_form=initial_input_form)
 
     # Run original workflow with 3 steps
-    with WorkflowInstanceForTests(workflow("Test wf")(lambda: init >> step1 >> done), "test_wf"):
-        _, p_stat, steps = run_workflow("test_wf", [{}])
+    workflow_1 = workflow_decorator(lambda: init >> step1 >> done)
+    with WorkflowInstanceForTests(workflow_1, "test_wf"):
+        _, p_stat, steps = run_workflow("test_wf", [{"test_field": "test"}])
         process_table = db.session.get(ProcessTable, p_stat.process_id)
 
         for step_fn, wf_process in steps[:num_steps_finished]:
@@ -928,11 +1023,42 @@ def test_load_process_with_altered_steps(num_steps_finished, step_names):
         assert get_step_names(process) == step_names[0]
 
     # Load process for workflow with step added at the end
-    with WorkflowInstanceForTests(workflow("Test wf")(lambda: init >> step1 >> step2 >> done), "test_wf"):
+    workflow_2 = workflow_decorator(lambda: init >> step1 >> step2 >> done)
+    with WorkflowInstanceForTests(workflow_2, "test_wf"):
         process = load_process(process_table)
         assert get_step_names(process) == step_names[1]
 
     # Load process for workflow with step removed at the end
-    with WorkflowInstanceForTests(workflow("Test wf")(lambda: init >> done), "test_wf"):
+    workflow_3 = workflow_decorator(lambda: init >> done)
+    with WorkflowInstanceForTests(workflow_3, "test_wf"):
         process = load_process(process_table)
         assert get_step_names(process) == step_names[2]
+
+
+def run_sync(process_id, fn):
+    fn()
+    return process_id
+
+
+@mock.patch("orchestrator.services.processes._run_process_async")
+def test_start_process_full_happy_flow(mock_run_process_async, sample_workflow):
+    mock_run_process_async.side_effect = run_sync
+    with mock.patch.object(db.session, "rollback"):
+        with WorkflowInstanceForTests(sample_workflow, "sample_workflow"):
+            process_id = start_process("sample_workflow", user_inputs=[{"test_field": "test input"}])
+            process = _get_process(process_id)
+            print(process.steps)
+            assert process.last_status == ProcessStatus.COMPLETED
+
+
+@mock.patch("orchestrator.services.processes._run_process_async")
+def test_resume_process_full_happy_flow(mock_run_process_async, sample_workflow_with_suspend):
+    mock_run_process_async.side_effect = run_sync
+    with mock.patch.object(db.session, "rollback"):
+        with WorkflowInstanceForTests(sample_workflow_with_suspend, "sample_workflow"):
+            process_id = start_process("sample_workflow", user_inputs=[{"test_field": "test input"}])
+            process = _get_process(process_id)
+            assert process.last_status == ProcessStatus.SUSPENDED
+            resume_process(process, user_inputs=[{"test_field_2": "test input 2"}])
+            process = _get_process(process_id)
+            assert process.last_status == ProcessStatus.COMPLETED


### PR DESCRIPTION
- add 2 tests that validate the happy flow of start_process and resume_process.
- add unit tests for resume_process.
- improve unit tests for start_process.
- move can_be_resumed from api/processes.py to services/processes.py.
- improve workflow removed error messages.
- revert resume_process incorrect return type.
- add can_be_resumed check in _celery_set_process_status_resumed so only correct statuses can be changed.
- add process status check in thread_resume_process to only retrieve input state on suspended status.
- change api resume workflow with incorrect status test to check all incorrect statuses.
- update task_resume_workflow tests.