### PR TITLE
Close sqlalchemy transactions within API + DB related refactoring + docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.0rc3
+current_version = 5.0.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -152,7 +152,7 @@ Below is an example implementation of a Celery worker with Websocket support, wh
     from uuid import UUID
 
     from celery import Celery
-    from celery.signals import worker_shutting_down
+    from celery.signals import task_postrun, worker_shutting_down
     from nwastdlib.debugging import start_debugger
     from orchestrator.core.db import init_database
     from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
@@ -171,6 +171,17 @@ Below is an example implementation of a Celery worker with Websocket support, wh
 
     logger = get_logger(__name__)
 
+    @task_postrun.connect
+    def cleanup_session_after_task(**kwargs: Any) -> None:
+        """Prevent idle-in-transaction connections after Celery task completion.
+
+        psycopg3 autobegin starts implicit transactions on any query. If code
+        executes queries outside a transactional() context (e.g., during model
+        serialization after a workflow step), those transactions are never
+        committed/rolled back. This handler ensures cleanup after every task.
+        """
+        db.session.rollback()
+        db.scoped_session.remove()
 
     def process_broadcast_fn(process_id: UUID) -> None:
         # Catch all exceptions as broadcasting failure is noncritical to workflow completion
@@ -199,6 +210,13 @@ Below is an example implementation of a Celery worker with Websocket support, wh
             # Load the product and workflow modules to register them with the application
             import your_orch.products
             import your_orch.workflows
+
+            # If you have custom SQLAlchemy models, register them here
+            from orchestrator.core.app import OrchestratorCore
+            from orchestrator.core.db import SubscriptionTable
+            from your_orch.db.models import MySubscriptionTable
+
+            OrchestratorCore.register_table(SubscriptionTable, MySubscriptionTable)
 
 
         def close(self) -> None:

--- a/docs/guides/upgrading/5.0.md
+++ b/docs/guides/upgrading/5.0.md
@@ -54,11 +54,14 @@ script available to help with this, which will try to do this automatically. It 
 In short, every reference to `orchestrator-core` like import statements `from orchestrator.X import Y` should be
 changed to `from orchestrator.core.X import Y`.
 
-| Old                                                           | New                                                                |
-|-----------------------------------------------------------------|----------------------------------------------------------------------|
-| `import orchestrator.db`                                        | `import orchestrator.core.db`                                        |
-| `from orchestrator.services.subscriptions import WF_USABLE_MAP` | `from orchestrator.core.services.subscriptions import WF_USABLE_MAP` |
-| `@patch("orchestrator.api.api_v1.endpoints")`                   | `@patch("orchestrator.core.api.api_v1.endpoints")`                   |
+| Old                                                             | New                                                                  | Examples of where you'll find this |
+|-----------------------------------------------------------------|----------------------------------------------------------------------|------------------------------------|
+| `import orchestrator.db`                                        | `import orchestrator.core.db`                                        | Anywhere                           |
+| `from orchestrator.services.subscriptions import WF_USABLE_MAP` | `from orchestrator.core.services.subscriptions import WF_USABLE_MAP` | Anywhere                           |
+| `@patch("orchestrator.api.api_v1.endpoints")`                   | `@patch("orchestrator.core.api.api_v1.endpoints")`                   | Unit tests                         |
+| `strawberry.lazy("orchestrator.graphql.schemas.subscription")`  | `strawberry.lazy("orchestrator.core.graphql.schemas.subscription")`  | GraphQL schema overrides           |
+| `include=["orchestrator.services.tasks"]`                       | `include=["orchestrator.core.services.tasks"]`                       | Celery client definition           |
+
 
 ### 2. GraphQL `scheduledTasks` query no longer returns tasks created by the decorator
 

--- a/orchestrator/core/app.py
+++ b/orchestrator/core/app.py
@@ -45,7 +45,7 @@ from orchestrator.core import __version__
 from orchestrator.core.api.api_v1.api import api_router
 from orchestrator.core.api.error_handling import ProblemDetailException
 from orchestrator.core.cli.main import app as cli_app
-from orchestrator.core.db import db, init_database
+from orchestrator.core.db import db, init_database, warn_db_uri_scheme
 from orchestrator.core.db.database import BaseModel, DBSessionMiddleware
 from orchestrator.core.db.listeners import monitor_sqlalchemy_queries
 from orchestrator.core.db.loaders import init_model_loaders
@@ -189,16 +189,7 @@ class OrchestratorCore(FastAPI):
         self.include_router(api_router, prefix="/api")
 
         db_uri = str(base_settings.DATABASE_URI.get_secret_value())
