### PR TITLE
1135: Add status field to PATCH product API endpoint

### DIFF
--- a/orchestrator/api/api_v1/endpoints/products.py
+++ b/orchestrator/api/api_v1/endpoints/products.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2026 SURF, ESnet, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,13 +16,15 @@ from uuid import UUID
 
 from fastapi.param_functions import Body
 from fastapi.routing import APIRouter
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload, selectinload
 
 from orchestrator.api.error_handling import raise_status
-from orchestrator.db import ProductBlockTable, ProductTable, db
+from orchestrator.db import ProductBlockTable, ProductTable, SubscriptionTable, db
+from orchestrator.domain.lifecycle import ProductLifecycle
 from orchestrator.schemas import ProductSchema
 from orchestrator.schemas.product import ProductPatchSchema
+from orchestrator.types import SubscriptionLifecycle
 
 router = APIRouter()
 
@@ -75,16 +77,40 @@ async def patch_product_by_id(product_id: UUID, data: ProductPatchSchema = Body(
     if not product:
         raise_status(HTTPStatus.NOT_FOUND, f"Product id {product_id} not found")
 
-    return await _patch_product_description(data, product)
+    return await _patch_product(data, product)
 
 
-async def _patch_product_description(
+async def _patch_product(
     data: ProductPatchSchema,
     product: ProductTable,
 ) -> ProductTable:
 
     updated_properties = data.model_dump(exclude_unset=True)
+
+    # Update description if provided
     description = updated_properties.get("description", product.description)
     product.description = description
+
+    # Update status if provided
+    if "status" in updated_properties:
+        new_status = updated_properties["status"]
+
+        # Validate: cannot set END_OF_LIFE if non-terminated subscriptions exist
+        if new_status == ProductLifecycle.END_OF_LIFE:
+            non_terminated_count = db.session.scalar(
+                select(func.count(SubscriptionTable.subscription_id)).where(
+                    SubscriptionTable.product_id == product.product_id,
+                    SubscriptionTable.status != SubscriptionLifecycle.TERMINATED,
+                )
+            )
+            if non_terminated_count and non_terminated_count > 0:
+                raise_status(
+                    HTTPStatus.BAD_REQUEST,
+                    f"Cannot set product to 'end of life': "
+                    f"{non_terminated_count} subscription(s) are not in terminated state",
+                )
+
+        product.status = new_status
+
     db.session.commit()
     return product

--- a/orchestrator/schemas/product.py
+++ b/orchestrator/schemas/product.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2026 SURF, ESnet, GÉANT.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -47,3 +47,4 @@ class ProductSchema(ProductBaseSchema):
 
 class ProductPatchSchema(OrchestratorBaseModel):
     description: Annotated[str, Field(max_length=DESCRIPTION_LENGTH)] | None = None
+    status: ProductLifecycle | None = None

--- a/test/unit_tests/api/test_products.py
+++ b/test/unit_tests/api/test_products.py
@@ -1,3 +1,16 @@
+# Copyright 2019-2026 SURF, ESnet, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from http import HTTPStatus
 from uuid import uuid4
 

--- a/test/unit_tests/api/test_products.py
+++ b/test/unit_tests/api/test_products.py
@@ -219,3 +219,52 @@ def test_product_by_id_returns_correct_data(seed, test_client):
     product = response.json()
 
     assert product["name"] == "LightPath"
+
+
+def test_update_status(seed, test_client):
+    """Patching status to a non-EOL value should succeed."""
+    body = {"status": "phase out"}
+    response = test_client.patch(f"/api/products/{PRODUCT_ID}", json=body)
+
+    assert HTTPStatus.CREATED == response.status_code
+    assert response.json()["status"] == "phase out"
+
+
+def test_update_status_end_of_life_with_active_subscriptions(seed, test_client):
+    """Cannot set 'end of life' when product has non-terminated subscriptions."""
+    body = {"status": "end of life"}
+    response = test_client.patch(f"/api/products/{PRODUCT_ID}", json=body)
+
+    assert HTTPStatus.BAD_REQUEST == response.status_code
+    assert "not in terminated state" in response.json()["detail"]
+
+
+def test_update_status_end_of_life_with_terminated_subscriptions(seed, test_client):
+    """Can set 'end of life' when all subscriptions are terminated."""
+    subscription = db.session.get(SubscriptionTable, SUBSCRIPTION_ID)
+    subscription.status = "terminated"
+    db.session.commit()
+
+    body = {"status": "end of life"}
+    response = test_client.patch(f"/api/products/{PRODUCT_ID}", json=body)
+
+    assert HTTPStatus.CREATED == response.status_code
+    assert response.json()["status"] == "end of life"
+
+
+def test_update_status_invalid_value(seed, test_client):
+    """Invalid status value should return 422 Unprocessable Entity."""
+    body = {"status": "invalid_status"}
+    response = test_client.patch(f"/api/products/{PRODUCT_ID}", json=body)
+
+    assert HTTPStatus.UNPROCESSABLE_ENTITY == response.status_code
+
+
+def test_update_description_and_status(seed, test_client):
+    """Patching both description and status should update both."""
+    body = {"description": "Updated", "status": "pre production"}
+    response = test_client.patch(f"/api/products/{PRODUCT_ID}", json=body)
+
+    assert HTTPStatus.CREATED == response.status_code
+    assert response.json()["description"] == "Updated"
+    assert response.json()["status"] == "pre production"


### PR DESCRIPTION
## Summary
The PATCH product endpoint will now accept a status (in addition to -or in lieu of- a description).  That status is validated to ensure it matches an acceptable value in an enum, and the endpoint will reject attempts of setting a product with non-terminated subscriptions to a status of "end of life"

## Related Issues
Closes #1135 

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
