### PR TITLE
Option to perform subcription model lifecycle validation checks for product type in workflow steps

### DIFF
--- a/docs/reference-docs/app/settings-overview.md
+++ b/docs/reference-docs/app/settings-overview.md
@@ -77,6 +77,27 @@ my_settings = MySettings()
 expose_settings("my_settings", my_settings)
 ```
 
+## Lifecycle Validation Mode
+
+You can run the application with three different lifecycle validation modes:
+
+```Python
+class LifecycleValidationMode(strEnum):
+    STRICT = "strict"
+    LOOSE = "loose" # default
+    IGNORED = "ignored"
+```
+
+The Lifecycle Validation Mode can be set using the `LIFECYCLE_VALIDATION_MODE` environment variable. The default value is `loose`.
+
+The Lifecycle Validation Mode setting is used to validate that a **subscription model has been instantiated with the correct product type class for its lifecycle status**. E.g. a subscription model with a lifecycle status of `PROVISIONING` should be instantiated with a product type class that has a lifecycle status of `PROVISIONING`.
+
+The different modes are explained below:
+
+- `strict`: In this mode, the application will enforce strict checks on the lifecycle status of subscription models. If any issues are found, the application will raise an error and stop running.
+- `loose`: In this mode, the application will log warnings for any issues with the lifecycle validation, but it will still run normally.
+- `ignored`: In this mode, the application will ignore all lifecycle validation issues and run normally.
+
 ## Masking Secrets
 
 The following rules apply when exposing settings:
@@ -89,6 +110,7 @@ The following rules apply when exposing settings:
 - `PostgresDsn` from `from pydantic import PostgresDsn` are masked.
 
 ## Overview of AppSettings class
+
 Toggle the source code block below to get a complete overview of the current application settings.
 ::: orchestrator.settings.AppSettings
     options:

--- a/docs/reference-docs/app/settings-overview.md
+++ b/docs/reference-docs/app/settings-overview.md
@@ -93,7 +93,20 @@ class LifecycleValidationMode(strEnum):
 The Lifecycle Validation Mode can be set using the `LIFECYCLE_VALIDATION_MODE` environment variable. The default setting is `loose`. The different modes are explained below:
 
 - `strict`: The application will enforce strict checks on the lifecycle status of subscription models in workflow steps. If any issues are found, the application will raise an error and stop running.
+
+!!! example "Error in `strict` mode"
+    ```bash
+    2025-09-26 13:46:56 [error    ] Subscription of type <class 'products.product_types.l3vpn.L3Vpn'> should use <class 'products.product_types.l3vpn.L3VpnProvisioning'> for lifecycle status 'provisioning' [orchestrator.domain.lifecycle] func=re_deploy_nso process_id=6a483f61-c21d-47be-8390-bbd608c59a77 workflow_name=create_l3vpn
+    ```
+
+!!! warning
+    A workflow failing on this error will not be recoverable, so it is advised to test this in development first.
 - `loose`: The application will log warnings for any issues with the lifecycle validation in workflow steps, but it will still run normally.
+
+!!! example "Warning in `loose` mode"
+    ```bash
+    2025-09-26 13:46:56 [warning    ] Subscription of type <class 'products.product_types.l3vpn.L3Vpn'> should use <class 'products.product_types.l3vpn.L3VpnProvisioning'> for lifecycle status 'provisioning' [orchestrator.domain.lifecycle] func=re_deploy_nso
+    ```
 - `ignored`: The application will ignore all lifecycle validation issues and run normally.
 
 ## Masking Secrets

--- a/docs/reference-docs/app/settings-overview.md
+++ b/docs/reference-docs/app/settings-overview.md
@@ -79,6 +79,8 @@ expose_settings("my_settings", my_settings)
 
 ## Lifecycle Validation Mode
 
+The Lifecycle Validation Mode is used to validate in workflow steps that a **subscription model has been instantiated with the correct product type class for its lifecycle status**. E.g. a subscription model with a lifecycle status of `PROVISIONING` should be instantiated with a product type class that has a lifecycle status of `PROVISIONING`.
+
 You can run the application with three different lifecycle validation modes:
 
 ```Python
