### PR TITLE
Add no_uncompleted_instance predicate to tasks

### DIFF
--- a/orchestrator/workflows/predicates.py
+++ b/orchestrator/workflows/predicates.py
@@ -16,7 +16,13 @@ from __future__ import annotations
 from sqlalchemy import func, select
 
 from orchestrator.db import ProcessTable, db
-from orchestrator.workflow import PredicateContext, RunPredicateFail, RunPredicatePass, RunPredicateResult
+from orchestrator.workflow import (
+    PredicateContext,
+    ProcessStatus,
+    RunPredicateFail,
+    RunPredicatePass,
+    RunPredicateResult,
+)
 
 
 def no_uncompleted_instance(context: PredicateContext) -> RunPredicateResult:
@@ -34,7 +40,7 @@ def no_uncompleted_instance(context: PredicateContext) -> RunPredicateResult:
         .select_from(ProcessTable)
         .filter(
             ProcessTable.workflow.has(name=workflow_name),
-            ProcessTable.last_status != "completed",
+            ProcessTable.last_status.not_in([ProcessStatus.COMPLETED, ProcessStatus.ABORTED]),
         )
     )
     if uncompleted_count == 0:

--- a/orchestrator/workflows/tasks/cleanup_tasks_log.py
+++ b/orchestrator/workflows/tasks/cleanup_tasks_log.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF, GÉANT.
+# Copyright 2019-2026 SURF, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -23,6 +23,7 @@ from orchestrator.settings import app_settings, get_authorizers
 from orchestrator.targets import Target
 from orchestrator.utils.datetime import nowtz
 from orchestrator.workflow import ProcessStatus, StepList, done, init, step, workflow
+from orchestrator.workflows.predicates import no_uncompleted_instance
 from pydantic_forms.types import State
 
 authorizers = get_authorizers()
@@ -74,6 +75,7 @@ def cleanup_ai_search_index(deleted_process_id_list: list) -> State:
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,
+    run_predicate=no_uncompleted_instance,
 )
 def task_clean_up_tasks() -> StepList:
     return init >> remove_tasks >> cleanup_ai_search_index >> done

--- a/orchestrator/workflows/tasks/resume_workflows.py
+++ b/orchestrator/workflows/tasks/resume_workflows.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF, GÉANT.
+# Copyright 2019-2026 SURF, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,6 +20,7 @@ from orchestrator.services import processes
 from orchestrator.settings import get_authorizers
 from orchestrator.targets import Target
 from orchestrator.workflow import ProcessStatus, StepList, done, init, step, workflow
+from orchestrator.workflows.predicates import no_uncompleted_instance
 from pydantic_forms.types import State, UUIDstr
 
 authorizers = get_authorizers()
@@ -114,6 +115,7 @@ def restart_created_workflows(created_state_process_ids: list[UUIDstr]) -> State
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,
+    run_predicate=no_uncompleted_instance,
 )
 def task_resume_workflows() -> StepList:
     return init >> find_waiting_workflows >> resume_found_workflows >> restart_created_workflows >> done

--- a/orchestrator/workflows/tasks/validate_subscriptions.py
+++ b/orchestrator/workflows/tasks/validate_subscriptions.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -27,6 +27,7 @@ from orchestrator.services.workflows import (
 from orchestrator.settings import app_settings, get_authorizers
 from orchestrator.targets import Target
 from orchestrator.workflow import StepList, done, init, step, workflow
+from orchestrator.workflows.predicates import no_uncompleted_instance
 
 logger = structlog.get_logger(__name__)
 
@@ -63,6 +64,7 @@ def validate_subscriptions() -> None:
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,
+    run_predicate=no_uncompleted_instance,
 )
 def task_validate_subscriptions() -> StepList:
     return init >> validate_subscriptions >> done

--- a/test/unit_tests/workflows/test_predicates.py
+++ b/test/unit_tests/workflows/test_predicates.py
@@ -1,24 +1,59 @@
+# Copyright 2019-2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for no_uncompleted_instance predicate: pass on zero count, fail with message on nonzero."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
-from orchestrator.workflow import PredicateContext, RunPredicateFail, RunPredicatePass
+from orchestrator.db import ProcessTable, db
+from orchestrator.workflow import (
+    PredicateContext,
+    ProcessStatus,
+    RunPredicateFail,
+    RunPredicatePass,
+)
 from orchestrator.workflows.predicates import no_uncompleted_instance
 
 
+@pytest.fixture
+def test_process(test_workflow, generic_subscription_1):
+    process = ProcessTable(process_id=uuid4(), workflow_id=test_workflow.workflow_id, last_status=ProcessStatus.CREATED)
+    db.session.add(process)
+    db.session.commit()
+    return process
+
+
 @pytest.mark.parametrize(
-    "count,expected_type",
+    "process_status,expected_type",
     [
-        pytest.param(0, RunPredicatePass, id="zero-passes"),
-        pytest.param(3, RunPredicateFail, id="nonzero-fails"),
+        pytest.param(ProcessStatus.COMPLETED, RunPredicatePass, id="completed"),
+        pytest.param(ProcessStatus.ABORTED, RunPredicatePass, id="aborted"),
+        pytest.param(ProcessStatus.CREATED, RunPredicateFail, id="created"),
+        pytest.param(ProcessStatus.RUNNING, RunPredicateFail, id="running"),
+        pytest.param(ProcessStatus.FAILED, RunPredicateFail, id="failed"),
     ],
 )
-@patch("orchestrator.workflows.predicates.db")
-def test_no_uncompleted_instance(mock_db: MagicMock, count: int, expected_type: type) -> None:
-    mock_db.session.scalar.return_value = count
+def test_no_uncompleted_by_process_last_status(test_process, test_workflow, process_status, expected_type) -> None:
+    test_process.last_status = process_status
+    db.session.add(test_process)
+    db.session.commit()
+
     context = MagicMock(spec=PredicateContext)
-    context.workflow_key = "test_workflow"
+    context.workflow_key = test_workflow.name
+
     result = no_uncompleted_instance(context)
+
     assert isinstance(result, expected_type)


### PR DESCRIPTION
- added no_uncompleted_instance to cleanup_tasks
  - task_validate_subscriptions
  - task_resume_workflows
  - task_clean_up_tasks
- update no_uncompleted_instance to allow new tasks when the last_status is aborted
- update unit test.