### PR TITLE
fix: make load-initial-schedule idempotent

### DIFF
--- a/orchestrator/cli/scheduler.py
+++ b/orchestrator/cli/scheduler.py
@@ -23,7 +23,7 @@ from orchestrator.schedules.scheduler import (
 )
 from orchestrator.schedules.service import (
     SCHEDULER_QUEUE,
-    add_scheduled_task_to_queue,
+    add_unique_scheduled_task_to_queue,
     workflow_scheduler_queue,
 )
 from orchestrator.schemas.schedules import APSchedulerJobCreate
@@ -132,7 +132,8 @@ def load_initial_schedule() -> None:
       - Task Clean Up Tasks
       - Task Validate Subscriptions
 
-    This command is idempotent. The schedules are only created when they do not already exist.
+    This command is idempotent since 4.7.1 when the scheduler is running. The schedules are only
+    created when they do not already exist in the database.
     """
     initial_schedules = [
         {
@@ -170,4 +171,4 @@ def load_initial_schedule() -> None:
         schedule["workflow_id"] = workflow.workflow_id
 
         typer.echo(f"Initial Schedule: {schedule}")
-        add_scheduled_task_to_queue(APSchedulerJobCreate(**schedule), skip_when_exists=True)  # type: ignore
+        add_unique_scheduled_task_to_queue(APSchedulerJobCreate(**schedule))  # type: ignore

--- a/orchestrator/schedules/service.py
+++ b/orchestrator/schedules/service.py
@@ -63,30 +63,46 @@ def deserialize_payload(bytes_dump: bytes) -> APSchedulerJobs:
     return APSJobAdapter.validate_json(json_dump)
 
 
-def add_scheduled_task_to_queue(payload: APSchedulerJobs, skip_when_exists: bool = False) -> bool:
+def add_scheduled_task_to_queue(payload: APSchedulerJobs) -> None:
     """Create a scheduled task service function.
 
-    We need to create a apscheduler job, and put the workflow and schedule_id in
-    the linker table workflows_apscheduler_jobs.
+    We need to create, update or delete an apscheduler job, and put the
+    workflow and schedule_id in the linker table workflows_apscheduler_jobs.
+    This is done by adding a job to a redis queue which will be executed
+    when the scheduler runs.
+
+    Args:
+        payload: APSchedulerJobs The scheduled task to create, update or delete
+    """
+    bytes_dump = serialize_payload(payload)
+    redis_connection.lpush(SCHEDULER_QUEUE, bytes_dump)
+    logger.info("Added scheduled task to queue.")
+
+
+def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate) -> bool:
+    """Create a unique scheduled task service function.
+
+    Checks if the workflow is already scheduled before creating an apscheduler
+    job, and putting the workflow and schedule_id in the linker table
+    workflows_apscheduler_jobs.
+    This is done by adding a job to a redis queue which will be executed
+    when the scheduler runs.
+
+    This function is not safe for concurrent usage and when the scheduler is not
+    running, as there might be a race condition between adding a job and checking
+    if it already exists in the database.
 
     Args:
         payload: APSchedulerJobCreate The scheduled task to create.
-        skip_when_exists: only add job when workflow is not scheduled yet. Defaults to False.
 
     Returns:
         True when the scheduled task was added to the queue
         False when the scheduled task was not added to the queue
     """
-    if (
-        isinstance(payload, APSchedulerJobCreate)
-        and skip_when_exists
-        and db.session.query(WorkflowApschedulerJob).filter_by(workflow_id=payload.workflow_id).all()
-    ):
+    if db.session.query(WorkflowApschedulerJob).filter_by(workflow_id=payload.workflow_id).all():
         logger.info(f"Not adding existing workflow {payload.workflow_name} as scheduled task.")
         return False
-    bytes_dump = serialize_payload(payload)
-    redis_connection.lpush(SCHEDULER_QUEUE, bytes_dump)
-    logger.info("Added scheduled task to queue.")
+    add_scheduled_task_to_queue(payload)
     return True
 
 

--- a/test/unit_tests/schedules/test_schedules_services.py
+++ b/test/unit_tests/schedules/test_schedules_services.py
@@ -16,6 +16,7 @@ from orchestrator.schedules.service import (
     _delete_scheduled_task,
     _update_scheduled_task,
     add_scheduled_task_to_queue,
+    add_unique_scheduled_task_to_queue,
     deserialize_payload,
     get_linker_entries_by_schedule_ids,
     run_start_workflow_scheduler_task,
@@ -462,7 +463,7 @@ def test_delete_scheduled_task_schedule_id_none(mock_delete_linker):
 
 
 @patch("orchestrator.schedules.service.redis_connection")
-def test_add_create_scheduled_task_to_queue_twice(mock_redis, scheduler_with_jobs):
+def test_add_unique_scheduled_task_to_queue(mock_redis, scheduler_with_jobs):
     workflow_name = "task_validate_products"
     workflow = get_workflow_by_name(workflow_name)
 
@@ -474,7 +475,7 @@ def test_add_create_scheduled_task_to_queue_twice(mock_redis, scheduler_with_job
         trigger_kwargs={"hours": 5},
     )
 
-    result = add_scheduled_task_to_queue(payload)
+    result = add_unique_scheduled_task_to_queue(payload)
 
     # Extract call args
     queue, bytes_arg = mock_redis.lpush.call_args[0]
@@ -492,5 +493,5 @@ def test_add_create_scheduled_task_to_queue_twice(mock_redis, scheduler_with_job
     db.session.add(workflows_apscheduler_job)
 
     # Try to add the same workflow again
-    result = add_scheduled_task_to_queue(payload, skip_when_exists=True)
+    result = add_unique_scheduled_task_to_queue(payload)
     assert not result


### PR DESCRIPTION
`python main.py scheduler load-initial-schedule` is not idempotent which is rather inconvenient. This PR fixes that issue.