### PR TITLE
Add missing done step to validate_subscriptions

### DIFF
--- a/orchestrator/workflows/tasks/validate_subscriptions.py
+++ b/orchestrator/workflows/tasks/validate_subscriptions.py
@@ -26,7 +26,7 @@ from orchestrator.services.workflows import (
 )
 from orchestrator.settings import app_settings, get_authorizers
 from orchestrator.targets import Target
-from orchestrator.workflow import StepList, init, step, workflow
+from orchestrator.workflow import StepList, done, init, step, workflow
 
 logger = structlog.get_logger(__name__)
 
@@ -65,4 +65,4 @@ def validate_subscriptions() -> None:
     retry_auth_callback=authorizers.retry_auth_callback,
 )
 def task_validate_subscriptions() -> StepList:
-    return init >> validate_subscriptions
+    return init >> validate_subscriptions >> done


### PR DESCRIPTION
Previously, the `validate_subscriptions` task was not visible in the tasks page which was corrected in 4.7.0.
Now that it is visible it became apparent that the task would stay in the `RUNNING` state even when all steps had been executed.
This PR fixes that.

Fixes #1314 