### PR TITLE
Fix scheduler using the same sqlalchemy session

### DIFF
--- a/orchestrator/cli/scheduler.py
+++ b/orchestrator/cli/scheduler.py
@@ -16,6 +16,7 @@ from typing import cast
 import typer
 from redis import Redis
 
+from orchestrator.db import db
 from orchestrator.schedules.scheduler import (
     get_all_scheduler_tasks,
     get_scheduler,
@@ -64,7 +65,8 @@ def run() -> None:
             if not item:
                 continue
 
-            workflow_scheduler_queue(item, scheduler_connection)
+            with db.database_scope():
+                workflow_scheduler_queue(item, scheduler_connection)
 
 
 @app.command()

--- a/orchestrator/schedules/service.py
+++ b/orchestrator/schedules/service.py
@@ -21,7 +21,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import delete
 
 from orchestrator import app_settings
-from orchestrator.db import db, transactional
+from orchestrator.db import db
 from orchestrator.db.models import WorkflowApschedulerJob
 from orchestrator.schemas.schedules import (
     APSchedulerJobCreate,
@@ -156,7 +156,7 @@ def run_start_workflow_scheduler_task(workflow_name: str) -> None:
     """
     log = logger.bind(workflow_name=workflow_name)
     try:
-        with transactional(db, logger):
+        with db.database_scope():
             log.info("Starting workflow")
             process_id = start_process(workflow_name)
             log.info("Started workflow", process_id=process_id)


### PR DESCRIPTION
For API requests we have a fastapi middleware that calls `with db.database_scope()`.
For workflows there is `with db.database_scope()` in the function that actually runs the steps.

The scheduler did not do that, so it was using the same sqlalchemy session all the time, effectively running all jobs in the same transaction; giving inconsistent results from the postgres function `current_timestamp()`.

To demonstrate the difference I scheduled the `task_resume_workflows` (which takes <1 second to run) on a 3 minute interval.
Without the change, the `started` timestamp (second last column) "lags" to the current timestamp of the previous transaction, while `last modified` (last column) is correct:

<img width="1530" height="258" alt="image" src="https://github.com/user-attachments/assets/c0a33c8c-684b-416c-bb10-8fad695313c7" />

After the change, the `started` timestamp is correct:
<img width="1550" height="246" alt="image" src="https://github.com/user-attachments/assets/6ba36631-550d-450a-a179-f0eb99a7c5bc" />

This should also address the problem where the scheduler does not recover from failed transactions, as those are now implicitly rolled back when the scoped session is removed.

Closes #1055 
Closes #1388 