### PR TITLE
Retype Authorizer

### DIFF
--- a/orchestrator/utils/auth.py
+++ b/orchestrator/utils/auth.py
@@ -1,9 +1,10 @@
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import TypeAlias, TypeVar
 
 from oauth2_lib.fastapi import OIDCUserModel
 
 # This file is broken out separately to avoid circular imports.
 
 # Can instead use "type Authorizer = ..." in later Python versions.
-Authorizer: TypeAlias = Callable[[OIDCUserModel | None], bool]
+T = TypeVar("T", bound=OIDCUserModel)
+Authorizer: TypeAlias = Callable[[T | None], bool]


### PR DESCRIPTION
Currently, Authorizer has type `Authorizer: TypeAlias = Callable[[OIDCUserModel | None], bool]`. This will break linting and similar tooling when instead using a subclass of OIDCUserModel, which will probably be done by every user of RBAC.

Closes #1125 .