### PR TITLE
Tests: prevent stale graphql router in test_client

### DIFF
--- a/test/unit_tests/conftest.py
+++ b/test/unit_tests/conftest.py
@@ -3,7 +3,8 @@ import datetime
 import os
 import typing
 import uuid
-from contextlib import closing
+from contextlib import closing, contextmanager
+from copy import copy
 from typing import Any, cast
 from unittest.mock import patch
 from uuid import uuid4
@@ -330,43 +331,87 @@ def db_session(database):
                 trans.rollback()
 
 
-@pytest.fixture(scope="session", autouse=True)
-def fastapi_app(database, db_uri):
+@contextmanager
+def make_orchestrator_app():
     from oauth2_lib.settings import oauth2lib_settings
 
     with (
         patch.multiple(
-            oauth2lib_settings, OAUTH2_ACTIVE=False, ENVIRONMENT_IGNORE_MUTATION_DISABLED=["local", "TESTING"]
+            oauth2lib_settings,
+            OAUTH2_ACTIVE=False,
+            ENVIRONMENT_IGNORE_MUTATION_DISABLED=["local", "TESTING"],
         ),
-        patch.multiple(app_settings, ENABLE_PROMETHEUS_METRICS_ENDPOINT=True),
+        patch.multiple(
+            app_settings,
+            ENABLE_PROMETHEUS_METRICS_ENDPOINT=True,
+            ENVIRONMENT="TESTING",
+        ),
     ):
         app = OrchestratorCore(base_settings=app_settings)
         app.broadcast_thread.start()
+
+        try:
+            yield app
+        finally:
+            app.broadcast_thread.stop()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fastapi_app(database, db_uri):
+    with make_orchestrator_app() as app:
         yield app
