### PR TITLE
Fix `FormNotCompleteError` in scheduler + extend scheduler CLI with options `-v/--verbose` and `--recreate`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.1
+current_version = 5.0.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/core/cli/scheduler.py
+++ b/orchestrator/core/cli/scheduler.py
@@ -151,7 +151,9 @@ def force(task_id: str) -> None:
 
 
 @app.command()
-def load_initial_schedule() -> None:
+def load_initial_schedule(
+    recreate: bool = typer.Option(False, help="Whether to delete any existing schedules before creating"),
+) -> None:
     """The `load-initial-schedule` command loads the initial schedule using the scheduler API.
 
     The initial schedules are:
@@ -159,8 +161,9 @@ def load_initial_schedule() -> None:
       - Task Clean Up Tasks
       - Task Validate Subscriptions
 
-    This command is idempotent since 4.7.1 when the scheduler is running. The schedules are only
-    created when they do not already exist in the database.
+    By default, this command is idempotent since v4.7.1 when the scheduler is running.
+    The schedules are only created when they do not already exist in the database.
+    This behavior can be altered through the --recreate option.
     """
     initial_schedules = [
         {
@@ -205,4 +208,5 @@ def load_initial_schedule() -> None:
         schedule["workflow_id"] = workflow.workflow_id
 
         typer.echo(f"Initial Schedule: {schedule}")
-        add_unique_scheduled_task_to_queue(APSchedulerJobCreate(**schedule))  # type: ignore
+        payload = APSchedulerJobCreate.model_validate(schedule)
+        add_unique_scheduled_task_to_queue(payload, recreate=recreate)

--- a/orchestrator/core/cli/scheduler.py
+++ b/orchestrator/core/cli/scheduler.py
@@ -10,10 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import time
+from collections.abc import Iterator
 from typing import cast
 
 import typer
+from apscheduler.job import Job
 from redis import Redis
 
 from orchestrator.core.db import db
@@ -69,8 +72,27 @@ def run() -> None:
                 workflow_scheduler_queue(item, scheduler_connection)
 
 
+def _to_schedule_row(task: Job, *, api_managed_ids: set[str], verbose: bool) -> list[str]:
+    source = "API" if task.id in api_managed_ids else "decorator"
+    run_time = str(task.next_run_time.replace(microsecond=0))
+
+    def values() -> Iterator[str]:
+        yield task.id # id
+        yield task.name # name
+        yield source # source
+        yield str(run_time) # next run time
+        yield str(task.trigger) # trigger
+        if verbose:
+            yield json.dumps(task.kwargs, indent=2) # kwargs
+
+    return list(values())
+
+
+
 @app.command()
-def show_schedule() -> None:
+def show_schedule(
+    verbose: bool = typer.Option(False, "-v", help="Show additional details, such as job kwargs"),
+) -> None:
     """The `show-schedule` command shows an overview of the scheduled jobs."""
     from rich.console import Console
     from rich.table import Table
@@ -79,21 +101,24 @@ def show_schedule() -> None:
 
     console = Console()
 
-    table = Table(title="Scheduled Tasks")
+    table = Table(title="Scheduled Tasks", show_lines=verbose)
     table.add_column("id", no_wrap=True)
     table.add_column("name")
     table.add_column("source")
     table.add_column("next run time")
     table.add_column("trigger")
+    if verbose:
+        table.add_column("kwargs")
 
     scheduled_tasks = get_all_scheduler_tasks()
     _schedule_ids = [task.id for task in scheduled_tasks]
     api_managed = {str(i.schedule_id) for i in get_linker_entries_by_schedule_ids(_schedule_ids)}
 
+    # Sort by next run time, then by name
+    scheduled_tasks.sort(key=lambda x: (x.next_run_time, x.name))
+
     for task in scheduled_tasks:
-        source = "API" if task.id in api_managed else "decorator"
-        run_time = str(task.next_run_time.replace(microsecond=0))
-        table.add_row(task.id, task.name, source, str(run_time), str(task.trigger))
+        table.add_row(*_to_schedule_row(task, api_managed_ids=api_managed, verbose=verbose))
 
     console.print(table)
 

--- a/orchestrator/core/forms/scheduler_form.py
+++ b/orchestrator/core/forms/scheduler_form.py
@@ -26,7 +26,7 @@ from orchestrator.core.db import db
 from orchestrator.core.db.models import WorkflowTable
 from orchestrator.core.forms.validators import Choice
 from orchestrator.core.forms.validators.timestamp import to_timestamp_field
-from orchestrator.core.workflow import Workflow
+from orchestrator.core.workflow import Workflow, default_user_inputs
 from orchestrator.core.workflows import get_workflow
 from pydantic_forms.types import FormGenerator, FormGeneratorAsync, State
 from pydantic_forms.validators.components.read_only import read_only_field
@@ -209,7 +209,7 @@ async def configure_schedule_form(state: State) -> FormGeneratorAsync:
         "workflow_name": task_name,
         "trigger": schedule_type_data["schedule_type"].name.lower(),
         "trigger_kwargs": trigger_kwargs,
-        "user_inputs": user_inputs if user_inputs else [{}],
+        "user_inputs": user_inputs or default_user_inputs(),
         "scheduled_type": "create",
         "name": description,
     }

--- a/orchestrator/core/schedules/service.py
+++ b/orchestrator/core/schedules/service.py
@@ -18,7 +18,7 @@ from apscheduler.schedulers.base import BaseScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 from orchestrator.core import app_settings
 from orchestrator.core.db import db
@@ -79,10 +79,16 @@ def add_scheduled_task_to_queue(payload: APSchedulerJobs) -> None:
     """
     bytes_dump = serialize_payload(payload)
     redis_connection.lpush(SCHEDULER_QUEUE, bytes_dump)
-    logger.info("Added scheduled task to queue.")
+    logger.info("Added scheduled task to queue")
 
 
-def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate) -> bool:
+def _delete_scheduled_tasks(schedules: list[WorkflowApschedulerJob]) -> None:
+    for ws in schedules:
+        delete_payload = APSchedulerJobDelete(workflow_id=ws.workflow_id, schedule_id=ws.schedule_id)
+        add_scheduled_task_to_queue(delete_payload)
+
+
+def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate, *, recreate: bool=False) -> bool:
     """Create a unique scheduled task service function.
 
     Checks if the workflow is already scheduled before creating an apscheduler
@@ -97,14 +103,21 @@ def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate) -> bool:
 
     Args:
         payload: APSchedulerJobCreate The scheduled task to create.
