### PR TITLE
Fix: Retrieve latest input state instead of oldest

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.0rc2
+current_version = 4.3.0rc3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/.github/workflows/run-codspeed-tests.yml
+++ b/.github/workflows/run-codspeed-tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run benchmarks
     runs-on: ubuntu-latest
     container:
-      image: python:3.13
+      image: python:3.13-bookworm
       options: --privileged
     services:
       postgres:

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -13,7 +13,7 @@
 
 """This is the orchestrator workflow engine."""
 
-__version__ = "4.3.0rc2"
+__version__ = "4.3.0rc3"
 
 from orchestrator.app import OrchestratorCore
 from orchestrator.settings import app_settings

--- a/orchestrator/services/input_state.py
+++ b/orchestrator/services/input_state.py
@@ -41,7 +41,7 @@ def retrieve_input_state(process_id: UUID, input_type: InputType, raise_exceptio
         select(InputStateTable)
         .filter(InputStateTable.process_id == process_id)
         .filter(InputStateTable.input_type == input_type)
-        .order_by(InputStateTable.input_time.asc())
+        .order_by(InputStateTable.input_time.desc())
     ).first()
 
     if res:

--- a/test/unit_tests/services/test_input_state.py
+++ b/test/unit_tests/services/test_input_state.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
@@ -60,3 +61,21 @@ def test_store_input_state(completed_process):
 
     states = InputStateTable.query.all()
     assert len(states) == 2
+
+
+def test_retrieve_latest_input_state(completed_process):
+    process_id, _ = completed_process
+
+    user_input_1 = InputStateTable(process_id=process_id, input_state={"first": "input"}, input_type="user_input")
+    user_input_2 = InputStateTable(
+        process_id=process_id,
+        input_state={"second": "input"},
+        input_type="user_input",
+        input_time=(datetime.now(timezone.utc) + timedelta(hours=1)),
+    )
+
+    db.session.add(user_input_1)
+    db.session.add(user_input_2)
+    db.session.commit()
+    retrieved_state = retrieve_input_state(process_id, "user_input")
+    assert retrieved_state == user_input_2


### PR DESCRIPTION
Discovered an issue where a `resume` action inserts an empty `user_input` dict into the DB `input_states`.  


If a workflow step fails before an `inputstep` and is resumed, it adds an empty dict `user_input` to the input state table.  
When it succeeds and later reaches the `inputstep` and you fill it in and submit, it adds the user_input into the DB as a new entry and resumes the step.  
The worker tries to pick up the workflow but raises an error that a required formfield is missing, because the oldest `user_input` is fetched from the DB.
This would also happen when a workflow has multiple input steps.

follow up ticket to improve `input_states`: [[Improvement]: Add `step_name` to the `input_states` table for type `user_input`](https://github.com/workfloworchestrator/orchestrator-core/issues/1033)