### PR TITLE
New reconcile workflow decorator for subscription synchronization with external systems

### DIFF
--- a/docs/architecture/application/workflow.md
+++ b/docs/architecture/application/workflow.md
@@ -71,6 +71,9 @@ Workflows are categorized based on the operations they perform on a subscription
 - Validate ([validate_workflow])
     - Verifies that external systems are consistent with the orchestrator's subscription state.
     - Only one validate workflow should exist per product.
+- Reconcile ([reconcile_workflow])
+    - Ensures that the orchestrator's subscription state is in sync with external systems.
+    - Only one reconcile workflow should exist per product.
 
 
 ### Default Workflows
@@ -187,6 +190,7 @@ Now this particular modify workflow can be run on subscriptions that are not in 
 [modify_workflow]: ../reference-docs/workflows/workflows.md#orchestrator.workflows.utils.modify_workflow
 [terminate_workflow]: ../reference-docs/workflows/workflows.md#orchestrator.workflows.utils.terminate_workflow
 [validate_workflow]: ../reference-docs/workflows/workflows.md#orchestrator.workflows.utils.validate_workflow
+[reconcile_workflow]: ../reference-docs/workflows/workflows.md#orchestrator.workflows.utils.reconcile_workflow
 [functional docs for step]: ../../reference-docs/workflows/workflow-steps.md#orchestrator.workflow.step
 [functional docs for retrystep]: ../../reference-docs/workflows/workflow-steps.md#orchestrator.workflow.retrystep
 [functional docs for inputstep]: ../../reference-docs/workflows/workflow-steps.md#orchestrator.workflow.inputstep

--- a/docs/reference-docs/workflows/workflows.md
+++ b/docs/reference-docs/workflows/workflows.md
@@ -18,6 +18,7 @@ To see more details about the workflow lifecycle states and functions, read on t
         - modify_workflow
         - terminate_workflow
         - validate_workflow
+        - reconcile_workflow
         - workflow
 
 ::: orchestrator.workflow.workflow

--- a/orchestrator/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/api/api_v1/endpoints/subscriptions.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 """Module that implements subscription related API endpoints."""
+
 from http import HTTPStatus
 from typing import Any
 from uuid import UUID

--- a/orchestrator/services/subscriptions.py
+++ b/orchestrator/services/subscriptions.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 """Module that provides service functions on subscriptions."""
+
 import pickle  # noqa: S403
 from collections import defaultdict
 from collections.abc import Sequence
@@ -506,6 +507,7 @@ TARGET_DEFAULT_USABLE_MAP: dict[Target, list[str]] = {
     Target.TERMINATE: ["active", "provisioning"],
     Target.SYSTEM: ["active"],
     Target.VALIDATE: ["active"],
+    Target.RECONCILE: ["active"],
 }
 
 WF_USABLE_MAP: dict[str, list[str]] = {}
@@ -532,6 +534,7 @@ def subscription_workflows(subscription: SubscriptionTable) -> dict[str, Any]:
         ...     "terminate": [],
         ...     "system": [],
         ...     "validate": [],