-        if db_uri.startswith("postgresql://"):
-            import warnings
-
-            warnings.warn(
-                "DATABASE_URI uses 'postgresql://' dialect which defaults to psycopg2. "
-                "orchestrator-core has migrated to psycopg3. "
-                "Please update DATABASE_URI to use 'postgresql+psycopg://' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        warn_db_uri_scheme(db_uri)
 
         init_database(base_settings)
 

--- a/orchestrator/core/db/__init__.py
+++ b/orchestrator/core/db/__init__.py
@@ -70,7 +70,19 @@ db = cast(Database, wrapped_db)
 
 # The Global Database is set after calling this function
 def init_database(settings: AppSettings) -> Database:
-    wrapped_db.update(Database(str(settings.DATABASE_URI.get_secret_value())))
+    db_uri = str(settings.DATABASE_URI.get_secret_value())
+    if db_uri.startswith("postgresql://"):
+        import warnings
+
+        warnings.warn(
+            "DATABASE_URI uses 'postgresql://' dialect which defaults to psycopg2. "
+            "orchestrator-core has migrated to psycopg3. "
+            "Please update DATABASE_URI to use 'postgresql+psycopg://' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    wrapped_db.update(Database(db_uri))
     return db
 
 

--- a/orchestrator/core/db/__init__.py
+++ b/orchestrator/core/db/__init__.py
@@ -71,19 +71,27 @@ db = cast(Database, wrapped_db)
 # The Global Database is set after calling this function
 def init_database(settings: AppSettings) -> Database:
     db_uri = str(settings.DATABASE_URI.get_secret_value())
+    warn_db_uri_scheme(db_uri)
+
+    wrapped_db.update(Database(db_uri))
+    return db
+
+
+def warn_db_uri_scheme(db_uri: str) -> None:
+    """Temporary helper function to assist users in moving to core 5.0.
+
+    TODO: remove in 5.1 or above
+    """
     if db_uri.startswith("postgresql://"):
         import warnings
 
         warnings.warn(
-            "DATABASE_URI uses 'postgresql://' dialect which defaults to psycopg2. "
+            "Database URI uses 'postgresql://' dialect which defaults to psycopg2. "
             "orchestrator-core has migrated to psycopg3. "
-            "Please update DATABASE_URI to use 'postgresql+psycopg://' instead.",
+            "Please update to use 'postgresql+psycopg://' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-
-    wrapped_db.update(Database(db_uri))
-    return db
 
 
 __all__ = [
@@ -111,6 +119,7 @@ __all__ = [
     "db",
     "init_database",
 ]
+
 
 ALL_DB_MODELS: list[type[DbBaseModel]] = [
     AgentRunTable,

--- a/orchestrator/core/db/database.py
+++ b/orchestrator/core/db/database.py
@@ -148,10 +148,20 @@ class BaseModel(_Base):
 
 
 class WrappedSession(Session):
-    """This Session class allows us to disable commit during steps."""
+    """This Session class allows us to disable commit."""
+
+    def is_commit_disabled(self) -> bool:
+        # Verify whether commiting is disabled on the session.
+        return self.info.get("disabled") is True
+
+    def enable_commit(self) -> None:
+        self.info["disabled"] = False
+
+    def disable_commit(self) -> None:
+        self.info["disabled"] = True
 
     def commit(self) -> None:
-        if self.info.get("disabled", False):
+        if self.is_commit_disabled():
             self.info.get("logger", logger).warning(
                 "Step function tried to issue a commit. It should not! "
                 "Will execute commit on behalf of step function when it returns."
@@ -241,26 +251,25 @@ class DBSessionMiddleware:
 
 @contextmanager
 def disable_commit(db: Database, log: BoundLogger) -> Iterator:
-    restore = True
     # If `db.session` already has its `commit` method disabled we won't try disabling *and* restoring it again.
-    if db.session.info.get("disabled", False):
-        restore = False
-    else:
-        log.debug("Temporarily disabling commit.")
-        db.session.info["disabled"] = True
-        db.session.info["logger"] = log
+    if db.session.is_commit_disabled():
+        yield
+        return
+
+    log.debug("Temporarily disabling commit.")
+    db.session.disable_commit()
+    db.session.info["logger"] = log
     try:
         yield
     finally:
-        if restore:
-            log.debug("Reenabling commit.")
-            db.session.info["disabled"] = False
-            db.session.info["logger"] = None
+        log.debug("Reenabling commit.")
+        db.session.enable_commit()
+        db.session.info["logger"] = None
 
 
 @contextmanager
 def transactional(db: Database, log: BoundLogger) -> Iterator:
-    """Run a step function in an implicit transaction with automatic rollback or commit.
+    """Run the context in an implicit transaction with automatic rollback or commit.
 
     It will roll back in case of error, commit otherwise. It will also disable the `commit()` method
     on `BaseModel.session` for the time `transactional` is in effect.
@@ -269,10 +278,11 @@ def transactional(db: Database, log: BoundLogger) -> Iterator:
     owns the transaction. This prevents the inner safeguard rollback from discarding the
     outer transaction's work.
     """
-    if db.session.info.get("disabled", False):
+    if db.session.is_commit_disabled():
         # Nested call: outer transactional() owns commit/rollback. Inner is a no-op.
         yield
         return
+
     try:
         with disable_commit(db, log):
             yield
@@ -280,8 +290,5 @@ def transactional(db: Database, log: BoundLogger) -> Iterator:
         db.session.commit()
     except Exception:
         log.warning("Rolling back transaction.")
-        raise
-    finally:
-        # Extra safeguard rollback. If the commit failed there is still a failed transaction open.
-        # BTW: without a transaction in progress this method is a pass-through.
         db.session.rollback()
+        raise

--- a/orchestrator/core/db/database.py
+++ b/orchestrator/core/db/database.py
@@ -28,6 +28,12 @@ from structlog.stdlib import BoundLogger
 
 from orchestrator.core.utils.json import json_dumps, json_loads
 
+MESSAGE_COMMIT_ATTEMPTED_WHILE_DISABLED = (
+    "Code wrapped in transactional() tried to issue a `COMMIT`. "
+    "It should not! "
+    "Delaying the commit until the end of the wrapped context."
+)
+
 logger = structlog.get_logger(__name__)
 
 
@@ -163,8 +169,7 @@ class WrappedSession(Session):
     def commit(self) -> None:
         if self.is_commit_disabled():
             self.info.get("logger", logger).warning(
-                "Step function tried to issue a commit. It should not! "
-                "Will execute commit on behalf of step function when it returns."
+                MESSAGE_COMMIT_ATTEMPTED_WHILE_DISABLED
             )
         else:
             super().commit()

--- a/orchestrator/core/domain/base.py
+++ b/orchestrator/core/domain/base.py
@@ -1322,7 +1322,7 @@ class SubscriptionModel(DomainModel):
     @classmethod
     def from_other_product(
         cls: type[S],
-        old_instantiation: S,
+        old_instantiation: "SubscriptionModel",
         new_product_id: UUID | str,
         new_root: tuple[str, ProductBlockModel] | None = None,
     ) -> S:

--- a/orchestrator/core/domain/base.py
+++ b/orchestrator/core/domain/base.py
@@ -986,12 +986,12 @@ class ProductBlockModel(DomainModel):
         self._db_model = value
 
     @property
-    def in_use_by(self) -> list[SubscriptionInstanceTable]:  # TODO check where used, might need eagerloading
+    def in_use_by(self) -> list[SubscriptionInstanceTable]:
         """This provides a list of product blocks that depend on this product block."""
         return self.db_model.in_use_by if self.db_model else []
 
     @property
-    def depends_on(self) -> list[SubscriptionInstanceTable]:  # TODO check where used, might need eagerloading
+    def depends_on(self) -> list[SubscriptionInstanceTable]:
         """This provides a list of product blocks that this product block depends on."""
         return self.db_model.depends_on if self.db_model else []
 

--- a/orchestrator/core/services/executors/celery.py
+++ b/orchestrator/core/services/executors/celery.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from orchestrator.core import app_settings
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.processes import (
     SYSTEM_USER,
     can_be_resumed,
@@ -123,11 +124,11 @@ def _celery_set_process_status_resumed(process_id: UUID) -> None:
 
 def _celery_validate(validation_workflow: str, json: list[State] | None) -> None:
     pstat = create_process(validation_workflow, user_inputs=json)
-    _celery_start_process(pstat)
+    CELERY_EXECUTION_CONTEXT[ExecutorFunction.START](pstat)
 
 
-CELERY_EXECUTION_CONTEXT: dict[str, Callable] = {
-    "start": _celery_start_process,
-    "resume": _celery_resume_process,
-    "validate": _celery_validate,
+CELERY_EXECUTION_CONTEXT: dict[ExecutorFunction, Callable] = {
+    ExecutorFunction.START: _celery_start_process,
+    ExecutorFunction.RESUME: _celery_resume_process,
+    ExecutorFunction.VALIDATE: _celery_validate,
 }

--- a/orchestrator/core/services/executors/celery.py
+++ b/orchestrator/core/services/executors/celery.py
@@ -117,7 +117,6 @@ def _celery_resume_process(
         raise e
 
 
-# TODO check usages -> ok
 def _celery_set_process_status_resumed(process_id: UUID) -> None:
     """Set the process status to RESUMED to show its waiting to be picked up by a worker.
 
@@ -137,9 +136,7 @@ def _celery_set_process_status_resumed(process_id: UUID) -> None:
 
     if can_be_resumed(locked_process.last_status):
         locked_process.last_status = ProcessStatus.RESUMED
-        # db.session.commit()
     else:
-        # db.session.rollback()
         raise ValueError(f"Process has incorrect status to resume: {locked_process.last_status}")
 
 

--- a/orchestrator/core/services/executors/celery.py
+++ b/orchestrator/core/services/executors/celery.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from orchestrator.core import app_settings
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.db.database import transactional
 from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.processes import (
     SYSTEM_USER,
@@ -47,7 +48,11 @@ def _block_when_testing(task_result: AsyncResult) -> None:
 
 
 def _celery_start_process(pstat: ProcessStat, user: str = SYSTEM_USER, **kwargs: Any) -> UUID:
-    """Client side call of Celery."""
+    """Trigger a celery worker to start the given process.
+
+    This wrapper ensures that:
+     - The current sqlalchemy SessionTransaction is closed
+    """
     from orchestrator.core.services.tasks import NEW_TASK, NEW_WORKFLOW, get_celery_task
 
     if not (wf_table := get_workflow_by_name(pstat.workflow.name)):
@@ -55,7 +60,12 @@ def _celery_start_process(pstat: ProcessStat, user: str = SYSTEM_USER, **kwargs:
 
     task_name = NEW_TASK if wf_table.is_task else NEW_WORKFLOW
     trigger_task = get_celery_task(task_name)
+
+    # Close the SessionTransaction on the API side.
+    db.session.close()
+
     try:
+        # Trigger the celery task. This will create a SessionTransaction on the worker to read the process.
         result = trigger_task.delay(pstat.process_id, user)
         _block_when_testing(result)
         return pstat.process_id
@@ -72,7 +82,13 @@ def _celery_resume_process(
     user: str | None = None,
     **kwargs: Any,
 ) -> bool:
-    """Client side call of Celery."""
+    """Trigger a celery worker to resume the given process.
+
+    This wrapper ensures that:
+     - The process has status RESUMED in the database
+     - The current sqlalchemy SessionTransaction is committed (and thus closed)
+     - The process status is reverted to the old status if triggering celery failed
+    """
     from orchestrator.core.services.tasks import RESUME_TASK, RESUME_WORKFLOW, get_celery_task
 
     last_process_status = process.last_status
@@ -80,9 +96,12 @@ def _celery_resume_process(
     task_name = RESUME_TASK if process.workflow.is_task else RESUME_WORKFLOW
     trigger_task = get_celery_task(task_name)
 
-    _celery_set_process_status_resumed(process.process_id)
+    # Final write action to the process: ensure the SessionTransaction is committed on the API side.
+    with transactional(db, logger):
+        _celery_set_process_status_resumed(process.process_id)
 
     try:
+        # Trigger the celery task. This will create a SessionTransaction on the worker to read the process.
         result = trigger_task.delay(process.process_id, user)
         _block_when_testing(result)
 
@@ -93,15 +112,17 @@ def _celery_resume_process(
             current_status=process.last_status,
             last_status=last_process_status,
         )
-        set_process_status(process.process_id, last_process_status)
+        with transactional(db, logger):
+            set_process_status(process.process_id, last_process_status)
         raise e
 
 
+# TODO check usages -> ok
 def _celery_set_process_status_resumed(process_id: UUID) -> None:
     """Set the process status to RESUMED to show its waiting to be picked up by a worker.
 
-    uses with_for_update to lock the subscription in a transaction, preventing other changes.
-    rolls back transation and raises an exception when it can't change to RESUMED to prevent it from being added to the queue.
+    Uses with_for_update to lock the process row, preventing other changes.
+    Raises an exception when it can't change to RESUMED to prevent it from being added to the queue.
 
     Args:
         process_id: Process ID to fetch process from DB
@@ -116,9 +137,9 @@ def _celery_set_process_status_resumed(process_id: UUID) -> None:
 
     if can_be_resumed(locked_process.last_status):
         locked_process.last_status = ProcessStatus.RESUMED
-        db.session.commit()
+        # db.session.commit()
     else:
-        db.session.rollback()
+        # db.session.rollback()
         raise ValueError(f"Process has incorrect status to resume: {locked_process.last_status}")
 
 

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -44,11 +44,13 @@ from pydantic_forms.types import State
 logger = structlog.get_logger(__name__)
 
 
+# TODO check usages -> ok
 def _set_process_status_running(process_id: UUID) -> None:
-    """Set the process status to RUNNING to prevent it from being picked up by mutliple workers.
+    """Set the process status to RUNNING to prevent it from being picked up by multiple workers.
 
-    uses with_for_update to lock the subscription in a transaction, preventing other changes.
-    rolls back transation and raises an exception when its already on status RUNNING to prevent worker from running an already running process
+    Uses with_for_update to lock the process row, preventing other changes.
+    Rolls back transation and raises an exception when it's already on status RUNNING to prevent worker from
+    running an already running process
 
     Args:
         process_id: Process ID to fetch process from DB
@@ -59,14 +61,14 @@ def _set_process_status_running(process_id: UUID) -> None:
     locked_process = result.scalar_one_or_none()
 
     if not locked_process:
-        db.session.rollback()
+        # db.session.rollback()
         raise ValueError(f"Process not found: {process_id}")
 
     if locked_process.last_status is not ProcessStatus.RUNNING:
         locked_process.last_status = ProcessStatus.RUNNING
-        db.session.commit()
+        # db.session.commit()
     else:
-        db.session.rollback()
+        # db.session.rollback()
         raise Exception("Process is already running")
 
 
@@ -82,12 +84,16 @@ def thread_start_process(
     # enforce an update to the process status to properly show the process
     _set_process_status_running(pstat.process_id)
 
-    # Celery workers use the empty-scope session (no database_scope); wrap in
-    # transactional() to prevent psycopg3 autobegin leaving the connection idle-in-transaction.
+    # Final select query on the process: ensure the SessionTransaction is committed.
+    # When using threadpool executor, this closes the SessionTransaction on the API, so that the threadpool worker can
+    # read the process.
+    # When using celery executor, this closes the SessionTransaction on the worker, so that the same worker can read
+    # the process. This is not needed, but also doesn't hurt.
     with transactional(db, logger):
         input_data = retrieve_input_state(pstat.process_id, "initial_state", False)
-    pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
 
+    # Trigger the task in the current thread or threadpool (depends on executor mode).
+    pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
     _safe_logstep_with_func = partial(safe_logstep, broadcast_func=broadcast_func)
     return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func))
 
@@ -99,25 +105,35 @@ def thread_resume_process(
     user_model: OIDCUserModel | None = None,
     broadcast_func: BroadcastFunc | None = None,
 ) -> UUID:
-    # ATTENTION!! When modifying this function make sure you make similar changes to `resume_workflow` in the test code
-    # Same idle-in-transaction concern as thread_start_process: wrap DB reads in transactional().
-    with transactional(db, logger):
-        pstat = load_process(process)
-        if pstat.workflow == removed_workflow:
-            raise ValueError(RESUME_WORKFLOW_REMOVED_ERROR_MSG)
+    """Resume the given process.
 
-        # retrieve_input_str is for the edge case when workflow engine stops whilst there is an existing 'CREATED' process queue'ed.
-        # It will have become a `RUNNING` process that gets resumed and this should fetch initial_state instead of user_input.
-        retrieve_input_str: InputType = "user_input" if process.steps else "initial_state"
-        input_data = retrieve_input_state(process.process_id, retrieve_input_str, False)
+    This wrapper ensures that:
+     - The process has status
+    """
+    # ATTENTION!! When modifying this function make sure you make similar changes to `resume_workflow` in the test code
+    pstat = load_process(process)
+    if pstat.workflow == removed_workflow:
+        raise ValueError(RESUME_WORKFLOW_REMOVED_ERROR_MSG)
+
+    # retrieve_input_str is for the edge case when workflow engine stops whilst there is an existing 'CREATED' process queue'ed.
+    # It will have become a `RUNNING` process that gets resumed and this should fetch initial_state instead of user_input.
+    retrieve_input_str: InputType = "user_input" if process.steps else "initial_state"
+    input_data = retrieve_input_state(process.process_id, retrieve_input_str, False)
 
     if user:
         pstat.update(current_user=user)
     pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
 
-    # enforce an update to the process status to properly show the process
-    _set_process_status_running(process.process_id)
+    # Final write action to the process: ensure the SessionTransaction is committed.
+    # When using threadpool executor, this closes the SessionTransaction on the API, so that the threadpool worker can
+    # read the process.
+    # When using celery executor, this closes the SessionTransaction on the worker, so that the same worker can read
+    # the process. This is not needed, but also doesn't hurt.
+    with transactional(db, logger):
+        # enforce an update to the process status to properly show the process
+        _set_process_status_running(process.process_id)
 
+    # Trigger the task in the current thread or threadpool (depends on executor mode).
     _safe_logstep_prep = partial(safe_logstep, broadcast_func=broadcast_func)
     _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_prep))
     return pstat.process_id

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -73,6 +73,12 @@ def thread_start_process(
     user_model: OIDCUserModel | None = None,
     broadcast_func: BroadcastFunc | None = None,
 ) -> UUID:
+    """Trigger the current thread or threadpool to start the given process.
+
+    This wrapper ensures that:
+     - The process has status RUNNING in the database
+     - The current sqlalchemy SessionTransaction is committed (and thus closed)
+    """
     if pstat.workflow == removed_workflow:
         raise ValueError(START_WORKFLOW_REMOVED_ERROR_MSG)
 
@@ -100,10 +106,11 @@ def thread_resume_process(
     user_model: OIDCUserModel | None = None,
     broadcast_func: BroadcastFunc | None = None,
 ) -> UUID:
-    """Resume the given process.
+    """Trigger the current thread or threadpool to resume the given process.
 
     This wrapper ensures that:
-     - The process has status
+     - The process has status RUNNING in the database
+     - The current sqlalchemy SessionTransaction is committed (and thus closed)
     """
     # ATTENTION!! When modifying this function make sure you make similar changes to `resume_workflow` in the test code
     pstat = load_process(process)
@@ -135,6 +142,7 @@ def thread_resume_process(
 
 
 def thread_validate_workflow(validation_workflow: str, json: list[State] | None) -> UUID:
+    """Create a validation workflow process and start it via the threadpool executor."""
     pstat = create_process(validation_workflow, user_inputs=json)
     return THREADPOOL_EXECUTION_CONTEXT[ExecutorFunction.START](pstat)
 

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.db.database import transactional
+from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.input_state import InputType, retrieve_input_state
 from orchestrator.core.services.processes import (
     RESUME_WORKFLOW_REMOVED_ERROR_MSG,
@@ -124,11 +125,11 @@ def thread_resume_process(
 
 def thread_validate_workflow(validation_workflow: str, json: list[State] | None) -> UUID:
     pstat = create_process(validation_workflow, user_inputs=json)
-    return thread_start_process(pstat)
+    return THREADPOOL_EXECUTION_CONTEXT[ExecutorFunction.START](pstat)
 
 
-THREADPOOL_EXECUTION_CONTEXT: dict[str, Callable] = {
-    "start": thread_start_process,
-    "resume": thread_resume_process,
-    "validate": thread_validate_workflow,
+THREADPOOL_EXECUTION_CONTEXT: dict[ExecutorFunction, Callable] = {
+    ExecutorFunction.START: thread_start_process,
+    ExecutorFunction.RESUME: thread_resume_process,
+    ExecutorFunction.VALIDATE: thread_validate_workflow,
 }

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -44,13 +44,11 @@ from pydantic_forms.types import State
 logger = structlog.get_logger(__name__)
 
 
-# TODO check usages -> ok
 def _set_process_status_running(process_id: UUID) -> None:
     """Set the process status to RUNNING to prevent it from being picked up by multiple workers.
 
     Uses with_for_update to lock the process row, preventing other changes.
-    Rolls back transation and raises an exception when it's already on status RUNNING to prevent worker from
-    running an already running process
+    Raises an exception when it's already on status RUNNING to prevent worker from running an already running process.
 
     Args:
         process_id: Process ID to fetch process from DB
@@ -61,14 +59,11 @@ def _set_process_status_running(process_id: UUID) -> None:
     locked_process = result.scalar_one_or_none()
 
     if not locked_process:
-        # db.session.rollback()
         raise ValueError(f"Process not found: {process_id}")
 
     if locked_process.last_status is not ProcessStatus.RUNNING:
         locked_process.last_status = ProcessStatus.RUNNING
-        # db.session.commit()
     else:
-        # db.session.rollback()
         raise Exception("Process is already running")
 
 

--- a/orchestrator/core/services/executors/types.py
+++ b/orchestrator/core/services/executors/types.py
@@ -1,0 +1,20 @@
+# Copyright 2019-2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from enum import StrEnum
+
+
+class ExecutorFunction(StrEnum):
+    # note: not using auto() to ensure backwards compatibility with current usages of X_EXECUTION_CONTEXT dicts
+    START = "start"
+    RESUME = "resume"
+    VALIDATE = "validate"

--- a/orchestrator/core/services/input_state.py
+++ b/orchestrator/core/services/input_state.py
@@ -51,9 +51,10 @@ def retrieve_input_state(process_id: UUID, input_type: InputType, raise_exceptio
         raise ValueError(f"No input state for pid: {process_id}")
     return InputStateTable(input_state={})
 
-
+# TODO check usages -> ok
 def store_input_state(
     process_id: UUID,
+    # input_state: dict[str, Any] | list[dict[str, Any]] | str,
     input_state: dict[str, Any] | list[dict[str, Any]],
     input_type: InputType,
 ) -> None:
@@ -68,12 +69,25 @@ def store_input_state(
         None
 
     """
+    # TODO remove if session.flush() works
+    # match input_state:
+    #     case str():
+    #         input_state_safe = json_loads(input_state)
+    #     case dict() | list():
+    #         input_state_safe = json_loads(json_dumps(input_state))
+    #     case _:
+    #         raise TypeError(f"Cannot store input state of type {type(input_state)}")
+
     logger.debug("Store input state", process_id=process_id, input_state=input_state, input_type=input_type)
     db.session.add(
         InputStateTable(
             process_id=process_id,
+            # input_state=input_state_safe,
             input_state=input_state,
             input_type=input_type,
         )
     )
-    db.session.commit()
+    # Flush to force serialization of the input_state JSONB contents
+    # TODO verify that this solves the issue of computed fields on SubscriptionModels being evaluated outside of the current DB transaction
+    db.session.flush()
+    # db.session.commit()

--- a/orchestrator/core/services/input_state.py
+++ b/orchestrator/core/services/input_state.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 
 from orchestrator.core.db import db
 from orchestrator.core.db.models import InputStateTable
+from orchestrator.core.utils.json import json_dumps, json_loads
 
 logger = structlog.get_logger(__name__)
 
@@ -54,7 +55,6 @@ def retrieve_input_state(process_id: UUID, input_type: InputType, raise_exceptio
 # TODO check usages -> ok
 def store_input_state(
     process_id: UUID,
-    # input_state: dict[str, Any] | list[dict[str, Any]] | str,
     input_state: dict[str, Any] | list[dict[str, Any]],
     input_type: InputType,
 ) -> None:
@@ -67,27 +67,19 @@ def store_input_state(
 
     Returns:
         None
-
     """
-    # TODO remove if session.flush() works
-    # match input_state:
-    #     case str():
-    #         input_state_safe = json_loads(input_state)
-    #     case dict() | list():
-    #         input_state_safe = json_loads(json_dumps(input_state))
-    #     case _:
-    #         raise TypeError(f"Cannot store input state of type {type(input_state)}")
+    match input_state:
+        case dict() | list():
+            input_state_resolved = json_loads(json_dumps(input_state))
+        case _:
+            raise TypeError(f"Cannot store input state of type {type(input_state)}")
 
-    logger.debug("Store input state", process_id=process_id, input_state=input_state, input_type=input_type)
+    logger.debug("Store input state", process_id=process_id, input_state_resolved=input_state_resolved, input_type=input_type)
     db.session.add(
         InputStateTable(
             process_id=process_id,
-            # input_state=input_state_safe,
-            input_state=input_state,
+            input_state=input_state_resolved,
             input_type=input_type,
         )
     )
-    # Flush to force serialization of the input_state JSONB contents
-    # TODO verify that this solves the issue of computed fields on SubscriptionModels being evaluated outside of the current DB transaction
-    db.session.flush()
     # db.session.commit()

--- a/orchestrator/core/services/input_state.py
+++ b/orchestrator/core/services/input_state.py
@@ -52,7 +52,6 @@ def retrieve_input_state(process_id: UUID, input_type: InputType, raise_exceptio
         raise ValueError(f"No input state for pid: {process_id}")
     return InputStateTable(input_state={})
 
-# TODO check usages -> ok
 def store_input_state(
     process_id: UUID,
     input_state: dict[str, Any] | list[dict[str, Any]],
@@ -82,4 +81,3 @@ def store_input_state(
             input_type=input_type,
         )
     )
-    # db.session.commit()

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -34,6 +34,7 @@ from orchestrator.core.db import EngineSettingsTable, ProcessStepTable, ProcessS
 from orchestrator.core.db.models import FAILED_REASON_LENGTH, TRACEBACK_LENGTH
 from orchestrator.core.distlock import distlock_manager
 from orchestrator.core.schemas.engine_settings import WorkerStatus
+from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.input_state import store_input_state
 from orchestrator.core.services.workflows import get_workflow_by_name
 from orchestrator.core.settings import ExecutorType, app_settings
@@ -78,7 +79,7 @@ START_WORKFLOW_REMOVED_ERROR_MSG = "This workflow cannot be started because it h
 RESUME_WORKFLOW_REMOVED_ERROR_MSG = "This workflow cannot be resumed because it has been removed"
 
 
-def get_execution_context() -> dict[str, Callable]:
+def get_execution_context() -> dict[ExecutorFunction, Callable]:
     if app_settings.EXECUTOR == ExecutorType.WORKER:
         from orchestrator.core.services.executors.celery import CELERY_EXECUTION_CONTEXT
 
@@ -534,7 +535,7 @@ def start_process(
     """
     pstat = create_process(workflow_key, user_inputs=user_inputs, user=user, user_model=user_model)
 
-    start_func = get_execution_context()["start"]
+    start_func = get_execution_context()[ExecutorFunction.START]
     return start_func(pstat, user=user, user_model=user_model, broadcast_func=broadcast_func)
 
 
@@ -557,7 +558,7 @@ def restart_process(
     """
     pstat = load_process(process)
 
-    start_func = get_execution_context()["start"]
+    start_func = get_execution_context()[ExecutorFunction.START]
     return start_func(pstat, user=user, broadcast_func=broadcast_func)
 
 
@@ -608,7 +609,7 @@ def resume_process(
 
     store_input_state(pstat.process_id, user_input, "user_input")
 
-    resume_func = get_execution_context()["resume"]
+    resume_func = get_execution_context()[ExecutorFunction.RESUME]
     return resume_func(process, user=user, broadcast_func=broadcast_func)
 
 
@@ -678,8 +679,8 @@ def continue_awaiting_process(
 
     replace_current_step_state(process, new_state=state)
 
-    # Continue the workflow
-    resume_func = get_execution_context()["resume"]
+    # Trigger the "resume" function.
+    resume_func = get_execution_context()[ExecutorFunction.RESUME]
     return resume_func(process, broadcast_func=broadcast_func)
 
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -31,6 +31,7 @@ from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.config.assignee import Assignee
 from orchestrator.core.db import EngineSettingsTable, ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
+from orchestrator.core.db.database import transactional
 from orchestrator.core.db.models import FAILED_REASON_LENGTH, TRACEBACK_LENGTH
 from orchestrator.core.distlock import distlock_manager
 from orchestrator.core.schemas.engine_settings import WorkerStatus
@@ -151,6 +152,7 @@ def shutdown_thread_pool() -> None:
         _workflow_executor = None
 
 
+# TODO check usages -> ok
 def _db_create_process(stat: ProcessStat) -> None:
     wf_table = get_workflow_by_name(stat.workflow.name)
     if not wf_table:
@@ -164,13 +166,14 @@ def _db_create_process(stat: ProcessStat) -> None:
         is_task=wf_table.is_task,
     )
     db.session.add(p)
-    db.session.commit()
+    # db.session.commit()
 
 
 def delete_process(process_id: UUID) -> None:
-    db.session.execute(delete(ProcessTable).where(ProcessTable.process_id == process_id))
+    with transactional(db, logger):
+        db.session.execute(delete(ProcessTable).where(ProcessTable.process_id == process_id))
     broadcast_invalidate_status_counts()
-    db.session.commit()
+    # db.session.commit()
 
 
 def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> ProcessTable:
@@ -508,8 +511,10 @@ def create_process(
         user_model=user_model,
     )
 
-    _db_create_process(pstat)
-    store_input_state(process_id, state | initial_state, "initial_state")
+    with transactional(db, logger):
+        _db_create_process(pstat)
+        store_input_state(process_id, state | initial_state, "initial_state")
+
     return pstat
 
 
@@ -607,6 +612,7 @@ def resume_process(
         logger.exception("Validation errors", user_inputs=user_inputs)
         raise
 
+    # Not committing the SessionTransaction here; triggering the execution takes care of this.
     store_input_state(pstat.process_id, user_input, "user_input")
 
     resume_func = get_execution_context()[ExecutorFunction.RESUME]
@@ -632,6 +638,7 @@ def ensure_correct_callback_token(pstat: ProcessStat, *, token: str) -> None:
         raise AssertionError("Invalid token")
 
 
+# TODO check usages -> ok
 def replace_current_step_state(process: ProcessTable, *, new_state: State) -> None:
     """Replace the state of the current step in a process.
 
@@ -643,7 +650,7 @@ def replace_current_step_state(process: ProcessTable, *, new_state: State) -> No
     current_step = process.steps[-1]
     current_step.state = new_state
     db.session.add(current_step)
-    db.session.commit()
+    # db.session.commit()
 
 
 def continue_awaiting_process(
@@ -677,6 +684,7 @@ def continue_awaiting_process(
     result_key = state.get("__callback_result_key", "callback_result")
     state = {**state, result_key: input_data}
 
+    # Not committing the SessionTransaction here; triggering the execution takes care of this.
     replace_current_step_state(process, new_state=state)
 
     # Trigger the "resume" function.
@@ -712,7 +720,11 @@ def update_awaiting_process_progress(
     progress_key = DEFAULT_CALLBACK_PROGRESS_KEY
     state = {**state, progress_key: data} | {"__remove_keys": [progress_key]}
 
-    replace_current_step_state(process, new_state=state)
+    # Commit the SessionTransaction before the "output" of this function: a websocket event
+    with transactional(db, logger):
+        replace_current_step_state(process, new_state=state)
+
+    # Emit the websocket event
     broadcast_process_update_to_websocket(process.process_id)
 
     return process.process_id
@@ -841,10 +853,11 @@ def _get_running_processes() -> list[ProcessTable]:
     return list(db.session.scalars(stmt))
 
 
+# TODO check usages -> ok
 def set_process_status(process: ProcessTable, status: ProcessStatus) -> None:
     process.last_status = status
     db.session.add(process)
-    db.session.commit()
+    # db.session.commit()
 
 
 def marshall_processes(engine_settings: EngineSettingsTable, new_global_lock: bool) -> EngineSettingsTable | None:

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -152,7 +152,6 @@ def shutdown_thread_pool() -> None:
         _workflow_executor = None
 
 
-# TODO check usages -> ok
 def _db_create_process(stat: ProcessStat) -> None:
     wf_table = get_workflow_by_name(stat.workflow.name)
     if not wf_table:
@@ -166,14 +165,12 @@ def _db_create_process(stat: ProcessStat) -> None:
         is_task=wf_table.is_task,
     )
     db.session.add(p)
-    # db.session.commit()
 
 
 def delete_process(process_id: UUID) -> None:
     with transactional(db, logger):
         db.session.execute(delete(ProcessTable).where(ProcessTable.process_id == process_id))
     broadcast_invalidate_status_counts()
-    # db.session.commit()
 
 
 def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> ProcessTable:
@@ -638,7 +635,6 @@ def ensure_correct_callback_token(pstat: ProcessStat, *, token: str) -> None:
         raise AssertionError("Invalid token")
 
 
-# TODO check usages -> ok
 def replace_current_step_state(process: ProcessTable, *, new_state: State) -> None:
     """Replace the state of the current step in a process.
 
@@ -650,7 +646,6 @@ def replace_current_step_state(process: ProcessTable, *, new_state: State) -> No
     current_step = process.steps[-1]
     current_step.state = new_state
     db.session.add(current_step)
-    # db.session.commit()
 
 
 def continue_awaiting_process(
@@ -853,11 +848,9 @@ def _get_running_processes() -> list[ProcessTable]:
     return list(db.session.scalars(stmt))
 
 
-# TODO check usages -> ok
 def set_process_status(process: ProcessTable, status: ProcessStatus) -> None:
     process.last_status = status
     db.session.add(process)
-    # db.session.commit()
 
 
 def marshall_processes(engine_settings: EngineSettingsTable, new_global_lock: bool) -> EngineSettingsTable | None:

--- a/orchestrator/core/services/workflows.py
+++ b/orchestrator/core/services/workflows.py
@@ -21,6 +21,7 @@ from orchestrator.core.db import (
     db,
 )
 from orchestrator.core.schemas import StepSchema, WorkflowSchema
+from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.subscriptions import TARGET_DEFAULT_USABLE_MAP, WF_USABLE_MAP
 from orchestrator.core.targets import Target
 from orchestrator.core.workflows import get_workflow
@@ -97,7 +98,7 @@ def start_validation_workflow_for_workflows(
             # against circular import
             from orchestrator.core.services.processes import get_execution_context
 
-            validate_func = get_execution_context()["validate"]
+            validate_func = get_execution_context()[ExecutorFunction.VALIDATE]
             validate_func(workflow_name, json=json)
 
             result.append(

--- a/orchestrator/core/workflows/tasks/cleanup_tasks_log.py
+++ b/orchestrator/core/workflows/tasks/cleanup_tasks_log.py
@@ -65,7 +65,6 @@ def cleanup_ai_search_index(deleted_process_id_list: list) -> State:
 
 
 @workflow(
-    "Clean up old tasks",
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,

--- a/orchestrator/core/workflows/tasks/resume_workflows.py
+++ b/orchestrator/core/workflows/tasks/resume_workflows.py
@@ -111,7 +111,6 @@ def restart_created_workflows(created_state_process_ids: list[UUIDstr]) -> State
 
 
 @workflow(
-    "Resume all workflows that are stuck on tasks with the status 'waiting', 'created' or 'resumed'",
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,

--- a/orchestrator/core/workflows/tasks/resume_workflows.py
+++ b/orchestrator/core/workflows/tasks/resume_workflows.py
@@ -67,16 +67,16 @@ def resume_found_workflows(
             if not process:
                 continue
 
-            # Workaround the commit disable function
-            db.session.info["disabled"] = False
+            # Enable commit to be able to start/resume the process as normal
+            db.session.enable_commit()
 
             processes.resume_process(process)
             resumed_process_ids.append(process_id)
         except Exception as exc:
             logger.warning("Could not resume process", process_id=process_id, error=str(exc))
         finally:
-            # Make sure to turn it on again
-            db.session.info["disabled"] = True
+            # Make sure to disable commit again
+            db.session.disable_commit()
 
     return {
         "number_of_resumed_process_ids": len(resumed_process_ids),
@@ -93,16 +93,16 @@ def restart_created_workflows(created_state_process_ids: list[UUIDstr]) -> State
             if not process:
                 continue
 
-            # Workaround the commit disable function
-            db.session.info["disabled"] = False
+            # Enable commit to be able to restart the process as normal
+            db.session.enable_commit()
 
             processes.restart_process(process)
             started_process_ids.append(process_id)
         except Exception as exc:
             logger.warning("Could not resume process", process_id=process_id, error=str(exc))
         finally:
-            # Make sure to turn it on again
-            db.session.info["disabled"] = True
+            # Make sure to disable commit again
+            db.session.disable_commit()
 
     return {
         "number_of_started_process_ids": len(started_process_ids),

--- a/orchestrator/core/workflows/tasks/validate_product_type.py
+++ b/orchestrator/core/workflows/tasks/validate_product_type.py
@@ -88,7 +88,6 @@ def validate_product_type(product_type: str) -> State:
 
 
 @workflow(
-    "Validate all subscriptions of Product Type",
     target=Target.SYSTEM,
     initial_input_form=initial_input_form_generator,
     authorize_callback=authorizers.authorize_callback,

--- a/orchestrator/core/workflows/tasks/validate_subscriptions.py
+++ b/orchestrator/core/workflows/tasks/validate_subscriptions.py
@@ -60,7 +60,6 @@ def validate_subscriptions() -> None:
 
 
 @workflow(
-    "Validate subscriptions",
     target=Target.SYSTEM,
     authorize_callback=authorizers.authorize_callback,
     retry_auth_callback=authorizers.retry_auth_callback,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "orchestrator-core"
 description = "This is the orchestrator workflow engine."
-version = "5.0.0rc3"
+version = "5.0.0"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/test/integration_tests/_fixtures.py
+++ b/test/integration_tests/_fixtures.py
@@ -75,6 +75,7 @@ from orchestrator.core.db import (
     SubscriptionMetadataTable,
     WorkflowTable,
     db,
+    warn_db_uri_scheme,
 )
 from orchestrator.core.db.database import ENGINE_ARGUMENTS, SESSION_ARGUMENTS, BaseModel, Database, SearchQuery
 from orchestrator.core.db.models import WorkflowApschedulerJob
@@ -265,6 +266,8 @@ def run_migrations(db_uri: str) -> None:
 
 
 def make_db_uri(worker_id, base_uri):
+    warn_db_uri_scheme(base_uri)
+
     if worker_id == "master":
         # pytest is being run without any workers
         print(f"No workers, final DATABASE_URI is {base_uri!r}")

--- a/test/integration_tests/db/test_database.py
+++ b/test/integration_tests/db/test_database.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 """Tests for database session management: WrappedSession commit gating, disable_commit nesting, and transactional."""
-
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,33 +23,38 @@ from orchestrator.core.db.database import (
 )
 
 
-def _make_db(disabled: bool = False) -> MagicMock:
-    db = MagicMock()
-    db.session.info = {"disabled": disabled}
-    return db
-
-
-def _make_session(disabled: bool = False, custom_logger: MagicMock | None = None) -> MagicMock:
-    session = MagicMock(spec=WrappedSession)
-    session.info = {"disabled": disabled}
+def _make_session(commit_disabled: bool = False, custom_logger: MagicMock | None = None) -> WrappedSession:
+    info: dict = {"disabled": commit_disabled}
     if custom_logger is not None:
-        session.info["logger"] = custom_logger
-    session.commit = WrappedSession.commit.__get__(session, WrappedSession)
-    return session
+        info["logger"] = custom_logger
+    return WrappedSession(info=info)
+
+
+def _make_db(commit_disabled: bool = False) -> MagicMock:
+    session = _make_session(commit_disabled=commit_disabled)
+    # Spy on the SQLAlchemy mutation methods so tests can assert call counts,
+    # while keeping is_commit_disabled / enable_commit / disable_commit / info real.
+    session.commit = MagicMock()  # type: ignore[method-assign]
+    session.rollback = MagicMock()  # type: ignore[method-assign]
+    session.add = MagicMock()  # type: ignore[method-assign]
+
+    db = MagicMock()
+    db.session = session
+    return db
 
 
 # --- WrappedSession.commit ---
 
 
 @pytest.mark.parametrize(
-    "disabled,expect_super_called",
+    "commit_disabled,expect_super_called",
     [
         pytest.param(False, True, id="enabled-calls-super"),
         pytest.param(True, False, id="disabled-skips-super"),
     ],
 )
-def test_wrapped_session_commit_respects_disabled_flag(disabled: bool, expect_super_called: bool) -> None:
-    session = _make_session(disabled=disabled)
+def test_wrapped_session_commit_respects_disabled_flag(commit_disabled: bool, expect_super_called: bool) -> None:
+    session = _make_session(commit_disabled=commit_disabled)
     with patch("orchestrator.core.db.database.Session.commit") as mock_super:
         session.commit()
     assert mock_super.called == expect_super_called
@@ -58,7 +62,7 @@ def test_wrapped_session_commit_respects_disabled_flag(disabled: bool, expect_su
 
 def test_wrapped_session_commit_disabled_logs_warning() -> None:
     mock_log = MagicMock()
-    session = _make_session(disabled=True, custom_logger=mock_log)
+    session = _make_session(commit_disabled=True, custom_logger=mock_log)
     with patch("orchestrator.core.db.database.Session.commit"):
         session.commit()
     mock_log.warning.assert_called_once()
@@ -68,21 +72,21 @@ def test_wrapped_session_commit_disabled_logs_warning() -> None:
 
 
 def test_disable_commit_sets_and_restores_state() -> None:
-    db = _make_db(disabled=False)
+    db = _make_db(commit_disabled=False)
     log = MagicMock()
     with disable_commit(db, log):
         assert db.session.info["disabled"] is True
         assert db.session.info["logger"] is log
-    _assert_state(db, disabled=False, logger=None)
+    _assert_state(db, commit_disabled=False, logger=None)
 
 
-def _assert_state(db: MagicMock, *, disabled: bool, logger: object) -> None:
-    assert db.session.info["disabled"] is disabled
+def _assert_state(db: MagicMock, *, commit_disabled: bool, logger: object) -> None:
+    assert db.session.info["disabled"] is commit_disabled
     assert db.session.info["logger"] is logger
 
 
 def test_disable_commit_nested_does_not_reenable() -> None:
-    db = _make_db(disabled=True)
+    db = _make_db(commit_disabled=True)
     log = MagicMock()
     with disable_commit(db, log):
         assert db.session.info["disabled"] is True
@@ -95,7 +99,7 @@ def test_disable_commit_nested_does_not_reenable() -> None:
     [pytest.param(ValueError, id="value-error"), pytest.param(RuntimeError, id="runtime-error")],
 )
 def test_disable_commit_restores_on_exception(exc_type: type[Exception]) -> None:
-    db = _make_db(disabled=False)
+    db = _make_db(commit_disabled=False)
     log = MagicMock()
     with pytest.raises(exc_type):
         with disable_commit(db, log):
@@ -139,7 +143,7 @@ def test_transactional_disables_commit_inside_block() -> None:
 
 def test_transactional_nested_does_not_commit_or_rollback() -> None:
     """Nested transactional() must not commit or rollback even after a real session operation."""
-    db = _make_db(disabled=True)  # simulate already inside an outer transactional()
+    db = _make_db(commit_disabled=True)  # simulate already inside an outer transactional()
     log = MagicMock()
 
     with transactional(db, log):
@@ -151,7 +155,7 @@ def test_transactional_nested_does_not_commit_or_rollback() -> None:
 
 def test_transactional_nested_propagates_exception_without_rollback() -> None:
     """Nested transactional() must propagate exceptions without rollback after a real session operation."""
-    db = _make_db(disabled=True)
+    db = _make_db(commit_disabled=True)
     log = MagicMock()
 
     with pytest.raises(RuntimeError, match="inner failed"):

--- a/test/integration_tests/db/test_database.py
+++ b/test/integration_tests/db/test_database.py
@@ -117,7 +117,6 @@ def test_transactional_commits_on_success() -> None:
     with transactional(db, log):
         pass
     db.session.commit.assert_called_once()
-    # db.session.rollback.assert_called_once()
     db.session.rollback.assert_not_called()
 
 

--- a/test/integration_tests/db/test_database.py
+++ b/test/integration_tests/db/test_database.py
@@ -117,7 +117,8 @@ def test_transactional_commits_on_success() -> None:
     with transactional(db, log):
         pass
     db.session.commit.assert_called_once()
-    db.session.rollback.assert_called_once()
+    # db.session.rollback.assert_called_once()
+    db.session.rollback.assert_not_called()
 
 
 def test_transactional_does_not_commit_on_exception() -> None:

--- a/test/integration_tests/db/test_db.py
+++ b/test/integration_tests/db/test_db.py
@@ -14,6 +14,7 @@
 from unittest import mock
 
 import pytest
+from db.database import MESSAGE_COMMIT_ATTEMPTED_WHILE_DISABLED
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -91,7 +92,7 @@ def test_transactional_no_commit():
     logger.assert_has_calls(
         [
             mock.call.warning(
-                "Step function tried to issue a commit. It should not! Will execute commit on behalf of step function when it returns."
+                MESSAGE_COMMIT_ATTEMPTED_WHILE_DISABLED
             ),
         ]
     )
@@ -135,8 +136,7 @@ def test_transactional_no_commit_second_thread():
     )
     logger.assert_has_calls(
         [
-            mock.call.warning(
-                "Step function tried to issue a commit. It should not! Will execute commit on behalf of step function when it returns."
+            mock.call.warning(MESSAGE_COMMIT_ATTEMPTED_WHILE_DISABLED
             ),
         ]
     )

--- a/test/integration_tests/services/executors/test_celery.py
+++ b/test/integration_tests/services/executors/test_celery.py
@@ -130,8 +130,6 @@ def test_celery_set_process_status_resumed_valid_statuses(mock_db, status):
     _celery_set_process_status_resumed(process)
 
     assert process.last_status == ProcessStatus.RESUMED
-    # mock_db.session.commit.assert_called_once()
-    # mock_db.session.rollback.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
@@ -148,5 +146,3 @@ def test_celery_set_process_status_resumed_invalid_statuses(mock_db, status):
         _celery_set_process_status_resumed(process)
 
     assert process.last_status == status
-    # mock_db.session.commit.assert_not_called()
-    # mock_db.session.rollback.assert_called_once()

--- a/test/integration_tests/services/executors/test_celery.py
+++ b/test/integration_tests/services/executors/test_celery.py
@@ -130,8 +130,8 @@ def test_celery_set_process_status_resumed_valid_statuses(mock_db, status):
     _celery_set_process_status_resumed(process)
 
     assert process.last_status == ProcessStatus.RESUMED
-    mock_db.session.commit.assert_called_once()
-    mock_db.session.rollback.assert_not_called()
+    # mock_db.session.commit.assert_called_once()
+    # mock_db.session.rollback.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.celery.db", return_value=MagicMock(session=MagicMock()))
@@ -148,5 +148,5 @@ def test_celery_set_process_status_resumed_invalid_statuses(mock_db, status):
         _celery_set_process_status_resumed(process)
 
     assert process.last_status == status
-    mock_db.session.commit.assert_not_called()
-    mock_db.session.rollback.assert_called_once()
+    # mock_db.session.commit.assert_not_called()
+    # mock_db.session.rollback.assert_called_once()

--- a/test/integration_tests/services/executors/test_threadpool.py
+++ b/test/integration_tests/services/executors/test_threadpool.py
@@ -71,8 +71,8 @@ def test_set_process_status_running(mock_db):
     _set_process_status_running(uuid4())
 
     assert mock_process.last_status == ProcessStatus.RUNNING
-    mock_db.session.commit.assert_called_once()
-    mock_db.session.rollback.assert_not_called()
+    # mock_db.session.commit.assert_called_once()
+    # mock_db.session.rollback.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool.db")
@@ -87,8 +87,8 @@ def test_set_process_status_running_errors_if_already_running(mock_db):
     with pytest.raises(Exception, match="Process is already running"):
         _set_process_status_running(uuid4())
 
-    mock_db.session.rollback.assert_called_once()
-    mock_db.session.commit.assert_not_called()
+    # mock_db.session.rollback.assert_called_once()
+    # mock_db.session.commit.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool.db")
@@ -102,8 +102,8 @@ def test_set_process_status_running_errors_if_not_found(mock_db):
     with pytest.raises(Exception, match=f"Process not found: {process_id}"):
         _set_process_status_running(process_id)
 
-    mock_db.session.rollback.assert_called_once()
-    mock_db.session.commit.assert_not_called()
+    # mock_db.session.rollback.assert_called_once()
+    # mock_db.session.commit.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool._set_process_status_running")

--- a/test/integration_tests/services/executors/test_threadpool.py
+++ b/test/integration_tests/services/executors/test_threadpool.py
@@ -71,8 +71,6 @@ def test_set_process_status_running(mock_db):
     _set_process_status_running(uuid4())
 
     assert mock_process.last_status == ProcessStatus.RUNNING
-    # mock_db.session.commit.assert_called_once()
-    # mock_db.session.rollback.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool.db")
@@ -87,8 +85,6 @@ def test_set_process_status_running_errors_if_already_running(mock_db):
     with pytest.raises(Exception, match="Process is already running"):
         _set_process_status_running(uuid4())
 
-    # mock_db.session.rollback.assert_called_once()
-    # mock_db.session.commit.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool.db")
@@ -102,8 +98,6 @@ def test_set_process_status_running_errors_if_not_found(mock_db):
     with pytest.raises(Exception, match=f"Process not found: {process_id}"):
         _set_process_status_running(process_id)
 
-    # mock_db.session.rollback.assert_called_once()
-    # mock_db.session.commit.assert_not_called()
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool._set_process_status_running")

--- a/test/unit_tests/db/test_wrapped_session.py
+++ b/test/unit_tests/db/test_wrapped_session.py
@@ -1,0 +1,67 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for WrappedSession accessor methods: is_commit_disabled, enable_commit, disable_commit."""
+
+import pytest
+
+from orchestrator.core.db.database import WrappedSession
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        pytest.param({"disabled": True}, True, id="disabled-true"),
+        pytest.param({"disabled": False}, False, id="disabled-false"),
+        pytest.param({}, False, id="disabled-unset"),
+        pytest.param({"disabled": None}, False, id="disabled-none"),
+        pytest.param({"disabled": 1}, False, id="disabled-truthy-non-bool"),
+        pytest.param({"disabled": "true"}, False, id="disabled-string-non-bool"),
+    ],
+)
+def test_is_commit_disabled(info: dict, expected: bool) -> None:
+    session = WrappedSession(info=info)
+    assert session.is_commit_disabled() is expected
+
+
+def test_disable_commit_sets_flag_true() -> None:
+    session = WrappedSession(info={"disabled": False})
+    session.disable_commit()
+    assert session.info["disabled"] is True
+    assert session.is_commit_disabled() is True
+
+
+def test_enable_commit_sets_flag_false() -> None:
+    session = WrappedSession(info={"disabled": True})
+    session.enable_commit()
+    assert session.info["disabled"] is False
+    assert session.is_commit_disabled() is False
+
+
+def test_disable_then_enable_round_trip() -> None:
+    session = WrappedSession(info={"disabled": False})
+    session.disable_commit()
+    session.enable_commit()
+    assert session.is_commit_disabled() is False
+
+
+def test_disable_commit_is_idempotent() -> None:
+    session = WrappedSession(info={"disabled": True})
+    session.disable_commit()
+    assert session.is_commit_disabled() is True
+
+
+def test_enable_commit_is_idempotent() -> None:
+    session = WrappedSession(info={"disabled": False})
+    session.enable_commit()
+    assert session.is_commit_disabled() is False

--- a/test/unit_tests/services/test_processes.py
+++ b/test/unit_tests/services/test_processes.py
@@ -29,6 +29,7 @@ from orchestrator.core.workflow import StepList, make_workflow, step
         ([{"a": 1}, {"b": 2}], [{"a": 1}, {"b": 2}]),
     ],
 )
+@mock.patch("orchestrator.core.services.processes.transactional")
 @mock.patch("orchestrator.core.services.processes.store_input_state")
 @mock.patch("orchestrator.core.services.processes._db_create_process")
 @mock.patch("orchestrator.core.services.processes.post_form")
@@ -38,6 +39,7 @@ def test_create_process_normalizes_user_inputs(
     mock_post_form,
     mock_db_create_process,
     mock_store_input_state,
+    mock_transactional,
     user_inputs,
     expected_post_form_inputs,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -2651,7 +2651,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-core"
-version = "5.0.0rc3"
+version = "5.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

### Essential psycopg3 related fixes

As follow-up to https://github.com/workfloworchestrator/orchestrator-core/pull/1549

- Ensure that sqlalchemy's SessionTransaction is committed or closed before "output signals" of the API (trigger celery/threadpool task, emit WS event)
  - Remove `db.session.commit()` and `db.session.rollback()` statements from lower level functions; handle this "higher up"
- Change `store_input_state` to take the input state through a json serialization/deserialization roundtrip to prevent out of band transactions (tried `db.session.flush()` but this is not thorough enough)

### Other changes

- Add DB helper function `warn_db_uri_scheme()` to warn for old style postgres URI (psycopg2)
- Add enum `ExecutorFunction` to identify keys of X_EXECUTION_CONTEXT dicts
- Add `WrappedSession` methods for read/write access to `db.session.info["disabled"]`
- Change `SubscriptionModel.from_other_product` param `old_instantiation` to type SubscriptionModel, there's no need for it to be the same type. This solves type checking errors in the orchestrator implementation
- Remove `description` parameter for builtin tasks


### Documentation

- Extend 5.0 upgrade guide with examples for `orchestrator.core` rename
- Document changes to `OrchestratorWorker(Celery)` for psycopg3

Closes #1097 

