### PR TITLE
Fix API errors from newer openapi generators not correctly being handled in a step

### DIFF
--- a/orchestrator/core/utils/errors.py
+++ b/orchestrator/core/utils/errors.py
@@ -34,7 +34,7 @@ class ApiException(Exception):  # noqa: N818
     status: HTTPStatus | None
     reason: str | None
     body: str | None
-    headers: dict[str, str]
+    headers: dict[str, str] | None
 
     def __init__(self, status: HTTPStatus | None = None, reason: str | None = None, http_resp: object | None = None):
         super().__init__(status, reason, http_resp)
@@ -93,20 +93,21 @@ class StartPredicateError(Exception):
 
 
 def is_api_exception(ex: Exception) -> bool:
-    """Test for swagger-codegen ApiException.
+    """Test for swagger-codegen / openapi-generator ApiException.
 
-    For each API, swagger-codegen generates a new ApiException class. These are not organized into
-    a hierarchy. Hence, testing whether one is dealing with one of the ApiException classes without knowing how
-    many there are and where they are located, needs some special logic.
+    Generated clients create a new ApiException class per API, and newer generators produce typed
+    subclasses (BadRequestException, NotFoundException, etc.) that all inherit from a class named
+    ApiException. Walking the MRO catches both the base class and all subclasses without requiring
+    a shared import.
 
     Args:
         ex: the Exception to be tested.
 
     Returns:
-        True if it is an ApiException, False otherwise.
+        True if any class in the exception's MRO is named ApiException.
 
     """
-    return ex.__class__.__name__ == "ApiException"
+    return any(c.__name__ == "ApiException" for c in type(ex).__mro__)
 
 
 @singledispatch
@@ -146,5 +147,4 @@ def _(err: Exception) -> ErrorDict:
             "headers": "\n".join(f"{k}: {v}" for k, v in headers.items()),
             "traceback": show_ex(err),
         }
-
     return {"class": type(err).__name__, "error": str(err), "traceback": show_ex(err)}

--- a/test/unit_tests/utils/test_errors.py
+++ b/test/unit_tests/utils/test_errors.py
@@ -13,7 +13,18 @@
 
 from http import HTTPStatus
 
+import pytest
+
 from orchestrator.core.utils.errors import ApiException, ProcessFailureError, error_state_to_dict
+
+
+# Simulate typed subclasses from newer openapi-generator clients (e.g. ims_client).
+class BadRequestException(ApiException):  # noqa: N818
+    pass
+
+
+class NotFoundException(ApiException):  # noqa: N818
+    pass
 
 
 class RESTResponse:  # From openapi-generator generated clients
@@ -37,15 +48,13 @@ def test_error_state_to_dict_base_exception():
     }
 
 
-def test_error_state_to_dict_api_exception():
-    e = ApiException(status=HTTPStatus.NOT_FOUND, reason="Not Found")
+def test_error_state_to_dict_process_failure_exception():
+    e = ProcessFailureError(message="Something went wrong", details={"foo": "bar"})
     assert error_state_to_dict(e) == {
-        "body": None,
-        "class": "ApiException",
-        "error": "Not Found",
-        "headers": "",
-        "status_code": HTTPStatus.NOT_FOUND,
-        "traceback": "ApiException: (404)\nReason: Not Found\n\n",
+        "class": "ProcessFailureError",
+        "details": {"foo": "bar"},
+        "error": "Something went wrong",
+        "traceback": "ProcessFailureError: ('Something went wrong', {'foo': 'bar'})\n",
     }
 
 
@@ -76,11 +85,20 @@ def test_error_state_to_dict_api_exception_with_headers_none():
     }
 
 
-def test_error_state_to_dict_process_failure_exception():
-    e = ProcessFailureError(message="Something went wrong", details={"foo": "bar"})
-    assert error_state_to_dict(e) == {
-        "class": "ProcessFailureError",
-        "details": {"foo": "bar"},
-        "error": "Something went wrong",
-        "traceback": "ProcessFailureError: ('Something went wrong', {'foo': 'bar'})\n",
-    }
+@pytest.mark.parametrize(
+    "exc_class,status,reason",
+    [
+        (ApiException, HTTPStatus.NOT_FOUND, "Not Found"),
+        (BadRequestException, HTTPStatus.BAD_REQUEST, "Bad Request"),
+        (NotFoundException, HTTPStatus.NOT_FOUND, "Not Found"),
+    ],
+)
+def test_error_state_to_dict_api_exception_subclass(exc_class, status, reason):
+    e = exc_class(status=status, reason=reason)
+    result = error_state_to_dict(e)
+    assert result["class"] == exc_class.__name__
+    assert result["error"] == reason
+    assert result["status_code"] == status
+    assert result["body"] is None
+    assert result["headers"] == ""
+    assert isinstance(result["traceback"], str)


### PR DESCRIPTION
newer versions of the openapi generator for external API's produce typed subclasses (BadRequestException, NotFoundException, etc.) so updated it to check for the `ApiException` in `__mro__`