### PR TITLE
Define function `default_user_inputs()` and use it as default factory for APSchedulerJobCreate.user_inputs

### DIFF
--- a/orchestrator/core/forms/scheduler_form.py
+++ b/orchestrator/core/forms/scheduler_form.py
@@ -26,7 +26,7 @@ from orchestrator.core.db import db
 from orchestrator.core.db.models import WorkflowTable
 from orchestrator.core.forms.validators import Choice
 from orchestrator.core.forms.validators.timestamp import to_timestamp_field
-from orchestrator.core.workflow import Workflow
+from orchestrator.core.workflow import Workflow, default_user_inputs
 from orchestrator.core.workflows import get_workflow
 from pydantic_forms.types import FormGenerator, FormGeneratorAsync, State
 from pydantic_forms.validators.components.read_only import read_only_field
@@ -209,7 +209,7 @@ async def configure_schedule_form(state: State) -> FormGeneratorAsync:
         "workflow_name": task_name,
         "trigger": schedule_type_data["schedule_type"].name.lower(),
         "trigger_kwargs": trigger_kwargs,
-        "user_inputs": user_inputs if user_inputs else [{}],
+        "user_inputs": user_inputs or default_user_inputs(),
         "scheduled_type": "create",
         "name": description,
     }

--- a/orchestrator/core/schemas/schedules.py
+++ b/orchestrator/core/schemas/schedules.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, TypeAdapter
 
+from orchestrator.core.workflow import default_user_inputs
 from pydantic_forms.types import State
 
 SCHEDULER_Q_CREATE = "create"
@@ -37,7 +38,7 @@ class APSchedulerJobCreate(APSchedulerJob):
         description="Arguments passed to the trigger on job creation",
         examples=[{"hours": 12}, {"minutes": 30}, {"days": 1, "hours": 2}],
     )
-    user_inputs: list[State] = Field(default_factory=list, description="user inputs for the task")
+    user_inputs: list[State] = Field(default_factory=default_user_inputs, description="user inputs for the task")
 
     scheduled_type: Literal["create"] = Field("create", frozen=True)
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -58,6 +58,7 @@ from orchestrator.core.workflow import (
     Success,
     Workflow,
     abort_wf,
+    default_user_inputs,
 )
 from orchestrator.core.workflow import Process as WFProcess
 from orchestrator.core.workflows import get_workflow
@@ -470,7 +471,7 @@ def create_process(
     # ATTENTION!! When modifying this function make sure you make similar changes to `run_workflow` in the test code
 
     if user_inputs is None:
-        user_inputs = [{}]
+        user_inputs = default_user_inputs()
 
     process_id = uuid4()
     workflow = get_workflow(workflow_key)

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -230,6 +230,14 @@ async def allow(_: OIDCUserModel | None) -> bool:
     return True
 
 
+def default_user_inputs() -> list[State]:
+    """Provide the default user inputs when executing a workflow when user inputs are not explicitly provided.
+
+    This mirrors the requirement from make_workflow() to always have at least 1 form.
+    """
+    return [{}]
+
+
 def make_workflow(
     f: Callable,
     description: str,


### PR DESCRIPTION
## Summary

Alternative solution to #1632:

The payload for creating apscheduler jobs has a `user_inputs` field that defaults to an empty list.
This PR changes that to a list with a `{}` similar to other parts of the codebase.

To make this more visible, I've added it to a reusable `default_user_inputs()` and applied this where needed.



