### PR TITLE
Make DateFilter more restrictive only accepting iso-format dates

### DIFF
--- a/orchestrator/search/filters/date_filters.py
+++ b/orchestrator/search/filters/date_filters.py
@@ -14,7 +14,6 @@
 from datetime import date, datetime
 from typing import Annotated, Any, Literal
 
-from dateutil.parser import parse as dt_parse
 from pydantic import BaseModel, BeforeValidator, Field, model_validator
 from sqlalchemy import TIMESTAMP, and_
 from sqlalchemy import cast as sa_cast
@@ -27,10 +26,10 @@ def _validate_date_string(v: Any) -> Any:
     if not isinstance(v, str):
         return v
     try:
-        dt_parse(v)
+        datetime.fromisoformat(v)
         return v
     except Exception as exc:
-        raise ValueError("is not a valid date or datetime string") from exc
+        raise ValueError("is not a valid ISO-8601 date or datetime string") from exc
 
 
 DateValue = datetime | date | str
@@ -44,8 +43,8 @@ class DateRange(BaseModel):
 
     @model_validator(mode="after")
     def _order(self) -> "DateRange":
-        to_datetime = dt_parse(str(self.end))
-        from_datetime = dt_parse(str(self.start))
+        to_datetime = datetime.fromisoformat(str(self.end))
+        from_datetime = datetime.fromisoformat(str(self.start))
         if to_datetime <= from_datetime:
             raise ValueError("'to' must be after 'from'")
         return self


### PR DESCRIPTION
dateutil.parse is too permissive.

A discriminated union is used for filters, they will be tried in order if the operator supports it. 

The following example incorrectly passes validation:
```
{
    "path": "subscription.vc.sap.sap.vlanrange",
    "value_kind": "string",
    "condition": {
        "op": "eq",
        "value": "22"
    }
}
```

```bash
python
Python 3.11.6 (main, Nov 17 2023, 12:02:12) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dateutil.parser import parse
>>> print(parse('22'))
2025-11-22 00:00:00
```