### PR TITLE
Move testing guide from "Contributing" to "Guide" section

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,7 +38,7 @@ pytest-support-clean:
 # Serve orchestrator-core docs with live-reload
 docs-preview:
     @just sync
-    uv run mkdocs serve
+    uv run mkdocs serve --livereload
 
 # Run pre-commit on all files
 pre-commit:

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,7 +1,7 @@
 # Writing unit tests
 
-This guide covers how to write unit tests for workflows and domain models in orchestrator-core.
-For setup instructions (database, running tests), see [development.md](development.md).
+This guide covers how to write unit tests for workflows and domain models using orchestrator-core.
+For setup instructions (database, running tests), see [development.md](../contributing/development.md).
 
 ## Test helpers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,8 @@ plugins:
           'migration-guide/3.0.md': 'guides/upgrading/3.0.md'
           'migration-guide/4.0.md': 'guides/upgrading/4.0.md'
           'migration-guide/4.0.md': 'guides/upgrading/4.0.md'
-copyright: Copyright &copy; 2018 - 2024 Workflow Orchestrator Programme
+          'contributing/testing.md': 'guides/testing.md'
+copyright: Copyright &copy; 2018 - 2026 Workflow Orchestrator Programme
 extra:
     generator: false
     social:
@@ -178,6 +179,7 @@ nav:
                 - Importing Existing Products: guides/product-modeling/imports.md
                 - Backfilling Existing Subscriptions: guides/product-modeling/backfilling.md
           - Creating Tasks and Schedules: guides/tasks.md
+          - Testing: guides/testing.md
           - Scaling the Orchestrator: guides/scaling.md
           - Pausing the Orchestrator: guides/pause-and-resume.md
           - Generating a Config File: guides/generate-config-file.md
@@ -275,7 +277,6 @@ nav:
     - Contributing:
           - Development setup: contributing/development.md
           - Guidelines: contributing/guidelines.md
-          - Testing: contributing/testing.md
 watch:
     - includes
     - orchestrator


### PR DESCRIPTION
## Summary

Moves `testing.md` to the Guides section since it's written for a "Workflow Developer" (IE: WFO user) instead of an orchestrator-core developer.

## Related Issues

## Checklist
- [x] I have updated relevant documentation.
- [ ] ~~I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.~~
- [ ] ~~My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).~~
