### PR TITLE
Fix scheduled tasks lost after 5.0 namespace change (#1638)

### DIFF
--- a/docs/guides/upgrading/5.0.md
+++ b/docs/guides/upgrading/5.0.md
@@ -45,6 +45,36 @@ We no longer use `flit` for building the Python wheels that are distributed on P
 forward. This is a change that only impacts `orchestrator-core` contributors that may have to run a `uv sync` just to
 be up-to-date again.
 
+##### Scheduled tasks
+
+!!! warning
+    The namespace change invalidates all existing scheduled tasks in the database. APScheduler stores the fully qualified
+    Python path of the task function in pickled job state (`apscheduler_jobs.job_state`). After upgrading to 5.0, these
+    references still point to `orchestrator.schedules.…` instead of `orchestrator.core.schedules.…`, which causes the
+    scheduler to silently skip them.
+
+A database migration (`cab8b6a0ac92`) is included that rewrites the stored function references from the old namespace to
+the new one. This migration runs automatically as part of `python main.py db upgrade heads`.
+
+**Before running the migration**, you should:
+
+1. **Stop the scheduler** before applying the 5.0 database migrations. If the scheduler is still running with the old
+   code while migrations are applied, it may overwrite the corrected references.
+2. **Create a backup** of the `apscheduler_jobs` table so you can restore scheduled tasks if anything goes wrong:
+   ```sql
+   CREATE TABLE apscheduler_jobs_backup AS SELECT * FROM apscheduler_jobs;
+   ```
+
+After the migration completes, verify that your scheduled tasks are visible again (e.g. via the GraphQL
+`scheduledTasks` query or the [show-schedule] CLI command), then start the scheduler.
+
+If you need to restore from backup:
+
+```sql
+DELETE FROM apscheduler_jobs;
+INSERT INTO apscheduler_jobs SELECT * FROM apscheduler_jobs_backup;
+```
+
 #### What you need to do
 
 All import statements that mention the Orchestrator core should be updated to reflect this change. There is a migration

--- a/orchestrator/core/migrations/versions/schema/2026-05-18_cab8b6a0ac92_fix_scheduled_tasks_issue.py
+++ b/orchestrator/core/migrations/versions/schema/2026-05-18_cab8b6a0ac92_fix_scheduled_tasks_issue.py
@@ -1,0 +1,61 @@
+# Copyright 2019-2026 SURF, ESnet, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fix issue where scheduled tasks are not shown due to namespace change from orchestrator. to orchestrator.core.
+
+Revision ID: cab8b6a0ac92
+Revises: be3163f7c49d
+Create Date: 2026-05-18 11:49:37.145417
+
+"""
+import pickle
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'cab8b6a0ac92'
+down_revision = 'be3163f7c49d'
+branch_labels = None
+depends_on = None
+
+OLD_PREFIX = "orchestrator."
+NEW_PREFIX = "orchestrator.core."
+
+def _rewrite_func_ref(func_ref: str, old: str, new: str) -> str | None:
+    """Rewrite a func ref from old prefix to new, returning None if unchanged."""
+    if func_ref.startswith(old) and not func_ref.startswith(new):
+        return new + func_ref[len(old) :]
+    return None
+
+
+def _migrate_job_states(old: str, new: str) -> None:
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, job_state FROM apscheduler_jobs")).fetchall()
+
+    for job_id, job_state in rows:
+        state = pickle.loads(job_state)  # noqa: S301
+        updated_ref = _rewrite_func_ref(state.get("func", ""), old, new)
+        if updated_ref:
+            state["func"] = updated_ref
+            conn.execute(
+                sa.text("UPDATE apscheduler_jobs SET job_state = :state WHERE id = :id"),
+                {"state": pickle.dumps(state, protocol=pickle.HIGHEST_PROTOCOL), "id": job_id},
+            )
+
+
+def upgrade() -> None:
+    _migrate_job_states(OLD_PREFIX, NEW_PREFIX)
+
+
+def downgrade() -> None:
+    _migrate_job_states(NEW_PREFIX, OLD_PREFIX)

--- a/orchestrator/core/schedules/service.py
+++ b/orchestrator/core/schedules/service.py
@@ -154,6 +154,11 @@ def _delete_linker_entry(workflow_id: UUID, schedule_id: str) -> None:
 def run_start_workflow_scheduler_task(workflow_name: str, user_inputs: list[State] | None = None) -> None:
     """Function to start a workflow from the scheduler.
 
+    Warning: Do not move or rename this function. Its fully qualified path is persisted in
+        pickled APScheduler job state (``apscheduler_jobs.job_state``). Changing the
+        path will invalidate all existing scheduled tasks. If a rename is unavoidable,
+        add a data migration to rewrite the stored ``func`` references.
+
     Args:
         workflow_name: str The name of the workflow to start.
         user_inputs: user inputs for the workflow to start.

--- a/orchestrator/core/schedules/service.py
+++ b/orchestrator/core/schedules/service.py
@@ -157,7 +157,8 @@ def run_start_workflow_scheduler_task(workflow_name: str, user_inputs: list[Stat
     Warning: Do not move or rename this function. Its fully qualified path is persisted in
         pickled APScheduler job state (``apscheduler_jobs.job_state``). Changing the
         path will invalidate all existing scheduled tasks. If a rename is unavoidable,
-        add a data migration to rewrite the stored ``func`` references.
+        add a data migration to rewrite the stored ``func`` references — see
+        ``2026-05-18_cab8b6a0ac92_fix_scheduled_tasks_issue.py`` for an example.
 
     Args:
         workflow_name: str The name of the workflow to start.


### PR DESCRIPTION
  ## Summary

  Deploying v5.0 silently invalidates all existing scheduled tasks because APScheduler persists the fully qualified Python path of the task function in pickled job state (`apscheduler_jobs.job_state`). The v5.0 namespace change from
   `orchestrator.*` to `orchestrator.core.*` breaks these stored references, causing the scheduler to skip all previously created tasks.

  This PR:

  - **Adds a database migration** (`cab8b6a0ac92`) that deserializes each APScheduler job state, rewrites `func` references from the old `orchestrator.` prefix to `orchestrator.core.`, and re-serializes them. The migration is fully
  reversible.
  - **Adds a warning docstring** to `run_start_workflow_scheduler_task()` alerting future developers not to move or rename the function without a corresponding data migration.
  - **Adds upgrade documentation** to the 5.0 guide under the namespace packaging section, warning users to stop the scheduler and back up the `apscheduler_jobs` table before migrating.

  ## Test plan 
  
  - [ ] Verify the migration runs without errors on a database with existing scheduled tasks
  - [ ] Verify scheduled tasks are visible after migration (via GraphQL `scheduledTasks` query or `show-schedule` CLI)
  - [ ] Verify the downgrade path restores the old namespace references
  - [ ] Verify the upgrade documentation renders correctly in the docs site

  Closes #1638