+        recreate: Whether to delete existing schedule(s) for the workflow
 
     Returns:
         True when the scheduled task was added to the queue
         False when the scheduled task was not added to the queue
     """
-    if db.session.query(WorkflowApschedulerJob).filter_by(workflow_id=payload.workflow_id).all():
-        logger.info(f"Not adding existing workflow {payload.workflow_name} as scheduled task.")
-        return False
+    schedules = db.session.scalars(select(WorkflowApschedulerJob).filter_by(workflow_id=payload.workflow_id)).all()
+    if schedules:
+        if not recreate:
+            logger.info("Not scheduling workflow as there are existing schedules, and recreate is not set", existing=schedules)
+            return False
+        logger.info("Deleting existing schedules for workflow", existing=schedules)
+        _delete_scheduled_tasks(
+            schedules,  # type: ignore[arg-type]
+        )
     add_scheduled_task_to_queue(payload)
     return True
 
@@ -185,7 +198,7 @@ def _add_scheduled_task(payload: APSchedulerJobCreate, scheduler_connection: Bas
         payload: APSchedulerJobCreate The scheduled task to create.
         scheduler_connection: BaseScheduler The scheduler connection.
     """
-    logger.info(f"Adding scheduled task: {payload}")
+    logger.info("Adding scheduled task", payload=payload)
 
     workflow_description = None
     # Check if a workflow exists - we cannot schedule a non-existing workflow
@@ -218,7 +231,7 @@ def _build_trigger_on_update(
     trigger_name: str | None, trigger_kwargs: dict
 ) -> IntervalTrigger | CronTrigger | DateTrigger | None:
     if not trigger_name or not trigger_kwargs:
-        logger.info("Skipping building trigger as no trigger information is provided.")
+        logger.info("Skipping building trigger as no trigger information is provided")
         return None
 
     match trigger_name:
