### PR TITLE
Change gh-pages.yml to trigger workfloworchestrator.github.io docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,29 +1,25 @@
-name: gh-pages
+name: Dispatch to workfloworchestrator.github.io
 on:
   push:
     branches:
       - main
 
-env:
-  UV_LOCKED: true  # Assert that the `uv.lock` will remain unchanged
-
 jobs:
-  deploy:
+  trigger-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
-          # It is considered best practice to pin to a specific uv version.
-          version: "0.11.6"
-          python-version: ${{ matrix.python-version }}
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: workfloworchestrator
+          repositories: workfloworchestrator.github.io
 
-      - name: Install the project
-        # --no-dev: exclude group 'dev' from [dependency-groups]
-        # --group docs: include group 'dev' from [dependency-groups]
-        run: uv sync --no-dev --group docs
-
-      - name: Build and publish docs
-        run: uv run mkdocs gh-deploy --force
+      - name: Trigger docs build on workfloworchestrator.github.io
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/workfloworchestrator/workfloworchestrator.github.io/dispatches \
+            -f event_type=docs-update

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
-site_name: Workflow Orchestrator
+# workfloworchestrator.github.io uses site_name in the URL, don't change it
+site_name: Orchestrator Core
 site_description: An extensible workflow engine to manage customer facing resources and resource facing resources.
 site_url: https://workfloworchestrator.org/orchestrator-core
 theme:


### PR DESCRIPTION
* Change gh-pages.yml to trigger the mkdocs build/deploy in the workfloworchestrator.github.io repository
* Change mkdocs.yml to ensure that after https://github.com/workfloworchestrator/workfloworchestrator.github.io/issues/21 the URL path of the `/orchestrator-core/` documentation will not change