-        app.broadcast_thread.stop()
+
+
+@pytest.fixture
+def fastapi_app_graphql(fastapi_app):
+    """Patches the session-level fastapi_app to be used for graphql queries."""
+
+    # Keep references to the fastapi routes and graphql router objects prior to registering
+    original_routes = copy(fastapi_app.router.routes)
+    original_router = fastapi_app.graphql_router
+
+    # Register the graphql router; this needs to be done for every testcase.
+    # This is because the product fixtures (e.g. generic_product_type_1) are function-level fixtures which change the
+    # definitions in SUBSCRIPTION_MODEL_REGISTRY.
+    # These models need to be updated in the graphql schema.
+    fastapi_app.register_graphql()
+
+    yield fastapi_app
+
+    # Restore old routes and router object
+    fastapi_app.router.routes = original_routes
+    fastapi_app.graphql_router = original_router
+
+
+class JsonTestClient(TestClient):
+    def request(  # type: ignore
+        self,
+        method: str,
+        url: str,
+        data: Any | None = None,
+        headers: typing.MutableMapping[str, str] | None = None,
+        json: typing.Any = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        if json is not None:
+            if headers is None:
+                headers = {}
+            data = json_dumps(json).encode()
+            headers["Content-Type"] = "application/json"
+
+        return super().request(method, url, data=data, headers=headers, **kwargs)  # type: ignore
 
 
 @pytest.fixture(scope="session")
 def test_client(fastapi_app):
-    class JsonTestClient(TestClient):
-        def request(  # type: ignore
-            self,
-            method: str,
-            url: str,
-            data: Any | None = None,
-            headers: typing.MutableMapping[str, str] | None = None,
-            json: typing.Any = None,
-            **kwargs: Any,
-        ) -> requests.Response:
-            if json is not None:
-                if headers is None:
-                    headers = {}
-                data = json_dumps(json).encode()
-                headers["Content-Type"] = "application/json"
-
-            return super().request(method, url, data=data, headers=headers, **kwargs)  # type: ignore
-
+    """Client to test REST calls."""
     return JsonTestClient(fastapi_app)
+
+
+@pytest.fixture
+def test_client_graphql(fastapi_app_graphql):
+    """Client to test GraphQL queries."""
+    return JsonTestClient(fastapi_app_graphql)
 
 
 @pytest.fixture(autouse=True)

--- a/test/unit_tests/graphql/conftest.py
+++ b/test/unit_tests/graphql/conftest.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 
-from orchestrator import app_settings
 from orchestrator.graphql.autoregistration import register_domain_models
 from test.unit_tests.fixtures.products.product_blocks.product_block_list_nested import (
     ProductBlockListNestedForTestInactiveGraphql,
@@ -10,9 +9,7 @@ from test.unit_tests.fixtures.products.product_blocks.product_block_list_nested 
 
 
 @pytest.fixture(autouse=True)
-def fastapi_app_graphql(
-    fastapi_app,
-    test_client,
+def load_fixtures(
     generic_product_type_1,
     generic_product_type_2,
     test_product_type_sub_list_union,
@@ -23,20 +20,8 @@ def fastapi_app_graphql(
     sub_two_subscription_1,
     product_sub_list_union_subscription_1,
 ):
-    from pydantic import BaseModel
-
-    from orchestrator.graphql.schemas.subscription import MetadataDict
-
-    class Metadata(BaseModel):
-        some_metadata_prop: list[str]
-
-    MetadataDict.update({"metadata": Metadata})
-
-    actual_env = app_settings.ENVIRONMENT
-    app_settings.ENVIRONMENT = "TESTING"
-    fastapi_app.register_graphql()
-    yield fastapi_app
-    app_settings.ENVIRONMENT = actual_env
+    print("Loading fixtures")
+    pass
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/test/unit_tests/graphql/extensions/test_stats.py
+++ b/test/unit_tests/graphql/extensions/test_stats.py
@@ -4,9 +4,10 @@ from dirty_equals import IsFloat, IsInt
 
 from orchestrator.db.listeners import disable_listeners, monitor_sqlalchemy_queries
 from orchestrator.settings import app_settings
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 
 
-def test_stats_extension(fastapi_app_graphql, test_client):
+def test_stats_extension(fastapi_app_graphql, test_client_graphql):
     # given
     query = """query MyQuery {
       workflows(first: 10) {
@@ -21,7 +22,7 @@ def test_stats_extension(fastapi_app_graphql, test_client):
             fastapi_app_graphql.register_graphql()
 
             # when
-            response = test_client.post("/api/graphql", json={"query": query})
+            response = test_client_graphql.post(GRAPHQL_ENDPOINT, json={"query": query})
     finally:
         disable_listeners()
 

--- a/test/unit_tests/graphql/mutations/test_customer_description.py
+++ b/test/unit_tests/graphql/mutations/test_customer_description.py
@@ -76,7 +76,7 @@ mutation CustomerDescriptionRemoveMutation ($customerId: String!, $subscriptionI
     ).encode("utf-8")
 
 
-def test_customer_description_create(httpx_mock, test_client, product_sub_list_union_subscription_1):
+def test_customer_description_create(httpx_mock, test_client_graphql, product_sub_list_union_subscription_1):
     # given
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -88,7 +88,7 @@ def test_customer_description_create(httpx_mock, test_client, product_sub_list_u
     query = get_customer_description_upsert_mutation(customer_id, subscription_id, description)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -104,7 +104,7 @@ def test_customer_description_create(httpx_mock, test_client, product_sub_list_u
     }
 
 
-def test_customer_description_create_not_found_error(httpx_mock, test_client):
+def test_customer_description_create_not_found_error(httpx_mock, test_client_graphql):
     # given
 
     subscription_id = "50b44ca0-25f6-40d4-b2af-f0418bf2e81a"
@@ -116,7 +116,7 @@ def test_customer_description_create_not_found_error(httpx_mock, test_client):
     query = get_customer_description_upsert_mutation(customer_id, subscription_id, description)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -129,7 +129,7 @@ def test_customer_description_create_not_found_error(httpx_mock, test_client):
     }
 
 
-def test_customer_description_update(httpx_mock, test_client, product_sub_list_union_subscription_1):
+def test_customer_description_update(httpx_mock, test_client_graphql, product_sub_list_union_subscription_1):
     # given
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -148,7 +148,7 @@ def test_customer_description_update(httpx_mock, test_client, product_sub_list_u
     query = get_customer_description_upsert_mutation(customer_id, subscription_id, description)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -164,7 +164,9 @@ def test_customer_description_update(httpx_mock, test_client, product_sub_list_u
     }
 
 
-def test_customer_description_update_with_version(httpx_mock, test_client, product_sub_list_union_subscription_1):
+def test_customer_description_update_with_version(
+    httpx_mock, test_client_graphql, product_sub_list_union_subscription_1
+):
     # given
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -185,7 +187,7 @@ def test_customer_description_update_with_version(httpx_mock, test_client, produ
     query = get_customer_description_upsert_mutation(customer_id, subscription_id, description, version)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -202,7 +204,7 @@ def test_customer_description_update_with_version(httpx_mock, test_client, produ
 
 
 def test_customer_description_update_with_incorrect_version(
-    httpx_mock, test_client, product_sub_list_union_subscription_1
+    httpx_mock, test_client_graphql, product_sub_list_union_subscription_1
 ):
     # given
 
@@ -224,7 +226,7 @@ def test_customer_description_update_with_incorrect_version(
     query = get_customer_description_upsert_mutation(customer_id, subscription_id, description, version)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -237,7 +239,7 @@ def test_customer_description_update_with_incorrect_version(
     }
 
 
-def test_customer_description_delete(httpx_mock, test_client, product_sub_list_union_subscription_1):
+def test_customer_description_delete(httpx_mock, test_client_graphql, product_sub_list_union_subscription_1):
     # given
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -256,7 +258,7 @@ def test_customer_description_delete(httpx_mock, test_client, product_sub_list_u
     query = get_customer_description_remove_mutation(customer_id, subscription_id)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -272,7 +274,9 @@ def test_customer_description_delete(httpx_mock, test_client, product_sub_list_u
     }
 
 
-def test_customer_description_delete_not_found_error(httpx_mock, test_client, product_sub_list_union_subscription_1):
+def test_customer_description_delete_not_found_error(
+    httpx_mock, test_client_graphql, product_sub_list_union_subscription_1
+):
     # given
 
     subscription_id = str(product_sub_list_union_subscription_1)
@@ -283,7 +287,7 @@ def test_customer_description_delete_not_found_error(httpx_mock, test_client, pr
     query = get_customer_description_remove_mutation(customer_id, subscription_id)
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 

--- a/test/unit_tests/graphql/mutations/test_start_process.py
+++ b/test/unit_tests/graphql/mutations/test_start_process.py
@@ -46,7 +46,7 @@ mutation StartProcessMutation ($name: String!, $payload: Payload!) {
     ).encode("utf-8")
 
 
-def test_process_not_found(httpx_mock, test_client):
+def test_process_not_found(httpx_mock, test_client_graphql):
     # given
 
     unknown_wf = "unknown_wf"
@@ -56,7 +56,7 @@ def test_process_not_found(httpx_mock, test_client):
     query = get_start_process_mutation(name=unknown_wf, payload={"payload": {}})
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
 
@@ -68,7 +68,7 @@ def test_process_not_found(httpx_mock, test_client):
     assert response.json() == expected
 
 
-def test_process_started(httpx_mock, test_client, generic_product_type_1):
+def test_process_started(httpx_mock, test_client_graphql, generic_product_type_1):
     # given
 
     known_wf = "task_validate_products"
@@ -78,7 +78,7 @@ def test_process_started(httpx_mock, test_client, generic_product_type_1):
     query = get_start_process_mutation(name=known_wf, payload={"payload": [{}]})
 
     with mutation_authorization():
-        response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
     # then
     assert response.status_code == HTTPStatus.OK

--- a/test/unit_tests/graphql/test_customer.py
+++ b/test/unit_tests/graphql/test_customer.py
@@ -38,8 +38,8 @@ query CustomerQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $so
     ).encode("utf-8")
 
 
-def test_customers(fastapi_app_graphql, test_client):
-    response = test_client.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
+def test_customers(test_client_graphql):
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     customer_data = result["data"]["customers"]["page"][0]
@@ -50,14 +50,14 @@ def test_customers(fastapi_app_graphql, test_client):
     }
 
 
-def test_change_customer_env_vars(fastapi_app_graphql, test_client):
+def test_change_customer_env_vars(test_client_graphql):
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("DEFAULT_CUSTOMER_FULLNAME", "Custom Default Customer")
         mp.setenv("DEFAULT_CUSTOMER_SHORTCODE", "shortcode")
         mp.setenv("DEFAULT_CUSTOMER_IDENTIFIER", "123456")
         new_app_settings = AppSettings()
         mp.setattr("orchestrator.graphql.resolvers.customer.app_settings", new_app_settings)
-        response = test_client.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
+        response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()

--- a/test/unit_tests/graphql/test_process.py
+++ b/test/unit_tests/graphql/test_process.py
@@ -14,6 +14,8 @@ import json
 from http import HTTPStatus
 from unittest import mock
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
+
 
 def build_simple_query(process_id):
     q = """
@@ -38,11 +40,13 @@ def build_simple_query(process_id):
     ).encode("utf-8")
 
 
-def test_process(test_client, mocked_processes):
+def test_process(test_client_graphql, mocked_processes):
     process_id = mocked_processes[0]
     test_query = build_simple_query(process_id)
 
-    response = test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {
         "data": {
@@ -53,13 +57,15 @@ def test_process(test_client, mocked_processes):
 
 @mock.patch("orchestrator.graphql.schemas.process.get_workflow")
 def test_process_is_allowed_with_historic_workflow_only_left_in_db(
-    mock_get_workflow, test_client, mocked_processes, test_workflow_soft_deleted
+    mock_get_workflow, test_client_graphql, mocked_processes, test_workflow_soft_deleted
 ):
     mock_get_workflow.return_value = None
     process_id = mocked_processes[0]
     test_query = build_simple_query(process_id)
 
-    response = test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+    )
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {
         "data": {

--- a/test/unit_tests/graphql/test_processes.py
+++ b/test/unit_tests/graphql/test_processes.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 
 from orchestrator import app_settings
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 from test.unit_tests.fixtures.workflows import add_soft_deleted_workflows  # noqa: F401
 
 
@@ -214,14 +215,14 @@ query ProcessQuery($first: Int!, $after: Int!, $sortBy: [GraphqlSort!], $filterB
 
 
 def test_processes_has_next_page(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
     generic_subscription_1,
 ):
     data = get_processes_query()
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     processes_data = result["data"]["processes"]
@@ -244,14 +245,14 @@ def test_processes_has_next_page(
 
 
 def test_process_has_previous_page(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
     generic_subscription_1,
 ):
     data = get_processes_query(after=1)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -271,7 +272,7 @@ def test_process_has_previous_page(
 
 
 def test_processes_sorting_asc(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -280,7 +281,7 @@ def test_processes_sorting_asc(
     # when
 
     data = get_processes_query(sort_by=[{"field": "startedAt", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -304,7 +305,7 @@ def test_processes_sorting_asc(
 
 
 def test_processes_sorting_desc(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -313,7 +314,7 @@ def test_processes_sorting_desc(
     # when
 
     data = get_processes_query(sort_by=[{"field": "startedAt", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -347,7 +348,7 @@ def test_processes_sorting_desc(
     ],
 )
 def test_processes_has_filtering(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -357,7 +358,7 @@ def test_processes_has_filtering(
     # when
 
     data = get_processes_query(**query_args)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     # then
 
     assert HTTPStatus.OK == response.status_code
@@ -383,7 +384,7 @@ def test_processes_has_filtering(
 
 
 def test_processes_filtering_with_invalid_filter(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -394,7 +395,7 @@ def test_processes_filtering_with_invalid_filter(
     data = get_processes_query(
         filter_by=[{"field": "lastStatus", "value": "completed"}, {"field": "test", "value": "invalid"}]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -450,7 +451,7 @@ def test_processes_filtering_with_invalid_filter(
     ],
 )
 def test_processes_various_filterings(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -461,7 +462,9 @@ def test_processes_various_filterings(
     # when
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_processes_query(**query_args)
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
 
     # then
 
@@ -481,7 +484,7 @@ def test_processes_various_filterings(
     ],
 )
 def test_single_process(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -492,7 +495,7 @@ def test_single_process(
     # when
 
     data = get_processes_query(**query_args(process_pid))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -514,7 +517,7 @@ def test_single_process(
 
 
 def test_single_process_with_form(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     generic_subscription_2,
     generic_subscription_1,
@@ -523,7 +526,7 @@ def test_single_process_with_form(
     # when
 
     data = get_processes_query(filter_by=[{"field": "process_id", "value": process_pid}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -560,7 +563,7 @@ def test_single_process_with_form(
     ],
 )
 def test_single_process_with_subscriptions(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -571,7 +574,7 @@ def test_single_process_with_subscriptions(
     # when
 
     data = get_processes_query_with_subscriptions(**query_args(process_pid))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
     assert HTTPStatus.OK == response.status_code
@@ -593,7 +596,7 @@ def test_single_process_with_subscriptions(
 
 
 def test_processes_sorting_product_tag_asc(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -602,7 +605,7 @@ def test_processes_sorting_product_tag_asc(
     # when
 
     data = get_processes_query(sort_by=[{"field": "productTag", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -643,7 +646,7 @@ def test_processes_sorting_product_tag_asc(
     ],
 )
 def test_processes_state_updates_and_delta(
-    test_client,
+    test_client_graphql,
     mocked_processes,
     mocked_processes_resumeall,
     generic_subscription_2,
@@ -654,7 +657,7 @@ def test_processes_state_updates_and_delta(
 
     process_pid = str(mocked_processes[0])
     data = get_processes_state_updates_and_delta(**query_args(process_pid))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 

--- a/test/unit_tests/graphql/test_product.py
+++ b/test/unit_tests/graphql/test_product.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 import pytest
 from fastapi import Response
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
+
 
 def get_product_query(
     first: int = 10,
@@ -204,10 +206,12 @@ query ProductQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $sor
     ],
 )
 def test_product_query(
-    test_client, generic_product_1, generic_product_2, generic_product_3, query_args, num_results, total
+    test_client_graphql, generic_product_1, generic_product_2, generic_product_3, query_args, num_results, total
 ):
     data = get_product_query(**query_args)
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -226,10 +230,12 @@ def test_product_query(
     }
 
 
-def test_all_product_block_names(test_client, test_product_one_nested):
+def test_all_product_block_names(test_client_graphql, test_product_one_nested):
     filter_by = {"filter_by": {"field": "name", "value": "TestProductOneNested"}}
     data = get_all_product_names_query(**filter_by)
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -240,9 +246,11 @@ def test_all_product_block_names(test_client, test_product_one_nested):
     assert names == ["PB_Chained_1", "PB_Chained_2", "ProductBlockOneNestedForTest"]
 
 
-def test_product_has_previous_page(test_client, generic_product_1, generic_product_2, generic_product_3):
+def test_product_has_previous_page(test_client_graphql, generic_product_1, generic_product_2, generic_product_3):
     data = get_product_query(after=1, sort_by=[{"field": "name", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -272,10 +280,12 @@ def test_product_has_previous_page(test_client, generic_product_1, generic_produ
     ],
 )
 def test_products_filter_by_product_block(
-    test_client, generic_product_1, generic_product_2, generic_product_3, query_args
+    test_client_graphql, generic_product_1, generic_product_2, generic_product_3, query_args
 ):
     data = get_product_query(**query_args, sort_by=[{"field": "name", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     products_data = result["data"]["products"]
@@ -293,9 +303,11 @@ def test_products_filter_by_product_block(
     assert products[1]["name"] == "Product 2"
 
 
-def test_products_sort_by_tag(test_client, generic_product_1, generic_product_2, generic_product_3):
+def test_products_sort_by_tag(test_client_graphql, generic_product_1, generic_product_2, generic_product_3):
     data = get_product_query(sort_by=[{"field": "tag", "order": "DESC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 
@@ -322,13 +334,13 @@ def test_products_sort_by_tag(test_client, generic_product_1, generic_product_2,
     ],
 )
 def test_single_product_with_subscriptions(
-    test_client, mocked_processes, generic_product_1, generic_subscription_2, generic_subscription_1, query_args
+    test_client_graphql, mocked_processes, generic_product_1, generic_subscription_2, generic_subscription_1, query_args
 ):
     product_id = str(generic_product_1.product_id)
     # when
 
     data = get_products_with_related_subscriptions_query(**query_args(product_id))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 

--- a/test/unit_tests/graphql/test_product_blocks.py
+++ b/test/unit_tests/graphql/test_product_blocks.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import Response
 
 from orchestrator import app_settings
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 from test.unit_tests.helpers import assert_no_diff
 
 
@@ -85,9 +86,11 @@ query ProductBlocksQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!]
         ({"query_string": "tag:pb3"}, 1),
     ],
 )
-def test_product_blocks_query(test_client, query_args, num_results):
+def test_product_blocks_query(test_client_graphql, query_args, num_results):
     data = get_product_blocks_query(**query_args)
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -108,9 +111,11 @@ def test_product_blocks_query(test_client, query_args, num_results):
     }
 
 
-def test_product_blocks_payload(test_client):
+def test_product_blocks_payload(test_client_graphql):
     data = get_product_blocks_query(first=2, sort_by=[{"field": "name", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -169,11 +174,11 @@ def test_product_blocks_payload(test_client):
         {"query_string": "name:(SubBlock* | ProductBlock*)"},
     ],
 )
-def test_product_block_query_with_relations(test_client, query_args):
+def test_product_block_query_with_relations(test_client_graphql, query_args):
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_product_blocks_query(**query_args)
-        response: Response = test_client.post(
-            "/api/graphql", content=data, headers={"Content-Type": "application/json"}
+        response: Response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
         )
 
     assert HTTPStatus.OK == response.status_code
@@ -243,9 +248,11 @@ def test_product_block_query_with_relations(test_client, query_args):
     assert_no_diff(expected_product_blocks, actual_product_blocks, exclude_paths=exclude_paths)
 
 
-def test_product_blocks_has_previous_page(test_client):
+def test_product_blocks_has_previous_page(test_client_graphql):
     data = get_product_blocks_query(after=1, sort_by=[{"field": "name", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -273,9 +280,11 @@ def test_product_blocks_has_previous_page(test_client):
         {"query_string": "resourceType:rt_1"},
     ],
 )
-def test_product_blocks_filter_by_resource_types(test_client, query_args):
+def test_product_blocks_filter_by_resource_types(test_client_graphql, query_args):
     data = get_product_blocks_query(**query_args, sort_by=[{"field": "name", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     product_blocks_data = result["data"]["productBlocks"]
@@ -292,12 +301,14 @@ def test_product_blocks_filter_by_resource_types(test_client, query_args):
     assert actual_product_blocks[0]["name"] == "PB_1"
 
 
-def test_product_blocks_filter_by_products(test_client):
+def test_product_blocks_filter_by_products(test_client_graphql):
     data = get_product_blocks_query(
         filter_by=[{"field": "product", "value": "Product 1|Product 3"}],
         sort_by=[{"field": "name", "order": "ASC"}],
     )
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     product_blocks_data = result["data"]["productBlocks"]
@@ -316,9 +327,11 @@ def test_product_blocks_filter_by_products(test_client):
     assert actual_product_blocks[1]["name"] == "PB_2"
 
 
-def test_product_blocks_sort_by_tag(test_client):
+def test_product_blocks_sort_by_tag(test_client_graphql):
     data = get_product_blocks_query(sort_by=[{"field": "tag", "order": "DESC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 

--- a/test/unit_tests/graphql/test_resource_types.py
+++ b/test/unit_tests/graphql/test_resource_types.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import Response
 
 from orchestrator import app_settings
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 
 
 def get_resource_types_query(
@@ -48,9 +49,11 @@ query ResourceTypesQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!]
     ).encode("utf-8")
 
 
-def test_resource_types_query(test_client):
+def test_resource_types_query(test_client_graphql):
     data = get_resource_types_query(first=2)
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -70,9 +73,11 @@ def test_resource_types_query(test_client):
     }
 
 
-def test_resource_types_has_previous_page(test_client):
+def test_resource_types_has_previous_page(test_client_graphql):
     data = get_resource_types_query(after=3, sort_by=[{"field": "resourceType", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -101,10 +106,10 @@ def test_resource_types_has_previous_page(test_client):
         {"query_string": "resourceType:rt_*"},
     ],
 )
-def test_resource_types_filter_by_resource_type(test_client, query_args):
+def test_resource_types_filter_by_resource_type(test_client_graphql, query_args):
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_resource_types_query(**query_args, sort_by=[{"field": "resourceType", "order": "ASC"}])
-        response: Response = test_client.post(
+        response: Response = test_client_graphql.post(
             "/api/graphql", content=data, headers={"Content-Type": "application/json"}
         )
 
@@ -133,9 +138,11 @@ def test_resource_types_filter_by_resource_type(test_client, query_args):
         # {"query_string": "PB_1"}, Trouble comparing arbitrary text with UUID columns
     ],
 )
-def test_resource_types_filter_by_product_blocks(test_client, query_args):
+def test_resource_types_filter_by_product_blocks(test_client_graphql, query_args):
     data = get_resource_types_query(**query_args, sort_by=[{"field": "resourceType", "order": "ASC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     resource_types_data = result["data"]["resourceTypes"]
@@ -153,9 +160,11 @@ def test_resource_types_filter_by_product_blocks(test_client, query_args):
     assert resource_types[0]["resourceType"] == "rt_1"
 
 
-def test_resource_types_sort_by_resource_type_desc(test_client):
+def test_resource_types_sort_by_resource_type_desc(test_client_graphql):
     data = get_resource_types_query(sort_by=[{"field": "resourceType", "order": "DESC"}])
-    response: Response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response: Response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 

--- a/test/unit_tests/graphql/test_scheduled_tasks.py
+++ b/test/unit_tests/graphql/test_scheduled_tasks.py
@@ -2,6 +2,8 @@ import json
 from http import HTTPStatus
 from uuid import uuid4
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
+
 
 def get_scheduled_tasks_query(
     first: int = 10,
@@ -45,7 +47,7 @@ query ScheduledTasksQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!
     ).encode("utf-8")
 
 
-def test_scheduled_tasks_query(test_client, scheduler_with_jobs, clear_all_scheduler_jobs):
+def test_scheduled_tasks_query(test_client_graphql, scheduler_with_jobs, clear_all_scheduler_jobs):
     clear_all_scheduler_jobs()
 
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
@@ -54,7 +56,7 @@ def test_scheduled_tasks_query(test_client, scheduler_with_jobs, clear_all_sched
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
 
     data = get_scheduled_tasks_query(first=2)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()
@@ -74,7 +76,7 @@ def test_scheduled_tasks_query(test_client, scheduler_with_jobs, clear_all_sched
     }
 
 
-def test_scheduled_tasks_has_previous_page(test_client, scheduler_with_jobs, clear_all_scheduler_jobs):
+def test_scheduled_tasks_has_previous_page(test_client_graphql, scheduler_with_jobs, clear_all_scheduler_jobs):
     clear_all_scheduler_jobs()
 
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
@@ -83,7 +85,7 @@ def test_scheduled_tasks_has_previous_page(test_client, scheduler_with_jobs, cle
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
 
     data = get_scheduled_tasks_query(after=1, sort_by=[{"field": "name", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()
@@ -103,7 +105,7 @@ def test_scheduled_tasks_has_previous_page(test_client, scheduler_with_jobs, cle
     assert len(scheduled_tasks) == 3
 
 
-def test_scheduled_tasks_filter(test_client, scheduler_with_jobs, clear_all_scheduler_jobs):
+def test_scheduled_tasks_filter(test_client_graphql, scheduler_with_jobs, clear_all_scheduler_jobs):
     clear_all_scheduler_jobs()
 
     scheduler_with_jobs(
@@ -118,7 +120,7 @@ def test_scheduled_tasks_filter(test_client, scheduler_with_jobs, clear_all_sche
     data = get_scheduled_tasks_query(
         filter_by=[{"field": "name", "value": "validat"}], sort_by=[{"field": "name", "order": "ASC"}]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()
@@ -141,9 +143,9 @@ def test_scheduled_tasks_filter(test_client, scheduler_with_jobs, clear_all_sche
     assert [job["name"] for job in scheduled_tasks] == expected_workflows
 
 
-def test_scheduled_tasks_invalid_filter(test_client):
+def test_scheduled_tasks_invalid_filter(test_client_graphql):
     data = get_scheduled_tasks_query(filter_by=[{"field": "idd", "value": "validate"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()
@@ -168,7 +170,7 @@ def test_scheduled_tasks_invalid_filter(test_client):
     assert not scheduled_tasks
 
 
-def test_scheduled_tasks_sort_by(test_client, scheduler_with_jobs, clear_all_scheduler_jobs):
+def test_scheduled_tasks_sort_by(test_client_graphql, scheduler_with_jobs, clear_all_scheduler_jobs):
     clear_all_scheduler_jobs()
 
     scheduler_with_jobs(
@@ -185,7 +187,7 @@ def test_scheduled_tasks_sort_by(test_client, scheduler_with_jobs, clear_all_sch
     scheduler_with_jobs(job_name="Clean up tasks", workflow_name="task-clean-up-tasks", schedule_id=f"{uuid4()}")
 
     data = get_scheduled_tasks_query(sort_by=[{"field": "name", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()
@@ -210,7 +212,7 @@ def test_scheduled_tasks_sort_by(test_client, scheduler_with_jobs, clear_all_sch
     assert [job["name"] for job in scheduled_tasks] == expected_workflows
 
 
-def test_scheduled_tasks_invalid_sort(test_client, scheduler_with_jobs, clear_all_scheduler_jobs):
+def test_scheduled_tasks_invalid_sort(test_client_graphql, scheduler_with_jobs, clear_all_scheduler_jobs):
     clear_all_scheduler_jobs()
 
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
@@ -219,7 +221,7 @@ def test_scheduled_tasks_invalid_sort(test_client, scheduler_with_jobs, clear_al
     scheduler_with_jobs(schedule_id=f"{uuid4()}")
 
     data = get_scheduled_tasks_query(sort_by=[{"field": "namee", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code, response.text
     result = response.json()

--- a/test/unit_tests/graphql/test_settings.py
+++ b/test/unit_tests/graphql/test_settings.py
@@ -70,8 +70,8 @@ mutation UpdateStatusMutation($globalLock: Boolean = false) {
     ).encode("utf-8")
 
 
-def test_settings_query(test_client):
-    response = test_client.post(
+def test_settings_query(test_client_graphql):
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT,
         content=get_settings_query(),
         headers=GRAPHQL_HEADERS,
@@ -89,14 +89,14 @@ def test_settings_query(test_client):
     # numberOfRunningJobs is different depending if you run the whole suite vs just the graphql tests
 
 
-def test_clear_cache_mutation_fails_auth(test_client, monkeypatch):
+def test_clear_cache_mutation_fails_auth(test_client_graphql, monkeypatch):
     from oauth2_lib.settings import oauth2lib_settings
 
     monkeypatch.setattr(oauth2lib_settings, "ENVIRONMENT_IGNORE_MUTATION_DISABLED", [])
 
     # oauth2lib_settings.ENVIRONMENT_IGNORE_MUTATION_DISABLED = []
     data = get_clear_cache_mutation()
-    response = test_client.post("/api/graphql", content=data, headers=GRAPHQL_HEADERS)
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers=GRAPHQL_HEADERS)
     assert response.status_code == HTTPStatus.OK
     result = response.json()
 
@@ -104,7 +104,7 @@ def test_clear_cache_mutation_fails_auth(test_client, monkeypatch):
     assert result["errors"][0]["message"] == "User is not authenticated"
 
 
-def test_success_clear_cache(test_client, cache_fixture):
+def test_success_clear_cache(test_client_graphql, cache_fixture):
     cache = create_redis_client(app_settings.CACHE_URI)
     key = "some_model_uuid"
     test_data = {key: {"data": [1, 2, 3]}}
@@ -120,7 +120,7 @@ def test_success_clear_cache(test_client, cache_fixture):
 
     assert len(cache.keys()) == 2
 
-    response = test_client.post("/api/graphql", content=get_clear_cache_mutation(), headers=GRAPHQL_HEADERS)
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=get_clear_cache_mutation(), headers=GRAPHQL_HEADERS)
     assert HTTPStatus.OK == response.status_code
 
     result = response.json()
@@ -130,17 +130,19 @@ def test_success_clear_cache(test_client, cache_fixture):
     assert data["deleted"] == 2
 
 
-def test_failure_clear_cache(test_client):
-    response = test_client.post(GRAPHQL_ENDPOINT, content=get_clear_cache_mutation("invalid"), headers=GRAPHQL_HEADERS)
+def test_failure_clear_cache(test_client_graphql):
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=get_clear_cache_mutation("invalid"), headers=GRAPHQL_HEADERS
+    )
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 
     assert result["data"] == {"clearCache": {"__typename": "Error", "message": "Invalid cache name"}}
 
 
-def test_mutate_engine_global_settings(test_client):
+def test_mutate_engine_global_settings(test_client_graphql):
     # Turn it off
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT, content=get_test_set_global_lock_mutation(True), headers=GRAPHQL_HEADERS
     )
     assert HTTPStatus.OK == response.status_code
@@ -153,7 +155,7 @@ def test_mutate_engine_global_settings(test_client):
     assert status_data["globalLock"] is True
 
     # Turn it back on
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT, content=get_test_set_global_lock_mutation(False), headers=GRAPHQL_HEADERS
     )
     assert HTTPStatus.OK == response.status_code

--- a/test/unit_tests/graphql/test_sort_and_filter_fields.py
+++ b/test/unit_tests/graphql/test_sort_and_filter_fields.py
@@ -27,6 +27,7 @@ from orchestrator.db.sorting.product_block import product_block_sort_fields
 from orchestrator.db.sorting.resource_type import resource_type_sort_fields
 from orchestrator.db.sorting.subscription import subscription_sort_fields
 from orchestrator.db.sorting.workflow import workflow_sort_fields
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 
 
 def get_page_info_sort_and_filter_fields(type_name) -> bytes:
@@ -59,9 +60,9 @@ query PageInfoSortAndFilterQuery {{
         ("resourceTypes", resource_type_sort_fields(), resource_type_filter_fields()),
     ],
 )
-def test_process_sort_and_filter_fields_in_page_info(test_client, type_name, sort_fields, filter_fields):
+def test_process_sort_and_filter_fields_in_page_info(test_client_graphql, type_name, sort_fields, filter_fields):
     data = get_page_info_sort_and_filter_fields(type_name)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()

--- a/test/unit_tests/graphql/test_subscription.py
+++ b/test/unit_tests/graphql/test_subscription.py
@@ -14,6 +14,8 @@ import json
 from http import HTTPStatus
 from uuid import uuid4
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
+
 
 def build_simple_query(subscription_id):
 
@@ -77,38 +79,44 @@ def build_last_validation_query(subscription_id):
     ).encode("utf-8")
 
 
-def test_last_validation_query(fastapi_app_graphql, test_client, validation_workflow_process_instance, benchmark):
+def test_last_validation_query(test_client_graphql, validation_workflow_process_instance, benchmark):
     process, process_subscription = validation_workflow_process_instance
     test_query = build_last_validation_query(process_subscription.subscription_id)
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+        )
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data": {"subscription": {"lastValidatedAt": process.last_modified_at.isoformat()}}}
 
 
-def test_single_simple_subscription(fastapi_app_graphql, test_client, product_sub_list_union_subscription_1, benchmark):
+def test_single_simple_subscription(test_client_graphql, product_sub_list_union_subscription_1, benchmark):
     test_query = build_simple_query(subscription_id=product_sub_list_union_subscription_1)
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+        )
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data": {"subscription": {"insync": True, "status": "ACTIVE"}}}
 
 
 def test_single_complex_subscription(
-    fastapi_app_graphql, test_client, product_sub_list_union_subscription_1, test_product_type_sub_list_union, benchmark
+    test_client_graphql, product_sub_list_union_subscription_1, test_product_type_sub_list_union, benchmark
 ):
     _, _, ProductSubListUnion = test_product_type_sub_list_union
     test_query = build_complex_query(subscription_id=product_sub_list_union_subscription_1)
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+        )
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {
@@ -123,12 +131,14 @@ def test_single_complex_subscription(
     }
 
 
-def test_subscription_does_not_exist(fastapi_app_graphql, test_client, benchmark):
+def test_subscription_does_not_exist(test_client_graphql, benchmark):
     test_query = build_simple_query(uuid4())
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=test_query, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=test_query, headers={"Content-Type": "application/json"}
+        )
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data": {"subscription": None}}

--- a/test/unit_tests/graphql/test_subscription_relations.py
+++ b/test/unit_tests/graphql/test_subscription_relations.py
@@ -15,6 +15,7 @@ from http import HTTPStatus
 
 import pytest
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 from test.unit_tests.conftest import do_refresh_subscriptions_search_view
 
 
@@ -201,8 +202,7 @@ def get_subscriptions_query_with_relations(
     ],
 )
 def test_single_subscription_with_processes(
-    fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     mocked_processes,
     mocked_processes_resumeall,  # noqa: F811
@@ -218,7 +218,7 @@ def test_single_subscription_with_processes(
     do_refresh_subscriptions_search_view()
 
     data = get_subscriptions_query_with_processes(**query_args(subscription_id))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -242,8 +242,7 @@ def test_single_subscription_with_processes(
 
 
 def test_single_subscription_with_depends_on_subscriptions(
-    fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     sub_one_subscription_1,
     sub_two_subscription_1,
@@ -257,7 +256,7 @@ def test_single_subscription_with_depends_on_subscriptions(
 
     subscription_id = str(product_sub_list_union_subscription_1)
     data = get_subscriptions_query_with_relations(query_string=subscription_id)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     expected_depends_on_ids = {
         str(subscription.subscription_id) for subscription in [sub_one_subscription_1, sub_two_subscription_1]
@@ -287,8 +286,7 @@ def test_single_subscription_with_depends_on_subscriptions(
 
 
 def test_single_subscription_with_in_use_by_subscriptions(
-    fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     sub_one_subscription_1,
     product_sub_list_union_subscription_1,
@@ -302,8 +300,8 @@ def test_single_subscription_with_in_use_by_subscriptions(
         filter_by=[{"field": "subscriptionId", "value": subscription_id}]
     )
 
-    response = test_client.post(
-        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=subscription_query, headers={"Content-Type": "application/json"}
     )
 
     expected_in_use_by_ids = [str(product_sub_list_union_subscription_1)]
@@ -431,8 +429,7 @@ in_use_by_recurse_only_product_type_test_ids = [
     ],
 )
 def test_single_subscription_with_in_use_by_subscriptions_recurse(
-    fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     factory_subscription_with_nestings_in_use_by,
     in_use_by_filter,
     in_use_by_subscription_filter,
@@ -450,8 +447,8 @@ def test_single_subscription_with_in_use_by_subscriptions_recurse(
         in_use_by_subscription_filter=in_use_by_subscription_filter,
     )
 
-    response = test_client.post(
-        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=subscription_query, headers={"Content-Type": "application/json"}
     )
 
     expected_relation_ids = [all_ids[sub_id] for sub_id in subscription_ids]
@@ -573,8 +570,7 @@ depends_on_recurse_only_product_type_test_ids = [
     ],
 )
 def test_single_subscription_with_depends_on_subscriptions_recurse(
-    fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     factory_subscription_with_nestings_depends_on,
     depends_on_filter,
     depends_on_subscription_filter,
@@ -592,8 +588,8 @@ def test_single_subscription_with_depends_on_subscriptions_recurse(
         depends_on_subscription_filter=depends_on_subscription_filter,
     )
 
-    response = test_client.post(
-        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=subscription_query, headers={"Content-Type": "application/json"}
     )
 
     expected_relation_ids = [all_ids[sub_id] for sub_id in subscription_ids]

--- a/test/unit_tests/graphql/test_subscriptions.py
+++ b/test/unit_tests/graphql/test_subscriptions.py
@@ -23,6 +23,7 @@ from orchestrator.db import SubscriptionMetadataTable, db
 from orchestrator.db.models import SubscriptionCustomerDescriptionTable, SubscriptionTable
 from orchestrator.domain.base import SubscriptionModel
 from orchestrator.types import SubscriptionLifecycle
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 from test.unit_tests.conftest import do_refresh_subscriptions_search_view
 
 subscription_fields = [
@@ -62,6 +63,19 @@ query SubscriptionQuery(
     {body}
 }}
 """
+
+
+@pytest.fixture(autouse=True)
+def patch_metadata_dict():
+    from pydantic import BaseModel
+
+    from orchestrator.graphql.schemas.subscription import MetadataDict
+
+    class Metadata(BaseModel):
+        some_metadata_prop: list[str]
+
+    with patch.dict(MetadataDict, {"metadata": Metadata}):
+        yield
 
 
 def get_subscriptions_query(
@@ -413,7 +427,9 @@ def get_subscriptions_with_metadata_and_schema_query(
     ).encode("utf-8")
 
 
-def test_subscriptions_single_page(test_client, product_type_1_subscriptions_factory, benchmark, monitor_sqlalchemy):
+def test_subscriptions_single_page(
+    test_client_graphql, product_type_1_subscriptions_factory, benchmark, monitor_sqlalchemy
+):
     # when
 
     product_type_1_subscriptions_factory(4)
@@ -423,7 +439,9 @@ def test_subscriptions_single_page(test_client, product_type_1_subscriptions_fac
 
         @benchmark
         def response():
-            return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+            return test_client_graphql.post(
+                GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+            )
 
     # then
 
@@ -450,12 +468,12 @@ def test_subscriptions_single_page(test_client, product_type_1_subscriptions_fac
             assert field in subscription["product"]
 
 
-def test_subscriptions_has_next_page(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_has_next_page(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query()
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -480,12 +498,12 @@ def test_subscriptions_has_next_page(test_client, product_type_1_subscriptions_f
             assert field in subscription
 
 
-def test_subscriptions_has_previous_page(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_has_previous_page(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query(after=1)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -508,12 +526,12 @@ def test_subscriptions_has_previous_page(test_client, product_type_1_subscriptio
     }
 
 
-def test_subscriptions_sorting_asc(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_sorting_asc(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query(sort_by=[{"field": "startDate", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -537,12 +555,12 @@ def test_subscriptions_sorting_asc(test_client, product_type_1_subscriptions_fac
         assert subscriptions[i]["startDate"] < subscriptions[i + 1]["startDate"]
 
 
-def test_subscriptions_sorting_desc(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_sorting_desc(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query(sort_by=[{"field": "startDate", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -566,11 +584,11 @@ def test_subscriptions_sorting_desc(test_client, product_type_1_subscriptions_fa
         assert subscriptions[i + 1]["startDate"] < subscriptions[i]["startDate"]
 
 
-def test_subscriptions_sorting_product_tag_asc(test_client, generic_subscription_1, generic_subscription_2):
+def test_subscriptions_sorting_product_tag_asc(test_client_graphql, generic_subscription_1, generic_subscription_2):
     # when
 
     data = get_subscriptions_query(sort_by=[{"field": "tag", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -594,11 +612,11 @@ def test_subscriptions_sorting_product_tag_asc(test_client, generic_subscription
     assert product_tag_list == ["GEN1", "GEN2", "Sub", "Sub", "UnionSub"]
 
 
-def test_subscriptions_sorting_product_tag_desc(test_client, generic_subscription_1, generic_subscription_2):
+def test_subscriptions_sorting_product_tag_desc(test_client_graphql, generic_subscription_1, generic_subscription_2):
     # when
 
     data = get_subscriptions_query(sort_by=[{"field": "tag", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -622,12 +640,12 @@ def test_subscriptions_sorting_product_tag_desc(test_client, generic_subscriptio
     assert product_tag_list == ["UnionSub", "Sub", "Sub", "GEN2", "GEN1"]
 
 
-def test_subscriptions_sorting_invalid_field(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_sorting_invalid_field(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query(sort_by=[{"field": "start_date", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -661,12 +679,12 @@ def test_subscriptions_sorting_invalid_field(test_client, product_type_1_subscri
     ]
 
 
-def test_subscriptions_sorting_invalid_order(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_sorting_invalid_order(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
     data = get_subscriptions_query(sort_by=[{"field": "start_date", "order": "test"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -686,7 +704,7 @@ def test_subscriptions_sorting_invalid_order(test_client, product_type_1_subscri
     ],
 )
 def test_subscriptions_filtering_on_status(
-    test_client, product_type_1_subscriptions_factory, generic_product_type_1, query_args
+    test_client_graphql, product_type_1_subscriptions_factory, generic_product_type_1, query_args
 ):
     # when
 
@@ -703,8 +721,8 @@ def test_subscriptions_filtering_on_status(
 
     subscription_query = get_subscriptions_query(**query_args)
 
-    response = test_client.post(
-        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=subscription_query, headers={"Content-Type": "application/json"}
     )
 
     # then
@@ -732,14 +750,16 @@ def test_subscriptions_filtering_on_status(
     assert subscriptions[1]["status"] == "TERMINATED"
 
 
-def test_subscriptions_range_filtering_on_start_date(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_range_filtering_on_start_date(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(30)
 
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_subscriptions_query(first=1, filter_by=[{"field": "startDate", "value": "2023-05-24"}])
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
         first_subscription = response.json()["data"]["subscriptions"]["page"][0]
 
     first_subscription_date = datetime.datetime.fromisoformat(first_subscription["startDate"])
@@ -752,7 +772,7 @@ def test_subscriptions_range_filtering_on_start_date(test_client, product_type_1
             {"field": "startDate", "value": f"<={lower_than_date}"},
         ]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -775,14 +795,16 @@ def test_subscriptions_range_filtering_on_start_date(test_client, product_type_1
         assert higher_than_date <= subscription["startDate"] <= lower_than_date
 
 
-def test_subscriptions_with_exact_filter_by(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_with_exact_filter_by(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(20)
 
     with patch.object(app_settings, "FILTER_BY_MODE", "exact"):
         data = get_subscriptions_query(filter_by=[{"field": "description", "value": "Subscription 1"}])
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
 
     # then
 
@@ -803,13 +825,13 @@ def test_subscriptions_with_exact_filter_by(test_client, product_type_1_subscrip
     }
 
 
-def test_subscriptions_range_filtering_on_type(test_client, product_type_1_subscriptions_factory):
+def test_subscriptions_range_filtering_on_type(test_client_graphql, product_type_1_subscriptions_factory):
     # when
 
     product_type_1_subscriptions_factory(15)
 
     data = get_subscriptions_query(filter_by=[{"field": "type", "value": "Test"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -833,7 +855,7 @@ def test_subscriptions_range_filtering_on_type(test_client, product_type_1_subsc
 
 
 def test_subscriptions_filtering_with_invalid_filter(
-    test_client, product_type_1_subscriptions_factory, generic_product_type_1
+    test_client_graphql, product_type_1_subscriptions_factory, generic_product_type_1
 ):
     # when
 
@@ -853,7 +875,7 @@ def test_subscriptions_filtering_with_invalid_filter(
             {"field": "test", "value": "invalid"},
         ]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -899,7 +921,9 @@ def test_subscriptions_filtering_with_invalid_filter(
         lambda sid: {"query_string": CUSTOMER_ID.split("-")[0]},
     ],
 )
-def test_single_subscription(test_client, product_type_1_subscriptions_factory, generic_product_type_1, query_args):
+def test_single_subscription(
+    test_client_graphql, product_type_1_subscriptions_factory, generic_product_type_1, query_args
+):
     # given
 
     _, GenericProductOne = generic_product_type_1
@@ -925,7 +949,9 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
     # when
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_subscriptions_query(**query_args(subscription_id))
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
 
     subscription = GenericProductOne.from_subscription(subscription_id)
 
@@ -994,7 +1020,7 @@ def test_single_subscription(test_client, product_type_1_subscriptions_factory, 
     ],
 )
 def test_multiple_subscriptions(
-    test_client, product_type_1_subscriptions_factory, generic_product_type_1, query_args, total_items
+    test_client_graphql, product_type_1_subscriptions_factory, generic_product_type_1, query_args, total_items
 ):
     # given
 
@@ -1005,7 +1031,7 @@ def test_multiple_subscriptions(
 
     # when
     data = get_subscriptions_query(first=100, **query_args(subscription_ids))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1034,8 +1060,8 @@ def test_multiple_subscriptions(
     ],
 )
 def test_single_subscription_with_processes(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     mocked_processes,
     mocked_processes_resumeall,  # noqa: F811
@@ -1051,7 +1077,7 @@ def test_single_subscription_with_processes(
     do_refresh_subscriptions_search_view()
 
     data = get_subscriptions_query_with_relations(**query_args(subscription_id))
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1075,8 +1101,8 @@ def test_single_subscription_with_processes(
 
 
 def test_single_subscription_with_depends_on_subscriptions(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     sub_one_subscription_1,
     sub_two_subscription_1,
@@ -1094,7 +1120,7 @@ def test_single_subscription_with_depends_on_subscriptions(
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     expected_depends_on_ids = {
         str(subscription.subscription_id) for subscription in [sub_one_subscription_1, sub_two_subscription_1]
@@ -1125,8 +1151,8 @@ def test_single_subscription_with_depends_on_subscriptions(
 
 
 def test_single_subscription_with_in_use_by_subscriptions(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     sub_one_subscription_1,
     product_sub_list_union_subscription_1,
@@ -1140,8 +1166,8 @@ def test_single_subscription_with_in_use_by_subscriptions(
         filter_by=[{"field": "subscriptionId", "value": subscription_id}]
     )
 
-    response = test_client.post(
-        "/api/graphql", content=subscription_query, headers={"Content-Type": "application/json"}
+    response = test_client_graphql.post(
+        GRAPHQL_ENDPOINT, content=subscription_query, headers={"Content-Type": "application/json"}
     )
 
     expected_in_use_by_ids = [str(product_sub_list_union_subscription_1)]
@@ -1186,8 +1212,8 @@ def test_single_subscription_with_in_use_by_subscriptions(
 
 
 def test_single_subscription_schema(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
     sub_one_subscription_1,
     sub_two_subscription_1,
@@ -1204,7 +1230,7 @@ def test_single_subscription_schema(
 
     @benchmark
     def response():
-        return test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        return test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1366,8 +1392,8 @@ def test_single_subscription_schema(
 
 
 def test_single_subscription_metadata_and_schema(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     sub_one_subscription_1,
 ):
     # when
@@ -1380,7 +1406,7 @@ def test_single_subscription_metadata_and_schema(
     data = get_subscriptions_with_metadata_and_schema_query(
         filter_by=[{"field": "subscriptionId", "value": subscription_id}]
     )
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     # then
 
     assert HTTPStatus.OK == response.status_code
@@ -1402,8 +1428,8 @@ def test_single_subscription_metadata_and_schema(
 
 
 def test_subscriptions_product_generic_one(
-    fastapi_app_graphql,
-    test_client,
+    load_fixtures,
+    test_client_graphql,
     product_type_1_subscriptions_factory,
 ):
     # when
@@ -1420,7 +1446,7 @@ def test_subscriptions_product_generic_one(
     db.session.commit()
 
     data = get_subscriptions_product_generic_one(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1453,15 +1479,15 @@ def test_subscriptions_product_generic_one(
 
 
 def test_single_subscription_product_list_union_type(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_sub_list_union_subscription_1,
 ):
     # when
 
     subscription_id = str(product_sub_list_union_subscription_1)
     data = get_subscriptions_product_sub_list_union(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1494,8 +1520,8 @@ def test_single_subscription_product_list_union_type(
 
 
 def test_single_subscription_product_list_union_type_provisioning_subscription(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_sub_list_union_subscription_1,
 ):
     # when
@@ -1506,7 +1532,7 @@ def test_single_subscription_product_list_union_type_provisioning_subscription(
 
     subscription_id = str(product_sub_list_union_subscription_1)
     data = get_subscriptions_product_sub_list_union(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 
@@ -1538,8 +1564,8 @@ def test_single_subscription_product_list_union_type_provisioning_subscription(
 
 
 def test_single_subscription_product_list_union_type_terminated_subscription(
-    fastapi_app_graphql,
-    test_client,
+    fastapi_app,
+    test_client_graphql,
     product_sub_list_union_subscription_1,
 ):
     # when
@@ -1550,7 +1576,7 @@ def test_single_subscription_product_list_union_type_terminated_subscription(
 
     subscription_id = str(product_sub_list_union_subscription_1)
     data = get_subscriptions_product_sub_list_union(filter_by=[{"field": "subscriptionId", "value": subscription_id}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     # then
 

--- a/test/unit_tests/graphql/test_version.py
+++ b/test/unit_tests/graphql/test_version.py
@@ -1,6 +1,8 @@
 import json
 from http import HTTPStatus
 
+from test.unit_tests.config import GRAPHQL_ENDPOINT
+
 
 def get_version_query() -> bytes:
     query = """
@@ -13,9 +15,9 @@ def get_version_query() -> bytes:
     return json.dumps({"operationName": "VersionQuery", "query": query}).encode("utf-8")
 
 
-def test_version_query(test_client):
+def test_version_query(test_client_graphql):
     data = get_version_query()
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     assert response.status_code == HTTPStatus.OK
     result = response.json()
     assert "errors" not in result

--- a/test/unit_tests/graphql/test_workflows.py
+++ b/test/unit_tests/graphql/test_workflows.py
@@ -8,6 +8,7 @@ from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator import app_settings, workflow
 from orchestrator.targets import Target
 from orchestrator.workflow import done, init
+from test.unit_tests.config import GRAPHQL_ENDPOINT
 from test.unit_tests.fixtures.workflows import add_soft_deleted_workflows  # noqa: F401
 from test.unit_tests.workflows import WorkflowInstanceForTests
 
@@ -73,9 +74,9 @@ query WorkflowsQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!], $s
     ).encode("utf-8")
 
 
-def test_workflows_query(test_client):
+def test_workflows_query(test_client_graphql):
     data = get_workflows_query(first=2)
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -98,9 +99,9 @@ def test_workflows_query(test_client):
     }
 
 
-def test_workflows_has_previous_page(test_client):
+def test_workflows_has_previous_page(test_client_graphql):
     data = get_workflows_query(after=1, sort_by=[{"field": "name", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -134,10 +135,12 @@ def test_workflows_has_previous_page(test_client):
         {"query_string": "name:task_*"},
     ],
 )
-def test_workflows_filter_by_name(test_client, query_args):
+def test_workflows_filter_by_name(test_client_graphql, query_args):
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_workflows_query(**query_args, sort_by=[{"field": "name", "order": "ASC"}])
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -170,9 +173,9 @@ def test_workflows_filter_by_name(test_client, query_args):
         {"query_string": 'product:"Product 1"'},
     ],
 )
-def test_workflows_filter_by_product(test_client, query_args):
+def test_workflows_filter_by_product(test_client_graphql, query_args):
     data = get_workflows_query(**query_args, sort_by=[{"field": "name", "order": "ASC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     assert HTTPStatus.OK == response.status_code
     result = response.json()
     workflows_data = result["data"]["workflows"]
@@ -193,10 +196,12 @@ def test_workflows_filter_by_product(test_client, query_args):
     "query_args",
     [{"query_string": "tag:gen1"}, {"query_string": "tag:gen2"}, {"query_string": "product:Product"}],
 )
-def test_workflows_filter_by_tag(test_client, query_args):
+def test_workflows_filter_by_tag(test_client_graphql, query_args):
     with patch.object(app_settings, "FILTER_BY_MODE", "partial"):
         data = get_workflows_query(**query_args, sort_by=[{"field": "name", "order": "ASC"}])
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
 
     assert HTTPStatus.OK == response.status_code
     result = response.json()
@@ -215,9 +220,9 @@ def test_workflows_filter_by_tag(test_client, query_args):
     assert workflows[0]["name"] == "modify_note"
 
 
-def test_workflows_sort_by_resource_type_desc(test_client):
+def test_workflows_sort_by_resource_type_desc(test_client_graphql):
     data = get_workflows_query(sort_by=[{"field": "name", "order": "DESC"}])
-    response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"})
     assert HTTPStatus.OK == response.status_code
     result = response.json()
 
@@ -243,7 +248,7 @@ def test_workflows_sort_by_resource_type_desc(test_client):
     assert [rt["name"] for rt in workflows] == expected_workflows
 
 
-def test_workflows_not_allowed(test_client):
+def test_workflows_not_allowed(test_client_graphql):
     forbidden_workflow_name = "unauthorized_workflow"
 
     async def disallow(_: OIDCUserModel | None = None) -> bool:
@@ -255,7 +260,9 @@ def test_workflows_not_allowed(test_client):
 
     with WorkflowInstanceForTests(unauthorized_workflow, forbidden_workflow_name):
         data = get_workflows_query(filter_by=[{"field": "name", "value": forbidden_workflow_name}])
-        response = test_client.post("/api/graphql", content=data, headers={"Content-Type": "application/json"})
+        response = test_client_graphql.post(
+            GRAPHQL_ENDPOINT, content=data, headers={"Content-Type": "application/json"}
+        )
         assert HTTPStatus.OK == response.status_code
         result = response.json()
 

--- a/test/unit_tests/graphql/utils/test_override_class.py
+++ b/test/unit_tests/graphql/utils/test_override_class.py
@@ -13,7 +13,7 @@ from test.unit_tests.config import GRAPHQL_ENDPOINT, GRAPHQL_HEADERS
 @pytest.fixture
 def override_class_app_graphql(
     fastapi_app_graphql,
-    test_client,
+    test_client_graphql,
     sub_one_subscription_1,
 ):
     def customer_id_override(self) -> str:
@@ -159,9 +159,9 @@ query SubscriptionQuery($first: Int!, $after: Int!, $filterBy: [GraphqlFilter!],
     ).encode("utf-8")
 
 
-def test_customers(fastapi_app_graphql, test_client):
+def test_customers(test_client_graphql):
     # when
-    response = test_client.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
+    response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=get_customers_query(), headers=GRAPHQL_HEADERS)
 
     # then
     assert HTTPStatus.OK == response.status_code
@@ -174,9 +174,9 @@ def test_customers(fastapi_app_graphql, test_client):
     }
 
 
-def test_customers_overriden(override_class_app_graphql, test_client):
+def test_customers_overriden(override_class_app_graphql, test_client_graphql):
     # when
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT, content=get_customers_query(override_fields=True), headers=GRAPHQL_HEADERS
     )
 
@@ -192,9 +192,9 @@ def test_customers_overriden(override_class_app_graphql, test_client):
     }
 
 
-def test_subscription_customer(fastapi_app_graphql, test_client, sub_one_subscription_1):
+def test_subscription_customer(test_client_graphql, sub_one_subscription_1):
     # when
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT,
         content=get_subscriptions_customer_query(
             filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}]
@@ -215,9 +215,9 @@ def test_subscription_customer(fastapi_app_graphql, test_client, sub_one_subscri
     }
 
 
-def test_subscription_customer_overriden(override_class_app_graphql, test_client, sub_one_subscription_1):
+def test_subscription_customer_overriden(override_class_app_graphql, test_client_graphql, sub_one_subscription_1):
     # when
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT,
         content=get_subscriptions_customer_query(
             filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}],
@@ -241,9 +241,9 @@ def test_subscription_customer_overriden(override_class_app_graphql, test_client
     }
 
 
-def test_subscription_detail_customer(fastapi_app_graphql, test_client, sub_one_subscription_1):
+def test_subscription_detail_customer(test_client_graphql, sub_one_subscription_1):
     # when
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT,
         content=get_subscriptions_detail_customer_query(
             filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}]
@@ -264,9 +264,11 @@ def test_subscription_detail_customer(fastapi_app_graphql, test_client, sub_one_
     }
 
 
-def test_subscription_detail_customer_overriden(override_class_app_graphql, test_client, sub_one_subscription_1):
+def test_subscription_detail_customer_overriden(
+    override_class_app_graphql, test_client_graphql, sub_one_subscription_1
+):
     # when
-    response = test_client.post(
+    response = test_client_graphql.post(
         GRAPHQL_ENDPOINT,
         content=get_subscriptions_detail_customer_query(
             filter_by=[{"field": "subscriptionId", "value": str(sub_one_subscription_1.subscription_id)}],

--- a/test/unit_tests/services/test_start_predicate.py
+++ b/test/unit_tests/services/test_start_predicate.py
@@ -216,7 +216,7 @@ def test_start_predicate_passes_via_rest(test_client):
 # --- GraphQL mutation tests ---
 
 
-def test_start_predicate_returns_mutation_error_via_graphql(httpx_mock, test_client):
+def test_start_predicate_returns_mutation_error_via_graphql(test_client_graphql):
     @step("Test step")
     def test_step_fn():
         return {"result": True}
@@ -233,7 +233,7 @@ def test_start_predicate_returns_mutation_error_via_graphql(httpx_mock, test_cli
         query = get_start_process_mutation(name="test_wf_blocked_gql", payload={"payload": [{}]})
 
         with mutation_authorization():
-            response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+            response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
         assert response.status_code == HTTPStatus.OK
         data = response.json()["data"]["startProcess"]
@@ -241,7 +241,7 @@ def test_start_predicate_returns_mutation_error_via_graphql(httpx_mock, test_cli
         assert "is not satisfied" in data["details"]
 
 
-def test_start_predicate_reason_in_graphql_error(httpx_mock, test_client):
+def test_start_predicate_reason_in_graphql_error(test_client_graphql):
     @step("Test step")
     def test_step_fn():
         return {"result": True}
@@ -258,7 +258,7 @@ def test_start_predicate_reason_in_graphql_error(httpx_mock, test_client):
         query = get_start_process_mutation(name="test_wf_reason_gql", payload={"payload": [{}]})
 
         with mutation_authorization():
-            response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+            response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
         assert response.status_code == HTTPStatus.OK
         data = response.json()["data"]["startProcess"]
@@ -266,7 +266,7 @@ def test_start_predicate_reason_in_graphql_error(httpx_mock, test_client):
         assert "Already running" in data["details"]
 
 
-def test_start_predicate_passes_via_graphql(httpx_mock, test_client):
+def test_start_predicate_passes_via_graphql(test_client_graphql):
     @step("Test step")
     def test_step_fn():
         return {"result": True}
@@ -279,7 +279,7 @@ def test_start_predicate_passes_via_graphql(httpx_mock, test_client):
         query = get_start_process_mutation(name="test_wf_allowed_gql", payload={"payload": [{}]})
 
         with mutation_authorization():
-            response = test_client.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
+            response = test_client_graphql.post(GRAPHQL_ENDPOINT, content=query, headers=GRAPHQL_HEADERS)
 
         assert response.status_code == HTTPStatus.OK
         data = response.json()["data"]["startProcess"]


### PR DESCRIPTION
* Ensure that all unit tests can (and must) use a `test_client_graphql` object to test graphql queries, and that `test_client` does not have a stale graphql router
* Use `patch.object` and `patch.multiple` for patching values with automatic reset to original value