@@ -243,7 +256,7 @@ def _update_scheduled_task(payload: APSchedulerJobUpdate, scheduler_connection: 
         payload: APSchedulerJobUpdate The scheduled task to update.
         scheduler_connection: BaseScheduler The scheduler connection.
     """
-    logger.info(f"Updating scheduled task: {payload}")
+    logger.info("Updating scheduled task", payload=payload)
 
     schedule_id = str(payload.schedule_id)
     job = scheduler_connection.get_job(job_id=schedule_id)
@@ -269,7 +282,7 @@ def _delete_scheduled_task(payload: APSchedulerJobDelete, scheduler_connection: 
         payload: APSchedulerJobDelete The scheduled task to delete.
         scheduler_connection: BaseScheduler The scheduler connection.
     """
-    logger.info(f"Deleting scheduled task: {payload}")
+    logger.info("Deleting scheduled task", payload=payload)
 
     schedule_id = str(payload.schedule_id)
     scheduler_connection.remove_job(job_id=schedule_id)
@@ -289,14 +302,9 @@ def workflow_scheduler_queue(queue_item: tuple[str, bytes], scheduler_connection
         match payload:
             case APSchedulerJobCreate():
                 _add_scheduled_task(payload, scheduler_connection)
-
             case APSchedulerJobUpdate():
                 _update_scheduled_task(payload, scheduler_connection)
-
             case APSchedulerJobDelete():
                 _delete_scheduled_task(payload, scheduler_connection)
-
-            case _:
-                logger.warning(f"Unexpected schedule type: {payload}")  # type: ignore
     except Exception:
         logger.exception("Error processing scheduler queue item")

--- a/orchestrator/core/schemas/schedules.py
+++ b/orchestrator/core/schemas/schedules.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, TypeAdapter
 
+from orchestrator.core.workflow import default_user_inputs
 from pydantic_forms.types import State
 
 SCHEDULER_Q_CREATE = "create"
@@ -37,7 +38,7 @@ class APSchedulerJobCreate(APSchedulerJob):
         description="Arguments passed to the trigger on job creation",
         examples=[{"hours": 12}, {"minutes": 30}, {"days": 1, "hours": 2}],
     )
-    user_inputs: list[State] = Field(default_factory=list, description="user inputs for the task")
+    user_inputs: list[State] = Field(default_factory=default_user_inputs, description="user inputs for the task")
 
     scheduled_type: Literal["create"] = Field("create", frozen=True)
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -58,6 +58,7 @@ from orchestrator.core.workflow import (
     Success,
     Workflow,
     abort_wf,
+    default_user_inputs,
 )
 from orchestrator.core.workflow import Process as WFProcess
 from orchestrator.core.workflows import get_workflow
@@ -470,7 +471,7 @@ def create_process(
     # ATTENTION!! When modifying this function make sure you make similar changes to `run_workflow` in the test code
 
     if user_inputs is None:
-        user_inputs = [{}]
+        user_inputs = default_user_inputs()
 
     process_id = uuid4()
     workflow = get_workflow(workflow_key)

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -230,6 +230,14 @@ async def allow(_: OIDCUserModel | None) -> bool:
     return True
 
 
+def default_user_inputs() -> list[State]:
+    """Provide the default user inputs when executing a workflow when user inputs are not explicitly provided.
+
+    This mirrors the requirement from make_workflow() to always have at least 1 form.
+    """
+    return [{}]
+
+
 def make_workflow(
     f: Callable,
     description: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "orchestrator-core"
 description = "This is the orchestrator workflow engine."
-version = "5.0.1"
+version = "5.0.2"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/test/unit_tests/cli/test_scheduler.py
+++ b/test/unit_tests/cli/test_scheduler.py
@@ -14,6 +14,7 @@
 """Tests for CLI scheduler commands: run, force, show-schedule, and load-initial-schedule."""
 
 import re
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import mock
 
@@ -23,8 +24,10 @@ from orchestrator.core.cli.scheduler import app
 
 runner = CliRunner()
 
+_BASE_RUN_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
-def _make_task(task_id: str = "task-1", name: str = "My Task", args=None, kwargs=None):
+
+def _make_task(task_id: str = "task-1", name: str = "My Task", args=None, kwargs=None, run_offset_seconds: int = 0):
     def _func(*a, **k):
         pass
 
@@ -34,7 +37,7 @@ def _make_task(task_id: str = "task-1", name: str = "My Task", args=None, kwargs
         func=_func,
         args=args,
         kwargs=kwargs,
-        next_run_time=SimpleNamespace(replace=lambda **_: "2026-01-01 00:00:00"),
+        next_run_time=_BASE_RUN_TIME + timedelta(seconds=run_offset_seconds),
         trigger="interval",
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2651,7 +2651,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-core"
-version = "5.0.1"
+version = "5.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

* Fix the default `user_inputs` value when creating schedules through the `load-initial-schedule` command
  * Refactored all places where default user_input is set to use a new function `default_user_inputs()` to mirror the initial form requirement from `make_workflow()`
* Add option `-v/--verbose` to the `show-schedule` command to show more details, such as the `"user_inputs"` for the scheduled task
* Add option `--recreate` to the `load-initial-schedule` command to forcefully recreate schedules for a workflow -> required when existing schedules have `user_inputs: []` instead of `user_inputs: [{}]`


## Context

This fixes `FormNotCompleteError` when existing schedule definitions have incorrect `user_inputs`.

For example, if the output of `python main.py scheduler show-schedule -v` shows a rule with

<img width="1581" height="121" alt="image" src="https://github.com/user-attachments/assets/b84fe26d-ba89-4258-87e1-1ab4df2faf07" />

Then the scheduler will show an error ` Failed to start scheduled task - unexpected error [orchestrator.core.schedules.service[] error=FormNotCompleteError` as it tries to execute the task.

To fix this:
* Make sure you have backed up any custom schedules for the core tasks
* Run `python main.py load-initial-schedule --recreate`

Then it should look like below:

<img width="1633" height="116" alt="image" src="https://github.com/user-attachments/assets/ec753cb9-85fc-433b-96af-de946d2a47e8" />
