### PR TITLE
Update documentation on using a separate wsgi file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install /tmp/*.whl --no-cache-dir
 RUN useradd orchestrator
 USER orchestrator
 WORKDIR /home/orchestrator
-CMD ["uvicorn", "--host", "0.0.0.0", "--port", "8080", "main:app"]
+CMD ["uvicorn", "--host", "0.0.0.0", "--port", "8080", "wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -42,19 +42,24 @@ Configure the database URI in your local environment:
 export DATABASE_URI=postgresql://nwa:nwa@localhost:5432/orchestrator-core
 ```
 
-### Step 3 - Create main.py
+### Step 3 - Create main.py and wsgi.py
 
-Create a `main.py` file.
+Create a `main.py` file for running the CLI.
 
 ```python
-from orchestrator import OrchestratorCore
 from orchestrator.cli.main import app as core_cli
-from orchestrator.settings import AppSettings
-
-app = OrchestratorCore(base_settings=AppSettings())
 
 if __name__ == "__main__":
     core_cli()
+```
+
+Create a `wsgi.py` file for running the web server.
+
+```python
+from orchestrator import OrchestratorCore
+from orchestrator.settings import AppSettings
+
+app = OrchestratorCore(base_settings=AppSettings())
 ```
 
 ### Step 4 - Run the database migrations
@@ -70,7 +75,7 @@ python main.py db upgrade heads
 
 ```shell
 export OAUTH2_ACTIVE=False
-uvicorn --reload --host 127.0.0.1 --port 8080 main:app
+uvicorn --reload --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 Visit the [ReDoc](http://127.0.0.1:8080/api/redoc) or [OpenAPI](http://127.0.0.1:8080/api/docs) page to view and interact with the API.

--- a/docs/getting-started/agentic.md
+++ b/docs/getting-started/agentic.md
@@ -51,13 +51,21 @@ docker run --rm --name temp-orch-db -e POSTGRES_PASSWORD=rootpassword -p 5432:54
 docker exec -it temp-orch-db su - postgres -c 'createuser -sP nwa && createdb orchestrator-core -O nwa'
 ```
 
-### Step 3 - Create the main.py:
+### Step 3 - Create the main.py and wsgi.py:
 
 Create a `main.py` file.
 
 ```python
-from orchestrator import AgenticOrchestratorCore
 from orchestrator.cli.main import app as core_cli
+
+if __name__ == "__main__":
+    core_cli()
+```
+
+Create a `wsgi.py` file.
+
+```python
+from orchestrator import AgenticOrchestratorCore
 from orchestrator.settings import app_settings
 from orchestrator.llm_settings import llm_settings
 
@@ -72,9 +80,6 @@ app = AgenticOrchestratorCore(
     llm_model=llm_settings.AGENT_MODEL,
     agent_tools=[]
 )
-
-if __name__ == "__main__":
-    core_cli()
 ```
 
 ### Step 4 - Run the database migrations:
@@ -100,7 +105,7 @@ python main.py db upgrade heads
 export DATABASE_URI=postgresql://nwa:PASSWORD_FROM_STEP_2@localhost:5432/orchestrator-core
 export OAUTH2_ACTIVE=False
 
-uvicorn --reload --host 127.0.0.1 --port 8080 main:app
+uvicorn --reload --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 </div>

--- a/docs/getting-started/base.md
+++ b/docs/getting-started/base.md
@@ -51,20 +51,26 @@ docker run --rm --name temp-orch-db -e POSTGRES_PASSWORD=rootpassword -p 5432:54
 docker exec -it temp-orch-db su - postgres -c 'createuser -sP nwa && createdb orchestrator-core -O nwa'
 ```
 
-### Step 3 - Create the main.py:
+### Step 3 - Create the main.py and wsgi.py:
 
 Create a `main.py` file.
 
 ```python
-from orchestrator import OrchestratorCore
 from orchestrator.cli.main import app as core_cli
-from orchestrator.settings import app_settings
-
-app = OrchestratorCore(base_settings=app_settings)
 
 if __name__ == "__main__":
     core_cli()
 ```
+
+Create a `wsgi.py` file.
+
+```python
+from orchestrator import OrchestratorCore
+from orchestrator.settings import app_settings
+
+app = OrchestratorCore(base_settings=app_settings)
+```
+
 
 ### Step 4 - Run the database migrations:
 
@@ -89,7 +95,7 @@ python main.py db upgrade heads
 export DATABASE_URI=postgresql://nwa:PASSWORD_FROM_STEP_2@localhost:5432/orchestrator-core
 export OAUTH2_ACTIVE=False
 
-uvicorn --reload --host 127.0.0.1 --port 8080 main:app
+uvicorn --reload --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 </div>

--- a/docs/reference-docs/app/scaling.md
+++ b/docs/reference-docs/app/scaling.md
@@ -229,7 +229,7 @@ For example:
 Start the orchestrator api:
 
 ```bash
-EXECUTOR="celery" uvicorn --reload --host 127.0.0.1 --port 8080 main:app
+EXECUTOR="celery" uvicorn --reload --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 Notice that we are setting `EXECUTOR` to `celery`. Without that variable the api resorts to the default threadpool.

--- a/docs/workshops/beginner/explore.md
+++ b/docs/workshops/beginner/explore.md
@@ -19,7 +19,7 @@ pip install orchestrator-core
 PYTHONPATH=. python main.py db init
 cp -av examples/*add_user_and_usergroup* migrations/versions/schema
 PYTHONPATH=. python main.py db upgrade heads
-ENABLE_WEBSOCKETS=True uvicorn --host 127.0.0.1 --port 8080 main:app
+ENABLE_WEBSOCKETS=True uvicorn --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 ## Explore

--- a/docs/workshops/beginner/start-applications.md
+++ b/docs/workshops/beginner/start-applications.md
@@ -7,12 +7,12 @@
 From the `example-orchestrator` folder, use Uvicorn to start the orchestrator:
 
 ```shell
-uvicorn --host 127.0.0.1 --port 8080 main:app
+uvicorn --host 127.0.0.1 --port 8080 wsgi:app
 ```
 
 If you are running without authentication set up, you can set the environment variable to false from the command line:
 ```
-OAUTH2_ACTIVE=false uvicorn --host localhost --port 8080 main:app
+OAUTH2_ACTIVE=false uvicorn --host localhost --port 8080 wsgi:app
 ```
 
 Visit [the app](http://127.0.0.1:8080/api/docs) to view the API documentation.

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF, GÉANT.
+# Copyright 2019-2025 SURF, GÉANT, ESnet.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -5,7 +5,7 @@ This module contains the main `OrchestratorCore` class for the `FastAPI` backend
 provides the ability to run the CLI.
 """
 
-# Copyright 2019-2020 SURF, ESnet, GÉANT.
+# Copyright 2019-2025 SURF, ESnet, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/orchestrator/cli/main.py
+++ b/orchestrator/cli/main.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2025 SURF, ESnet, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Using a separate WSGI file avoids initializing the entire orchestrator app when running the CLI, preventing issues like #1084