### PR TITLE
Disable renovate updates for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
     },
     {
       "matchPackageNames": ["python"],
-      "rangeStrategy": "widen"
+      "rangeStrategy": "widen",
+      "enabled": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Adding support for a new Python version is rarely as simple as bumping the version, so we'll do this ourselves.