### PR TITLE
Remove unused versioning for code blocks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,43 +46,21 @@ export DATABASE_URI=postgresql+psycopg://nwa:nwa@localhost:5432/orchestrator-cor
 
 Create a `main.py` file for running the CLI.
 
-=== "`orchestrator-core` ≥ 5.0"
+```python
+from orchestrator.core.cli.main import app as core_cli
 
-    ```python
-    from orchestrator.core.cli.main import app as core_cli
-
-    if __name__ == "__main__":
-        core_cli()
-    ```
-
-=== "`orchestrator-core` < 5.0"
-
-    ```python
-    from orchestrator.cli.main import app as core_cli
-
-    if __name__ == "__main__":
-        core_cli()
-    ```
+if __name__ == "__main__":
+    core_cli()
+```
 
 Create a `wsgi.py` file for running the web server.
 
-=== "`orchestrator-core` ≥ 5.0"
+```python
+from orchestrator.core import OrchestratorCore
+from orchestrator.core.settings import AppSettings
 
-    ```python
-    from orchestrator.core import OrchestratorCore
-    from orchestrator.core.settings import AppSettings
-
-    app = OrchestratorCore(base_settings=AppSettings())
-    ```
-
-=== "`orchestrator-core` < 5.0"
-
-    ```python
-    from orchestrator import OrchestratorCore
-    from orchestrator.settings import AppSettings
-
-    app = OrchestratorCore(base_settings=AppSettings())
-    ```
+app = OrchestratorCore(base_settings=AppSettings())
+```
 
 ### Step 4 - Run the database migrations
 


### PR DESCRIPTION
## Summary
In the README file, we don't render the versioned codeblocks in different tabs, so it looks off when browsing the repo on here.

## Related Issues
Fixes: my sanity

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
