### PR TITLE
CI: Add check-waiting-label.yml

### DIFF
--- a/.github/workflows/check-waiting-label.yml
+++ b/.github/workflows/check-waiting-label.yml
@@ -11,7 +11,7 @@ on:
       - synchronize
 
 jobs:
-  fail-if-labeled:
+  fail-if-waiting:
     if: contains(github.event.pull_request.labels.*.name, 'waiting')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For upcoming major releases we want to prepare PR's and set them ready for review (and have them reviewed), but have a way to prevent merging them. This PR adds a CI workflow that fails if the PR has a `waiting` label. 

<img width="904" height="332" alt="image" src="https://github.com/user-attachments/assets/7b95af23-3efd-448d-ab07-217131309300" />

Benefit of this is that it provides an overview in the PR tab of all changes that are waiting for the next major release.