### PR TITLE
Fix SQLAlchemy filter in schedule validate_products: use relationship.has(...) for workflow.name check

### DIFF
--- a/orchestrator/schedules/validate_products.py
+++ b/orchestrator/schedules/validate_products.py
@@ -29,7 +29,7 @@ def validate_products() -> None:
     uncompleted_products = db.session.scalar(
         select(func.count())
         .select_from(ProcessTable)
-        .filter(ProcessTable.workflow.name == "validate_products", ProcessTable.last_status != "completed")
+        .filter(ProcessTable.workflow.has(name="validate_products"), ProcessTable.last_status != "completed")
     )
     if not uncompleted_products:
         start_process("task_validate_products")


### PR DESCRIPTION
Fixes #1126

The filter `ProcessTable.workflow.name == "validate_products"` caused an error that restarted the scheduler pod each time the `validate_products` schedule ran. Replacing it with `ProcessTable.workflow.has(name="validate_products")` fixes the issue. Is this change ok for you as well?