+        ...     "reconcile: [],
         ... }
 
     """
@@ -552,6 +555,7 @@ def subscription_workflows(subscription: SubscriptionTable) -> dict[str, Any]:
         "terminate": [],
         "system": [],
         "validate": [],
+        "reconcile": [],
     }
     for workflow in subscription.product.workflows:
         if workflow.name in WF_USABLE_WHILE_OUT_OF_SYNC or workflow.is_task:

--- a/orchestrator/targets.py
+++ b/orchestrator/targets.py
@@ -23,3 +23,4 @@ class Target(strEnum):
     TERMINATE = "TERMINATE"
     SYSTEM = "SYSTEM"
     VALIDATE = "VALIDATE"
+    RECONCILE = "RECONCILE"

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -154,7 +154,7 @@ def _generate_modify_form(workflow_target: str, workflow_name: str) -> InputForm
 
 
 def wrap_modify_initial_input_form(initial_input_form: InputStepFunc | None) -> StateInputStepFunc | None:
-    """Wrap initial input for modify and terminate workflows.
+    """Wrap initial input for modify, reconcile and terminate workflows.
 
     This is needed because the frontend expects all modify workflows to start with a page that only contains the
     subscription id. It also expects the second page to have some user visible inputs and the subscription id *again*.
@@ -353,6 +353,53 @@ def validate_workflow(description: str) -> Callable[[Callable[[], StepList]], Wo
         return make_workflow(f, description, validate_initial_input_form_generator, Target.VALIDATE, steplist)
 
     return _validate_workflow
+
+
+def reconcile_workflow(
+    description: str,
+    additional_steps: StepList | None = None,
+    authorize_callback: Authorizer | None = None,
+    retry_auth_callback: Authorizer | None = None,
+) -> Callable[[Callable[[], StepList]], Workflow]:
+    """Uses modify_workflow with minimum of required input fields to perform sync with external systems based on existing configuration.
+
+    Use this for subscription reconcile workflows.
+
+    Example::
+
+        @reconcile_workflow("Reconcile l2vpn")
+        def reconcile_l2vpn() -> StepList:
+            return (
+                begin
+                >> update_l2vpn_in_external_systems
+            )
+    """
+
+    wrapped_reconcile_initial_input_form_generator = wrap_modify_initial_input_form(None)
+
+    def _reconcile_workflow(f: Callable[[], StepList]) -> Workflow:
+        steplist = (
+            init
+            >> store_process_subscription()
+            >> unsync
+            >> f()
+            >> (additional_steps or StepList())
+            >> resync
+            >> refresh_subscription_search_index
+            >> done
+        )
+
+        return make_workflow(
+            f,
+            description,
+            wrapped_reconcile_initial_input_form_generator,
+            Target.RECONCILE,
+            steplist,
+            authorize_callback=authorize_callback,
+            retry_auth_callback=retry_auth_callback,
+        )
+
+    return _reconcile_workflow
 
 
 def ensure_provisioning_status(modify_steps: Step | StepList) -> StepList:

--- a/orchestrator/workflows/utils.py
+++ b/orchestrator/workflows/utils.py
@@ -361,7 +361,7 @@ def reconcile_workflow(
     authorize_callback: Authorizer | None = None,
     retry_auth_callback: Authorizer | None = None,
 ) -> Callable[[Callable[[], StepList]], Workflow]:
-    """Uses modify_workflow with minimum of required input fields to perform sync with external systems based on existing configuration.
+    """Similar to a modify_workflow but without required input user input to perform a sync with external systems based on the subscriptions existing configuration.
 
     Use this for subscription reconcile workflows.
 

--- a/test/unit_tests/workflows/test_utils.py
+++ b/test/unit_tests/workflows/test_utils.py
@@ -1,0 +1,105 @@
+import pytest
+
+from orchestrator.workflow import StepList, Workflow, begin, done, step
+from orchestrator.workflows.utils import reconcile_workflow
+
+
+@step("Extra Step")
+def extra_dummy_step():
+    pass
+
+
+def test_reconcile_workflow_basic():
+    workflow_description = "Test Reconcile Workflow"
+
+    @reconcile_workflow(workflow_description)
+    def test_workflow() -> StepList:
+        return begin >> done
+
+    workflow = test_workflow
+
+    assert isinstance(workflow, Workflow)
+    assert workflow.description == workflow_description
+    assert workflow.target.name == "RECONCILE"
+    step_names = [step.name for step in workflow.steps]
+
+    expected_steps = [
+        "Start",
+        "Create Process Subscription relation",
+        "Lock subscription",
+        "Done",
+        "Unlock subscription",
+        "Refresh subscription search index",
+        "Done",
+    ]
+    assert step_names == expected_steps
+
+
+def test_reconcile_workflow_additional_steps():
+    workflow_description = "Test Reconcile Workflow with additional step"
+
+    additional_step = StepList() >> extra_dummy_step
+
+    @reconcile_workflow(workflow_description, additional_steps=additional_step)
+    def test_workflow() -> StepList:
+        return begin >> done
+
+    workflow = test_workflow
+
+    assert isinstance(workflow, Workflow)
+    assert workflow.description == workflow_description
+    assert workflow.target.name == "RECONCILE"
+    step_names = [step.name for step in workflow.steps]
+    expected_steps = [
+        "Start",
+        "Create Process Subscription relation",
+        "Lock subscription",
+        "Done",
+        "Extra Step",
+        "Unlock subscription",
+        "Refresh subscription search index",
+        "Done",
+    ]
+    assert step_names == expected_steps
+
+
+def test_reconcile_workflow_empty_function_steps():
+    workflow_description = "Test Reconcile Workflow empty steps"
+
+    @reconcile_workflow(workflow_description)
+    def test_workflow() -> StepList:
+        return StepList()
+
+    workflow = test_workflow
+
+    assert isinstance(workflow, Workflow)
+    assert workflow.description == workflow_description
+    assert workflow.target.name == "RECONCILE"
+
+    step_names = [step.name for step in workflow.steps]
+    expected_steps = [
+        "Start",
+        "Create Process Subscription relation",
+        "Lock subscription",
+        "Unlock subscription",
+        "Refresh subscription search index",
+        "Done",
+    ]
+    assert step_names == expected_steps
+
+
+def test_reconcile_workflow_decorated_function_raises():
+    workflow_description = "Test Reconcile Workflow exception"
+
+    def will_raise() -> StepList:
+        raise RuntimeError("Something went wrong")
+
+    with pytest.raises(RuntimeError, match="Something went wrong"):
+        _ = reconcile_workflow(workflow_description)(will_raise)
+
+
+def test_reconcile_workflow_non_callable():
+    workflow_description = "Test Reconcile Workflow non-callable"
+
+    with pytest.raises(TypeError):
+        _ = reconcile_workflow(workflow_description)(None)

--- a/test/unit_tests/workflows/test_utils.py
+++ b/test/unit_tests/workflows/test_utils.py
@@ -12,7 +12,7 @@ def extra_dummy_step():
 def test_reconcile_workflow_basic():
     workflow_description = "Test Reconcile Workflow"
 
-    @reconcile_workflow(workflow_description)
+    @reconcile_workflow(workflow_description)  # type: ignore
     def test_workflow() -> StepList:
         return begin >> done
 
@@ -40,7 +40,7 @@ def test_reconcile_workflow_additional_steps():
 
     additional_step = StepList() >> extra_dummy_step
 
-    @reconcile_workflow(workflow_description, additional_steps=additional_step)
+    @reconcile_workflow(workflow_description, additional_steps=additional_step)  # type: ignore
     def test_workflow() -> StepList:
         return begin >> done
 
@@ -66,7 +66,7 @@ def test_reconcile_workflow_additional_steps():
 def test_reconcile_workflow_empty_function_steps():
     workflow_description = "Test Reconcile Workflow empty steps"
 
-    @reconcile_workflow(workflow_description)
+    @reconcile_workflow(workflow_description)  # type: ignore
     def test_workflow() -> StepList:
         return StepList()
 


### PR DESCRIPTION
## Add reconcile workflow decorator for subscription synchronization

This PR implements a new reconcile_workflow decorator that enables synchronization of subscription configurations with external systems. 

The reconcile workflow reuses the modify workflow but removes the need for user input forms, making it ideal for automated synchronization tasks.

## Summary
- Implement reconcile_workflow decorator that wraps modify_workflow functionality without requiring user input via forms
- Update subscription workflows to include reconcile workflows in the available workflow list
- Add unit tests for new reconcile workflow covering basic usage

Issue: #1026