@@ -88,15 +90,11 @@ class LifecycleValidationMode(strEnum):
     IGNORED = "ignored"
 ```
 
-The Lifecycle Validation Mode can be set using the `LIFECYCLE_VALIDATION_MODE` environment variable. The default value is `loose`.
+The Lifecycle Validation Mode can be set using the `LIFECYCLE_VALIDATION_MODE` environment variable. The default setting is `loose`. The different modes are explained below:
 
-The Lifecycle Validation Mode setting is used to validate that a **subscription model has been instantiated with the correct product type class for its lifecycle status**. E.g. a subscription model with a lifecycle status of `PROVISIONING` should be instantiated with a product type class that has a lifecycle status of `PROVISIONING`.
-
-The different modes are explained below:
-
-- `strict`: In this mode, the application will enforce strict checks on the lifecycle status of subscription models. If any issues are found, the application will raise an error and stop running.
-- `loose`: In this mode, the application will log warnings for any issues with the lifecycle validation, but it will still run normally.
-- `ignored`: In this mode, the application will ignore all lifecycle validation issues and run normally.
+- `strict`: The application will enforce strict checks on the lifecycle status of subscription models in workflow steps. If any issues are found, the application will raise an error and stop running.
+- `loose`: The application will log warnings for any issues with the lifecycle validation in workflow steps, but it will still run normally.
+- `ignored`: The application will ignore all lifecycle validation issues and run normally.
 
 ## Masking Secrets
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -1385,7 +1385,7 @@ class SubscriptionModel(DomainModel):
 
         status = SubscriptionLifecycle(subscription.status)
 
-        if not cls.__base_type__:  # provisioning of active
+        if not cls.__base_type__:
             # Import here to prevent cyclic imports
             from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 

--- a/orchestrator/domain/base.py
+++ b/orchestrator/domain/base.py
@@ -614,9 +614,7 @@ class ProductBlockModel(DomainModel):
         product_blocks_in_model = cls._get_depends_on_product_block_types()
         product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
 
-        product_blocks_in_model = set(
-            flatten(map(attrgetter("__names__"), product_blocks_types_in_model))
-        )  # type: ignore
+        product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
 
         missing_product_blocks_in_db = product_blocks_in_model - product_blocks_in_db  # type: ignore
         missing_product_blocks_in_model = product_blocks_in_db - product_blocks_in_model  # type: ignore
@@ -1084,9 +1082,7 @@ class SubscriptionModel(DomainModel):
         product_blocks_in_model = cls._get_depends_on_product_block_types()
         product_blocks_types_in_model = get_depends_on_product_block_type_list(product_blocks_in_model)
 
-        product_blocks_in_model = set(
-            flatten(map(attrgetter("__names__"), product_blocks_types_in_model))
-        )  # type: ignore
+        product_blocks_in_model = set(flatten(map(attrgetter("__names__"), product_blocks_types_in_model)))  # type: ignore
 
         missing_product_blocks_in_db = product_blocks_in_model - product_blocks_in_db  # type: ignore
         missing_product_blocks_in_model = product_blocks_in_db - product_blocks_in_model  # type: ignore
@@ -1294,7 +1290,6 @@ class SubscriptionModel(DomainModel):
     # Some common functions shared by from_other_product and from_subscription
     @classmethod
     def _get_subscription(cls: type[S], subscription_id: UUID | UUIDstr) -> SubscriptionTable | None:
-
         if not isinstance(subscription_id, UUID | UUIDstr):
             raise TypeError(f"subscription_id is of type {type(subscription_id)} instead of UUID | UUIDstr")
 
@@ -1390,7 +1385,7 @@ class SubscriptionModel(DomainModel):
 
         status = SubscriptionLifecycle(subscription.status)
 
-        if not cls.__base_type__:
+        if not cls.__base_type__:  # provisioning of active
             # Import here to prevent cyclic imports
             from orchestrator.domain import SUBSCRIPTION_MODEL_REGISTRY
 

--- a/orchestrator/domain/lifecycle.py
+++ b/orchestrator/domain/lifecycle.py
@@ -16,11 +16,17 @@ from typing import TYPE_CHECKING, TypeVar
 import strawberry
 import structlog
 
+# from orchestrator.domain.base import DomainModel, SubscriptionModel
+from orchestrator.settings import LifecycleValidationMode
 from orchestrator.types import SubscriptionLifecycle
 from pydantic_forms.types import strEnum
 
 if TYPE_CHECKING:
-    from orchestrator.domain.base import DomainModel
+    from orchestrator.domain.base import DomainModel, SubscriptionModel
+else:
+    SubscriptionModel = None
+    DomainModel = None
+T = TypeVar("T", bound=SubscriptionModel)
 
 logger = structlog.get_logger(__name__)
 
@@ -71,9 +77,21 @@ def validate_lifecycle_status(
         )
 
 
-if TYPE_CHECKING:
-    from orchestrator.domain.base import DomainModel, SubscriptionModel
-else:
-    SubscriptionModel = None
-    DomainModel = None
-T = TypeVar("T", bound=SubscriptionModel)
+def validate_subscription_lifecycle(
+    subscription: SubscriptionModel,
+    validation_mode: LifecycleValidationMode,
+) -> None:
+    """Validate that a subscription model has been instantiated with the correct product type class."""
+
+    actual_class = subscription.__class__
+    expected_class = lookup_specialized_type(actual_class, subscription.status)
+
+    if actual_class != expected_class:
+        msg = f"Subscription of type {actual_class} should use {expected_class} for lifecycle status '{subscription.status}'"
+        if validation_mode == LifecycleValidationMode.STRICT:
+            logger.error(msg)
+            raise ValueError(msg)
+        if validation_mode == LifecycleValidationMode.LOOSE:
+            logger.warning(msg)
+        elif validation_mode == LifecycleValidationMode.DISABLED:
+            pass

--- a/orchestrator/domain/lifecycle.py
+++ b/orchestrator/domain/lifecycle.py
@@ -16,8 +16,7 @@ from typing import TYPE_CHECKING, TypeVar
 import strawberry
 import structlog
 
-# from orchestrator.domain.base import DomainModel, SubscriptionModel
-from orchestrator.settings import LifecycleValidationMode
+from orchestrator.settings import LifecycleValidationMode, app_settings
 from orchestrator.types import SubscriptionLifecycle
 from pydantic_forms.types import strEnum
 
@@ -77,11 +76,11 @@ def validate_lifecycle_status(
         )
 
 
-def validate_subscription_lifecycle(
+def validate_subscription_model_product_type(
     subscription: SubscriptionModel,
-    validation_mode: LifecycleValidationMode,
+    validation_mode: LifecycleValidationMode = app_settings.LIFECYCLE_VALIDATION_MODE,
 ) -> None:
-    """Validate that a subscription model has been instantiated with the correct product type class."""
+    """Validate that a subscription model has been instantiated with the correct product type class for its lifecycle status."""
 
     actual_class = subscription.__class__
     expected_class = lookup_specialized_type(actual_class, subscription.status)
@@ -93,5 +92,5 @@ def validate_subscription_lifecycle(
             raise ValueError(msg)
         if validation_mode == LifecycleValidationMode.LOOSE:
             logger.warning(msg)
-        elif validation_mode == LifecycleValidationMode.DISABLED:
+        elif validation_mode == LifecycleValidationMode.IGNORED:
             pass

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -33,7 +33,7 @@ class ExecutorType(strEnum):
 class LifecycleValidationMode(strEnum):
     STRICT = "strict"
     LOOSE = "loose"
-    DISABLED = "disabled"
+    IGNORED = "ignored"
 
 
 class AppSettings(BaseSettings):

--- a/orchestrator/settings.py
+++ b/orchestrator/settings.py
@@ -30,6 +30,12 @@ class ExecutorType(strEnum):
     THREADPOOL = "threadpool"
 
 
+class LifecycleValidationMode(strEnum):
+    STRICT = "strict"
+    LOOSE = "loose"
+    DISABLED = "disabled"
+
+
 class AppSettings(BaseSettings):
     TESTING: bool = True
     SESSION_SECRET: OrchSecretStr = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # type: ignore
@@ -91,6 +97,7 @@ class AppSettings(BaseSettings):
     FILTER_BY_MODE: Literal["partial", "exact"] = "exact"
     EXPOSE_SETTINGS: bool = False
     EXPOSE_OAUTH_SETTINGS: bool = False
+    LIFECYCLE_VALIDATION_MODE: LifecycleValidationMode = LifecycleValidationMode.LOOSE
 
 
 app_settings = AppSettings()

--- a/test/unit_tests/domain/test_base.py
+++ b/test/unit_tests/domain/test_base.py
@@ -170,7 +170,7 @@ def test_subscription_model_registry(clean_registry):
         try:
             SUBSCRIPTION_MODEL_REGISTRY.update({name: model})
         except TypeError:
-            pytest.fail(f"Subscription {model.__name__} registered as " f"{name} should be valid but raised TypeError.")
+            pytest.fail(f"Subscription {model.__name__} registered as {name} should be valid but raised TypeError.")
 
     # Test every signature the update method takes and reset using clear
     try:

--- a/test/unit_tests/domain/test_lifecycle.py
+++ b/test/unit_tests/domain/test_lifecycle.py
@@ -1,7 +1,7 @@
 import pytest
 
 from orchestrator.domain.base import ProductBlockModel
-from orchestrator.domain.lifecycle import validate_subscription_lifecycle
+from orchestrator.domain.lifecycle import validate_subscription_model_product_type
 from orchestrator.settings import LifecycleValidationMode
 from orchestrator.types import SubscriptionLifecycle
 
@@ -51,21 +51,49 @@ def test_invalid_lifecycle_status_union(setup):
             sub_block2: SubBlockProvisioning | SubBlockInactive  # first lifecycle is valid, second is not
 
 
-def test_validate_subscription_lifecycle_valid(sub_one_subscription_1, caplog):
-    # Test create with wrong lifecycle, we can create
+@pytest.mark.parametrize("lifecycle_validation_mode", [LifecycleValidationMode.STRICT, LifecycleValidationMode.LOOSE])
+def test_validate_subscription_model_product_type_correct_type(
+    sub_one_subscription_1, caplog, lifecycle_validation_mode
+):
+    """Test that a subscription model has been instantiated with the correct product type class for its lifecycle status."""
 
     with caplog.at_level("WARNING"):
-        validate_subscription_lifecycle(sub_one_subscription_1, validation_mode=LifecycleValidationMode.STRICT)
-        # Assert no warnings or errors were logged
+        validate_subscription_model_product_type(sub_one_subscription_1, validation_mode=lifecycle_validation_mode)
         assert not caplog.records
 
 
-def test_validate_subscription_lifecycle_invalid(sub_one_subscription_1):
-    # Test create with wrong lifecycle, we can create
-    sub_one_subscription_1.status = "provisioning"
+@pytest.mark.parametrize(
+    "lifecycle_status,expected_error",
+    [
+        (SubscriptionLifecycle.INITIAL, r"Subscription of type .* should use .* for lifecycle status 'initial'"),
+        (SubscriptionLifecycle.MIGRATING, r"Subscription of type .* should use .* for lifecycle status 'migrating'"),
+        (SubscriptionLifecycle.DISABLED, r"Subscription of type .* should use .* for lifecycle status 'disabled'"),
+        (SubscriptionLifecycle.TERMINATED, r"Subscription of type .* should use .* for lifecycle status 'terminated'"),
+        (
+            SubscriptionLifecycle.PROVISIONING,
+            r"Subscription of type .* should use .* for lifecycle status 'provisioning'",
+        ),
+    ],
+)
+def test_validate_subscription_model_product_type_invalid_lifecycle_error(
+    sub_one_subscription_1, lifecycle_status, expected_error
+):
+    """Test with lifecycles that does not match the subscription type."""
+    sub_one_subscription_1.status = lifecycle_status
 
     with pytest.raises(
         ValueError,
-        match=r"Subscription of type .* should use .* for lifecycle status '.*'",
+        match=expected_error,
     ):
-        validate_subscription_lifecycle(sub_one_subscription_1, validation_mode=LifecycleValidationMode.STRICT)
+        validate_subscription_model_product_type(sub_one_subscription_1, validation_mode=LifecycleValidationMode.STRICT)
+
+
+def test_warning_logged_on_invalid_lifecycle(sub_one_subscription_1, caplog):
+    """Test that a warning is logged when the lifecycle status does not match the subscription type and validation mode is LOOSE."""
+    sub_one_subscription_1.status = SubscriptionLifecycle.PROVISIONING  # actual status is 'active'
+
+    with caplog.at_level("WARNING"):
+        validate_subscription_model_product_type(sub_one_subscription_1, validation_mode=LifecycleValidationMode.LOOSE)
+
+    # Assert that a warning was logged
+    assert any(record.levelname == "WARNING" for record in caplog.records)


### PR DESCRIPTION
## Summary

The Lifecycle Validation Mode setting is used to validate in workflow steps that a subscription model has been instantiated with the correct product type class for its lifecycle status

E.g. a subscription model with a lifecycle status of `PROVISIONING` should be instantiated with a product type class that has a lifecycle status of `PROVISIONING`.

* Added lifecycle validation check
* Updated settings.py so that users can decide in which mode they want to run their app
* Wrote unit tests
* Added documentation

Issue: #1003 