### PR TITLE
Add missing documentation for registring required GraphQL upon app start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ from orchestrator.core import OrchestratorCore
 from orchestrator.core.settings import AppSettings
 
 app = OrchestratorCore(base_settings=AppSettings())
+app.register_graphql()
 ```
 
 ### Step 4 - Run the database migrations

--- a/docs/getting-started/base.md
+++ b/docs/getting-started/base.md
@@ -104,6 +104,7 @@ This will be used to run the Orchestrator API.
     from orchestrator.core.settings import app_settings
 
     app = OrchestratorCore(base_settings=app_settings)
+    app.register_graphql()
     ```
 
 === "`orchestrator-core` < 5.0"
@@ -113,6 +114,7 @@ This will be used to run the Orchestrator API.
     from orchestrator.settings import app_settings
 
     app = OrchestratorCore(base_settings=app_settings)
+    app.register_graphql()
     ```
 
 


### PR DESCRIPTION
## Summary
Docs were missing a vital `app.register_graphql()`, so anyone new following the installation instructions would end up with a non-functioning orchestrator.

## Related Issues
N/A

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
