### PR TITLE
Add draft 5.0 release presentations for team review

### DIFF
--- a/presentations/4.0-to-5.0-features/deck.md
+++ b/presentations/4.0-to-5.0-features/deck.md
@@ -1,0 +1,226 @@
+# What's new in orchestrator-core since 4.0
+
+A tour of the major capabilities added across the 4.x line and into 5.0.
+
+- Audience: mixed — operators, developers, and stakeholders
+- Timeline: 4.0 (mid-2025) through 5.0.1 (May 2026)
+- Roughly 35 releases, ~530 commits, six big themes
+
+::: notes
+The 4.x line was a long arc — about a year of work between 4.0 and 5.0. Rather
+than walk through 35 changelogs, we'll group the work into six themes that
+each shaped what the platform can do today: AI search, AI agents,
+authorization, scheduling, workflow capabilities, and developer experience.
+:::
+
+# Agenda
+
+1. The 4.x story at a glance
+2. **AI-powered search** (4.5 → 5.0)
+3. **AI agent platform** (4.8 → 5.0)
+4. **Authorization framework** (4.1 → 4.8)
+5. **Scheduler rebuilt** (4.4)
+6. **Workflow features**: reconcile + run predicates
+7. **Observability & ops**
+8. **GraphQL evolution**
+9. **Extensibility** (5.0)
+10. **Developer experience**
+11. Where to dig deeper
+
+# The 4.x story at a glance
+
+- **Bigger surface area** — the platform grew from "workflow engine + GraphQL" into a full orchestration suite
+- Three new pillars added: **search**, **AI agents**, and **fine-grained auth**
+- Existing pillars matured: scheduler, observability, GraphQL, extensibility
+- Theme of the era: **expose orchestrator-core to other systems** — UIs, AI tooling, external services
+
+::: notes
+If you had to describe the 4.x arc in one sentence: orchestrator-core stopped
+being just a backend for a single UI and became a platform that other things
+talk to. That shows up in nearly every new feature — search exposes a query
+API, the agent platform exposes MCP and A2A, the auth framework lets external
+systems contribute decisions, and the namespace change opens the door to
+optional add-on modules.
+:::
+
+# AI-powered search (4.5 → 5.0)
+
+- Started as an opt-in `[search]` extra in 4.5 with LLM-assisted retrieval
+- Structured search added in 4.8 with aggregations, sorting, totals
+- A dedicated `/api/search` endpoint replaces TSV-style `query=` parameters
+- Indexes subscriptions, products, processes, **and** workflows
+- **Now mandatory in 5.0** — `litellm` is a core dependency; vector + text always on
+- Powered by pgvector + standard PostgreSQL extensions
+
+::: notes
+Search began life in 4.5 as a proof of concept and steadily hardened across
+4.6, 4.7, and 4.8 — coverage jumped from 59% to 92% along the way. In 5.0 the
+team committed and made it part of the core, on the bet that everyone will
+benefit. Text search works out of the box; semantic search activates when
+you configure an embedding provider. For operators, the deployment story is
+simple: pgvector image, five PostgreSQL extensions, and a CLI command to
+populate the index.
+:::
+
+# AI agent platform (4.8 → 5.0)
+
+- Foundations laid in 4.5 (schema retrieval, validation exceptions, auth-aware router)
+- 4.8 introduced a **finite-state-machine agent** with skills, planners, and tool artifacts
+- Transport adapters: **AG-UI** for streaming UIs, **A2A** with agent card at `/.well-known/agent-card.json`
+- **MCP server** in 5.0 mounted at `/mcp` (opt-in via `fastmcp` install)
+- All endpoints share the platform's auth via `AgentAuthMiddleware`
+
+::: notes
+This is the platform's bet on AI-native operations. The agent runtime is a
+cyclic finite-state machine — it plans, acts, observes, and iterates — and
+the surrounding scaffolding makes it pluggable across three industry
+protocols. AG-UI for interactive chat-like flows, A2A for agent-to-agent
+delegation, and MCP for tool integration from clients like Claude or Cursor.
+None of it bypasses your existing OIDC setup; the same authorization rules
+that protect workflows protect agent actions.
+:::
+
+# Authorization framework (4.1 → 4.8)
+
+- 4.1: RBAC for running, resuming, retrying workflows
+- 4.2: `isAllowed` field in GraphQL queries — UIs can hide what users can't do
+- 4.6: `retry_auth_callback` on step / retrystep / step_group
+- 4.7: **Async authorization callbacks**, global default authorizers
+- 4.8: `AgentAuthMiddleware` for A2A and MCP endpoints
+- 5.0: Callbacks now receive a rich `AuthContext` (user + action + workflow + step)
+
+::: notes
+Authorization started in 4.1 as a small set of RBAC decorators on workflow
+lifecycle endpoints and evolved into a comprehensive framework. The
+`isAllowed` field is a small thing with big UX consequences — the UI can grey
+out actions instead of letting the user click and fail. The 5.0 `AuthContext`
+gives callbacks the full picture of who is trying to do what to which
+workflow at which step, so you can write much smarter policies — e.g.
+"engineer can retry their own steps but not approve them."
+:::
+
+# Scheduler rebuilt with APScheduler (4.4)
+
+- 4.4: Replaced the built-in scheduler with **APScheduler** and a persistent jobstore
+- Schedules survive restarts; jobs visible in `apscheduler_jobs`
+- 4.7: Full **Scheduler CRUD API** — schedule via UI or HTTP, not just code
+- 4.7: Decorator-based scheduling deprecated; default schedules removed
+- 4.8: `validate-products` migrated to API + **run predicates**
+- `python main.py scheduler load-initial-schedule` restores defaults
+
+::: notes
+Before 4.4, scheduling was decorator-only — fine for fixed jobs, painful for
+anything dynamic. APScheduler brings persistence and the new CRUD API lets
+users schedule jobs from the UI, the API, or both. The path from 4.4 through
+4.8 deprecates decorator scheduling step by step; by 5.0 the GraphQL
+`scheduledTasks` query only shows API-scheduled jobs. If you still rely on
+decorators, the upgrade guide walks you through migrating them.
+:::
+
+# Workflow features
+
+- **Reconcile workflow decorator** (4.4) — sync subscriptions with external systems
+- Reconcile target + lifecycle validation in workflow steps (4.5)
+- **Workflow run predicates** (4.8) — declarative conditions on whether a workflow may start
+- Validation report endpoint with `lastValidatedAt` on subscriptions (4.3)
+- Resume CREATED/RESUMED processes correctly (4.3)
+- Improved step timestamping (4.2) and structlog context per step (3.2)
+
+::: notes
+Two big additions and a handful of refinements. Reconcile workflows formalize
+the "make external state match our state" pattern — useful when you sync to
+an IPAM, a CMDB, or another orchestrator. Run predicates are about gating:
+think maintenance mode, dependency checks, or "this workflow can't run while
+that other one is in progress." Together they let you express more of the
+operational logic declaratively rather than in step code.
+:::
+
+# Observability & operations
+
+- **Metrics endpoint** (4.0) with example **Grafana dashboard** (4.2) shipped in the repo
+- **Worker status monitor** (4.8) — live count of running processes, replaces brittle counter column
+- Validation report endpoint with `lastValidatedAt` per subscription (4.3)
+- Distributed lock manager added with test coverage
+- Migrations now logged with truncated tracebacks instead of full dumps (4.8)
+- MkDocs CI made strict — docs build is part of the test suite (4.3, 4.6)
+
+::: notes
+Observability got steady, unflashy attention across 4.x. The Grafana
+dashboard JSON ships in the repo as a starting point. The worker status
+monitor replaces a counter column that had to be manually incremented on
+every process start and stop — error-prone and a source of drift. The
+validation report endpoint lets operators see, at a glance, which
+subscriptions have been validated recently and which haven't.
+:::
+
+# GraphQL evolution
+
+- 4.2: `isAllowed` on workflow query, `workflow_target` on `ProcessSubscriptionTable` deprecated
+- 4.3: Async resolver wrapping via `make_async` + `run_in_threadpool`
+- 4.6: Int-type-redefinition fix; fetching soft-deleted workflows fixed
+- 4.7: `get_current_user` properly awaited in resolvers
+- 5.0: Strawberry upgraded with `FEDERATION_VERSION`, multi-UI support (`graphiql` / `apollo-sandbox` / `pathfinder`)
+- 5.0: Custom scalars use `name=` (cleaner than the old `NewType` pattern)
+
+::: notes
+GraphQL itself didn't get a headline rewrite, but the implementation got a
+lot more solid. The async resolver wrapper means slow synchronous code in a
+resolver doesn't block the entire event loop. Federation support, soft-delete
+correctness, and authorization fields all matured. By 5.0 the layer is stable
+enough that the team felt confident pulling Strawberry up to a current
+release with the breaking changes that came with it.
+:::
+
+# Extensibility — the 5.0 unlock
+
+- orchestrator-core is now a **namespace package** (`orchestrator.core.*`)
+- Opens the door to optional add-on modules built and shipped separately
+- New **`OrchestratorCore.register_table()`** API to extend base tables (e.g. `SubscriptionTable`) with computed columns
+- Result: customize and extend without forking or monkey-patching
+- Background: `docs/architecture/extensibility/packaging.md`
+
+::: notes
+The namespace move in 5.0 is the structural change that unlocks the next
+phase of the project. Before, customizing core models meant subclassing and
+hoping nothing else imported the original; now `register_table()` lets you
+attach extra column properties cleanly, visible to both SQLAlchemy and
+GraphQL. The namespace itself means add-on modules — think of optional
+features like search, agents, billing integrations — can live in their own
+packages and compose with the core.
+:::
+
+# Developer experience
+
+- **Build tooling**: flit → **uv** in 4.2; `uv_build` for wheels in 5.0
+- **Linting**: scattered black usage fully replaced by **ruff**
+- **Python 3.14** support enabled in 4.6
+- **Renovate** replaced Dependabot (4.6) — better grouping, lower noise
+- **Mypy 1.9 → 1.19** in 5.0 — roughly 2× faster type checking
+- **Vulture** added for dead-code detection
+- Test coverage climbed dramatically — search 59→92%, websocket 67→99%, CLI 20→80%, API 42→76%
+
+::: notes
+None of these are user-facing, but together they're why the project moves as
+quickly as it does. The uv migration speeds up installs and CI; the mypy
+upgrade makes the test loop tighter; Renovate keeps dependencies fresh
+without drowning maintainers in PRs. The coverage jump matters too — by 5.0
+most of the codebase has tests behind it, which is why the team felt
+confident about the 5.0 breaking changes.
+:::
+
+# Where to dig deeper
+
+- **Upgrade guides** — `docs/guides/upgrading/{4.7,4.8,5.0}.md`
+- **Architecture** — `docs/architecture/` (extensibility, application, orchestration)
+- **Search reference** — `docs/reference-docs/search.md`
+- **Tasks / scheduler** — `docs/guides/tasks.md`
+- **Run predicates** — `docs/reference-docs/workflows/run-predicates.md`
+- **Releases** — GitHub releases page, tags `4.0.0` through `5.0.1`
+- **Q&A**
+
+::: notes
+The upgrade guides are surprisingly readable as feature overviews — they
+explain not just what to change but why each change exists. The architecture
+docs are where to go for the bigger picture, especially the extensibility
+section that motivates the namespace move. Questions?
+:::

--- a/presentations/4.0-to-5.0-features/deck.md
+++ b/presentations/4.0-to-5.0-features/deck.md
@@ -45,11 +45,11 @@ optional add-on modules.
 
 # AI-powered search (4.5 → 5.0)
 
-- Started as an opt-in `[search]` extra in 4.5 with LLM-assisted retrieval
-- Structured search added in 4.8 with aggregations, sorting, totals
-- A dedicated `/api/search` endpoint replaces TSV-style `query=` parameters
+- 4.5: Started as an opt-in `[search]` extra with LLM-assisted retrieval
+- 4.8: Structured search added with aggregations, sorting, totals
+- 5.0: Dedicated `/api/search` endpoint; TSV `query=` parameter deprecated
+- 5.0: **Now mandatory** — `litellm` is a core dependency; vector + text always on
 - Indexes subscriptions, products, processes, **and** workflows
-- **Now mandatory in 5.0** — `litellm` is a core dependency; vector + text always on
 - Powered by pgvector + standard PostgreSQL extensions
 
 ::: notes
@@ -64,11 +64,11 @@ populate the index.
 
 # AI agent platform (4.8 → 5.0)
 
-- Foundations laid in 4.5 (schema retrieval, validation exceptions, auth-aware router)
-- 4.8 introduced a **finite-state-machine agent** with skills, planners, and tool artifacts
-- Transport adapters: **AG-UI** for streaming UIs, **A2A** with agent card at `/.well-known/agent-card.json`
-- **MCP server** in 5.0 mounted at `/mcp` (opt-in via `fastmcp` install)
-- All endpoints share the platform's auth via `AgentAuthMiddleware`
+- 4.5: Foundations laid — schema retrieval, validation exceptions, auth-aware router
+- 4.8: **Finite-state-machine agent** with skills, planners, and tool artifacts
+- 4.8: Transport adapters — **AG-UI** streaming and **A2A** with agent card at `/.well-known/agent-card.json`
+- 4.8: `AgentAuthMiddleware` shares the platform's OIDC auth across agent endpoints
+- 5.0: **MCP server** mounted at `/mcp` (opt-in via `fastmcp` install)
 
 ::: notes
 This is the platform's bet on AI-native operations. The agent runtime is a
@@ -102,11 +102,11 @@ workflow at which step, so you can write much smarter policies — e.g.
 # Scheduler rebuilt with APScheduler (4.4)
 
 - 4.4: Replaced the built-in scheduler with **APScheduler** and a persistent jobstore
-- Schedules survive restarts; jobs visible in `apscheduler_jobs`
+- 4.4: Schedules survive restarts; jobs visible in `apscheduler_jobs`
 - 4.7: Full **Scheduler CRUD API** — schedule via UI or HTTP, not just code
 - 4.7: Decorator-based scheduling deprecated; default schedules removed
+- 4.7: `python main.py scheduler load-initial-schedule` restores defaults
 - 4.8: `validate-products` migrated to API + **run predicates**
-- `python main.py scheduler load-initial-schedule` restores defaults
 
 ::: notes
 Before 4.4, scheduling was decorator-only — fine for fixed jobs, painful for
@@ -119,12 +119,12 @@ decorators, the upgrade guide walks you through migrating them.
 
 # Workflow features
 
-- **Reconcile workflow decorator** (4.4) — sync subscriptions with external systems
-- Reconcile target + lifecycle validation in workflow steps (4.5)
-- **Workflow run predicates** (4.8) — declarative conditions on whether a workflow may start
-- Validation report endpoint with `lastValidatedAt` on subscriptions (4.3)
-- Resume CREATED/RESUMED processes correctly (4.3)
-- Improved step timestamping (4.2) and structlog context per step (3.2)
+- 4.2: Improved step timestamping
+- 4.3: Validation report endpoint with `lastValidatedAt` on subscriptions
+- 4.3: Resume CREATED/RESUMED processes correctly
+- 4.4: **Reconcile workflow decorator** — sync subscriptions with external systems
+- 4.5: Reconcile target + lifecycle validation in workflow steps
+- 4.8: **Workflow run predicates** — declarative conditions on whether a workflow may start
 
 ::: notes
 Two big additions and a handful of refinements. Reconcile workflows formalize
@@ -137,12 +137,12 @@ operational logic declaratively rather than in step code.
 
 # Observability & operations
 
-- **Metrics endpoint** (4.0) with example **Grafana dashboard** (4.2) shipped in the repo
-- **Worker status monitor** (4.8) — live count of running processes, replaces brittle counter column
-- Validation report endpoint with `lastValidatedAt` per subscription (4.3)
+- 4.0: **Metrics endpoint** shipped in the repo
+- 4.2: Example **Grafana dashboard** shipped alongside
+- 4.3, 4.6: MkDocs CI made strict — docs build is part of the test suite
+- 4.8: **Worker status monitor** — live count of running processes, replaces a brittle counter column
+- 4.8: Migrations log truncated tracebacks instead of full dumps
 - Distributed lock manager added with test coverage
-- Migrations now logged with truncated tracebacks instead of full dumps (4.8)
-- MkDocs CI made strict — docs build is part of the test suite (4.3, 4.6)
 
 ::: notes
 Observability got steady, unflashy attention across 4.x. The Grafana
@@ -191,13 +191,13 @@ packages and compose with the core.
 
 # Developer experience
 
-- **Build tooling**: flit → **uv** in 4.2; `uv_build` for wheels in 5.0
-- **Linting**: scattered black usage fully replaced by **ruff**
-- **Python 3.14** support enabled in 4.6
-- **Renovate** replaced Dependabot (4.6) — better grouping, lower noise
-- **Mypy 1.9 → 1.19** in 5.0 — roughly 2× faster type checking
-- **Vulture** added for dead-code detection
-- Test coverage climbed dramatically — search 59→92%, websocket 67→99%, CLI 20→80%, API 42→76%
+- 4.2: Migrated build tooling from flit to **uv**
+- 4.6: **Python 3.14** support enabled
+- 4.6: **Renovate** replaced Dependabot — better grouping, lower noise
+- 5.0: Adopted `uv_build` for wheel builds; stray **black** usage replaced by **ruff**
+- 5.0: **Mypy 1.9 → 1.19** — roughly 2× faster type checking
+- 5.0: **Vulture** added for dead-code detection
+- 5.0: Test coverage jump — search 59→92%, websocket 67→99%, CLI 20→80%, API 42→76%
 
 ::: notes
 None of these are user-facing, but together they're why the project moves as

--- a/presentations/5.0-release/README.md
+++ b/presentations/5.0-release/README.md
@@ -1,0 +1,38 @@
+# orchestrator-core 5.0 release deck
+
+A ~15-minute operator-focused walkthrough of what changed in orchestrator-core
+5.0, weighted toward breaking changes and major new features.
+
+## Build
+
+```bash
+./build.sh
+```
+
+Produces `deck.pptx`. Open it in PowerPoint (or Keynote / LibreOffice) and
+polish styling as needed. Speaker notes live in `::: notes` blocks in the
+markdown and become PowerPoint speaker notes after conversion.
+
+To apply a corporate template, drop a `.pptx` template alongside as
+`reference.pptx` and uncomment the `--reference-doc=reference.pptx` line in
+`build.sh`.
+
+## Source map
+
+Every claim in the deck traces back to a file in the repo:
+
+| Slide                          | Source                                                                                          |
+|--------------------------------|-------------------------------------------------------------------------------------------------|
+| Prerequisites (4.7 / 4.8)      | `docs/guides/upgrading/4.7.md`, `docs/guides/upgrading/4.8.md`                                  |
+| Breaking #1 (namespace)        | `docs/guides/upgrading/5.0.md` §1; motivation: `docs/architecture/extensibility/packaging.md`   |
+| Breaking #2 (scheduled tasks)  | `docs/guides/upgrading/5.0.md` §1 (scheduled tasks warning); migration `cab8b6a0ac92`           |
+| Breaking #3 (psycopg3)         | `docs/guides/upgrading/5.0.md` §11                                                              |
+| Breaking #4 (secret URIs)      | `docs/guides/upgrading/5.0.md` §3                                                                |
+| Breaking #5–8 (forms/GraphQL)  | `docs/guides/upgrading/5.0.md` §4 (pydantic-forms), §7 (Strawberry)                              |
+| Breaking #9–12 (auth, misc)    | `docs/guides/upgrading/5.0.md` §9, §10, §5, §6                                                   |
+| LLM search default             | `docs/guides/upgrading/5.0.md` §8; migration `262744958e0c`                                     |
+| MCP server                     | PRs #1483 and #1620                                                                              |
+| `register_table()`             | `docs/guides/upgrading/5.0.md` §12                                                              |
+
+When the upgrade guide is updated, refresh this deck by re-reading the
+referenced sections and amending matching slides.

--- a/presentations/5.0-release/build.sh
+++ b/presentations/5.0-release/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build deck.pptx from deck.md using pandoc.
+# Drop a corporate template into reference.pptx and uncomment the line below
+# to apply your house style.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+pandoc deck.md \
+    --slide-level=1 \
+    -o deck.pptx
+#   --reference-doc=reference.pptx
+
+echo "Wrote $(pwd)/deck.pptx"

--- a/presentations/5.0-release/deck.md
+++ b/presentations/5.0-release/deck.md
@@ -1,0 +1,266 @@
+# orchestrator-core 5.0
+
+What operators need to know
+
+- 5.0.0 released 2026-05-12
+- 5.0.1 hotfix released 2026-05-18 — use this one
+- A short walk through the breaking changes and headline features
+
+::: notes
+Welcome. In the next 15 minutes I will walk through what changed between 4.0
+and 5.0, weighted toward what you need to do as an operator. Two release dates
+matter: 5.0.0 went out on May 12, and 5.0.1 followed six days later with
+important scheduler fixes — please upgrade straight to 5.0.1, not 5.0.0.
+:::
+
+# Agenda
+
+- Prerequisites — 4.7 and 4.8 changes you may have skipped
+- The 12 breaking changes in 5.0
+- Three new features worth knowing about
+- A concrete operator upgrade checklist
+- Q&A
+
+::: notes
+We start with two short prerequisite slides because the 5.0 upgrade guide
+explicitly says: if you skipped 4.7 or 4.8, read those first. Then we go
+through the breaking changes — grouped so we can move quickly — then features,
+then a checklist you can take back to your runbook.
+:::
+
+# 5.0 at a glance
+
+- One **headline** change: orchestrator is now a namespace package
+- 12 breaking changes total — most are mechanical find-and-replace
+- 3 new operator-visible features: LLM search, MCP server, `register_table()`
+- A migration helper script ships with the release
+- Authoritative source: `docs/guides/upgrading/5.0.md`
+
+::: notes
+The single change that touches every line of your code is the namespace move.
+Everything else is smaller in scope. The team ships a `migrate_50` script that
+rewrites your imports automatically, so even the big change is mostly
+mechanical. The upgrade guide in the repo is the source of truth for this
+talk — every claim here points back to a numbered section in that file.
+:::
+
+# First: prerequisites from 4.7 and 4.8
+
+- **4.7**: scheduling via `@scheduler.scheduled_job` is **deprecated** — use the Scheduler API
+- **4.7**: workflow authorization callbacks must now be `async def`
+- **4.8**: `validate-products` schedule moved from decorator to the API
+- **4.8**: workflow **run predicates** introduced (gate workflows on conditions)
+- To restore default schedules: `python main.py scheduler load-initial-schedule`
+
+::: notes
+If your last upgrade was 4.6 or earlier, read the 4.7 and 4.8 upgrade guides
+before 5.0. The decorator-based scheduling was deprecated in 4.7 and is on its
+way out — 5.0 already changes how the GraphQL `scheduledTasks` query reports
+them. If you have custom workflow auth callbacks, they must be `async def` from
+4.7 onward. The `load-initial-schedule` command brings back the default jobs
+through the API if you want them.
+:::
+
+# Breaking #1 — Namespace package
+
+- Every `orchestrator.*` import becomes `orchestrator.core.*`
+- Automated rewrite: `uv run -m orchestrator.core.devtools.scripts.migrate_50 <dir>`
+- Run it against your project code **and** your tests
+- Build tooling changed: `flit` → `uv_build`, `black` → `ruff`
+- Motivation: future optional add-on modules — see `docs/architecture/extensibility/packaging.md`
+
+::: notes
+This is the change that ripples through everything you've written against
+orchestrator-core. The good news is the team ships a migration script that
+rewrites imports for you — point it at your source tree and your tests. Don't
+forget patches in tests, Strawberry `lazy("...")` references, and Celery
+`include=[...]` lists — those are string literals the linter won't catch. The
+build tooling switch (flit/black to uv_build/ruff) only matters if you
+contribute upstream.
+:::
+
+# Breaking #2 — Scheduled tasks need a DB migration
+
+- APScheduler stores the **pickled module path** of every job
+- The namespace change invalidates those paths — jobs would silently disappear
+- Migration `cab8b6a0ac92` rewrites the stored paths automatically
+- **Order matters**: stop scheduler → back up `apscheduler_jobs` → `python main.py db upgrade heads`
+- Use **5.0.1**, not 5.0.0 — the fix landed in #1645
+
+::: notes
+This is the single most dangerous part of the upgrade, and the reason 5.0.1
+exists. APScheduler pickles the fully qualified function name into the
+database, so when the namespace shifts those references break and the
+scheduler silently skips them. The migration rewrites them, but only if the
+scheduler isn't running and overwriting the corrections. Stop scheduler,
+back up the table with a CREATE TABLE AS, run `db upgrade heads`, then start
+the scheduler. The restore SQL is in the upgrade guide if anything goes
+sideways.
+:::
+
+# Breaking #3 — psycopg2 → psycopg3
+
+- Dialect change in **every** `DATABASE_URI`:
+  - `postgresql://...` → `postgresql+psycopg://...`
+- Update `.env`, CI configs, deploy scripts, Helm values
+- Dependency: `psycopg[binary]>=3.3.3` (was `psycopg2-binary`)
+- **Autobegin**: psycopg3 starts a transaction on first query — wrap loose queries in `transactional()`
+- Deprecation warning at startup if old dialect is detected
+
+::: notes
+The dialect change is mechanical but easy to miss because it lives in your
+environment, not your code. Audit every place a Postgres URI lives — including
+test databases, CI, and Helm values. Direct uses of psycopg2 should be ported
+to psycopg3; the API is close but not identical. The subtler issue is
+autobegin: psycopg3 implicitly opens a transaction on the first query, so any
+query outside a `transactional()` context can leave a connection idle in
+transaction. The framework handles its own paths, but custom Celery handlers
+or workflow steps that hit the DB directly need wrapping.
+:::
+
+# Breaking #4 — Secret settings for URIs
+
+- `DATABASE_URI`: `PostgresDsn` → `SecretPostgresDsn`
+- `CACHE_URI`: `RedisDsn` → `SecretRedisDsn`
+- `WEBSOCKET_BROADCASTER_URL`: `str` → `SecretStr`
+- Values are now auto-masked in logs, prints, and tracebacks
+- Call `.get_secret_value()` everywhere you read these settings
+- **Critical**: patch your `migrations/env.py` — Alembic needs the unwrapped DSN
+
+::: notes
+These three settings can carry passwords, so 5.0 wraps them in Pydantic Secret
+types. The values are masked when settings are logged, printed, or appear in
+tracebacks — which is the whole point. Every read site needs
+`.get_secret_value()`. The one that surprises people is the Alembic env.py,
+because it sets `sqlalchemy.url` from `DATABASE_URI` — if you skip that line,
+Alembic will try to connect to a literal `**********` and fail. The upgrade
+guide shows the exact diff.
+:::
+
+# Breaking #5–8 — Forms and GraphQL
+
+- `pydantic-forms` ≥ 2.4.0:
+  - `ReadOnlyField()` → `read_only_field()` for scalars
+  - `ReadOnlyField([...], default_type=list[...])` → `read_only_list([...])`
+- `FEDERATION_ENABLED` (bool) → `FEDERATION_VERSION` (string, default `"2.9"`)
+- `SERVE_GRAPHQL_UI` is now a string: `"graphiql" | "apollo-sandbox" | "pathfinder" | ""`
+- Custom Strawberry scalars: replace `NewType("Foo", str)` with `name="Foo"`
+
+::: notes
+Four smaller changes grouped together. The pydantic-forms split exists because
+the old API forced you to declare `default_type` for non-scalars; the new
+typed factories make the intent clear. The Strawberry upgrade brings two env
+var changes and a tweak to how custom scalars are declared — drop the
+`NewType` wrapper, pass `name=` instead. None of these are large in scope,
+but each is a hard error rather than a deprecation warning, so they're worth
+calling out.
+:::
+
+# Breaking #9–12 — Auth and miscellaneous
+
+- `authorize` and `authorize_websocket` now **raise 403 on `False`** (was silent)
+- Workflow/step `Authorizer` callbacks receive `AuthContext`, not `OIDCUserModel`
+  - Has `user`, `action`, `workflow`, `step` — richer auth decisions possible
+- `engine_settings.running_processes` column removed (replaced by `WorkerStatusMonitor`)
+  - Service rename: `get_engine_settings()` → `get_engine_settings_table()` (+ variants)
+- Workflow decorator `description=` is **deprecated** — manage in DB / UI instead
+
+::: notes
+The auth change has a real failure mode: if your custom Authorization returns
+False and you previously assumed it was silently allowing requests, those
+requests will start 403'ing. So verify behavior, don't just verify the
+signature. The callback signature change is straightforward — accept
+`AuthContext` and pull `.user` from it; you also get the workflow and step
+metadata for free. The engine_settings change is internal but visible if you
+query that column directly — use the `/settings/status` REST endpoint or the
+GraphQL `settings` query instead. The description deprecation is opt-in for
+now; you'll get a warning, not an error.
+:::
+
+# New feature — LLM-powered search is the default
+
+- No more `SEARCH_ENABLED`, no more `[search]` pip extra — `litellm` is core
+- Required PostgreSQL extensions: `uuid-ossp`, `ltree`, `unaccent`, `pg_trgm`, **`vector`**
+- `vector` needs **pgvector** — use `pgvector/pgvector:pg17` if you can
+- Migration `262744958e0c` creates the AI search tables
+- Index your data:
+
+```bash
+python main.py index subscriptions
+python main.py index products
+python main.py index processes
+python main.py index workflows
+```
+
+- Env rename: `OPENAI_API_KEY` → `EMBEDDING_API_KEY`, `OPENAI_BASE_URL` → `EMBEDDING_API_BASE`
+
+::: notes
+What was an opt-in beta in 4.x is now part of the core. Text search works out
+of the box; semantic vector search needs an embedding provider configured.
+The biggest deployment change is the pgvector requirement — if your Postgres
+image doesn't carry it, switch to the official pgvector image or install the
+extension. The migration creates the search tables; the indexing CLI populates
+them. Don't forget to remove the old `SEARCH_ENABLED` and `OPENAI_*` env vars
+from your configs so future-you isn't confused.
+:::
+
+# New feature — MCP server for AI workflow ops
+
+- Model Context Protocol endpoint mounted at `/mcp`
+- Lets AI agents drive workflow operations through a standard protocol
+- Activates **only** when the optional `fastmcp` package is installed
+- OIDC-protected — same auth story as the rest of the API
+
+::: notes
+If you have no plans to expose orchestrator-core to AI tooling, this slide is
+informational: the endpoint stays inert unless `fastmcp` is installed. If you
+do want it, install the package, restart, and the route appears under `/mcp`
+behind OIDC. The MCP protocol is the same standard Anthropic and others use
+for tool integration, so any MCP-aware client can drive workflows from here.
+:::
+
+# New feature — `OrchestratorCore.register_table()`
+
+- Register a subclass's `column_property` definitions onto a base table mapper
+- Makes custom computed columns visible to **SQLAlchemy queries and GraphQL**
+- Typical use: extend `SubscriptionTable` with a joined-in display name
+
+```python
+app = OrchestratorCore(...)
+app.register_table(SubscriptionTable, MySubscriptionTable)
+```
+
+- Register at **both** app startup **and** in your Celery worker startup
+
+::: notes
+This is the cleanest way yet to extend the core models without monkey-patching.
+Define a subclass with the extra column_property attributes, then register it
+once at startup. The base table mapper gets the columns and GraphQL exposes
+them automatically. The gotcha — and it is easy to miss — is that Celery
+workers boot a separate process with their own mapper state, so register
+again in your worker startup or your background tasks won't see the new
+columns.
+:::
+
+# Operator upgrade checklist
+
+1. Read `docs/guides/upgrading/5.0.md` end to end (and 4.7 / 4.8 if needed)
+2. Run `migrate_50` against your code repos and tests
+3. Update `DATABASE_URI` dialect to `postgresql+psycopg://` everywhere
+4. Patch `migrations/env.py` to use `.get_secret_value()`
+5. **Stop the scheduler**, back up `apscheduler_jobs`, run `db upgrade heads`
+6. Verify scheduled tasks via `show-schedule` CLI; restart scheduler
+7. Ensure pgvector + extensions exist; re-index search:
+   `python main.py index {subscriptions,products,processes,workflows}`
+8. Remove `SEARCH_ENABLED`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` from env
+9. Pin **5.0.1** (the scheduler hotfix release)
+
+Resources: `docs/guides/upgrading/5.0.md` · GitHub releases tagged `5.0.0`, `5.0.1`
+
+::: notes
+This is the slide to screenshot for your runbook. The order matters — stop the
+scheduler before the DB upgrade, not after, because a running scheduler with
+the old code can overwrite the migration's corrections. Pin 5.0.1 not 5.0.0;
+5.0.1 carries fixes for scheduled tasks, form input on the first page, and a
+validation task session bug. Questions?
+:::


### PR DESCRIPTION
## Summary

Two draft slide decks for the 5.0 release talk, posted here so the team can
review and decide which one to use (or whether to merge them).

- **`presentations/5.0-release/`** — 14-slide **operator-focused** walkthrough
  of the 4.x → 5.0 upgrade. Weighted toward the 12 breaking changes and the
  three headline new features (LLM search default, MCP server,
  `register_table()`). Includes `deck.md` (Marp-style markdown with pandoc
  `::: notes` speaker notes), `build.sh` (pandoc → pptx with optional
  `--reference-doc=`), and `README.md` with a source map back to
  `docs/guides/upgrading/5.0.md`.
- **`presentations/4.0-to-5.0-features/`** — 13-slide **mixed-audience** tour
  of every major capability added across the 4.x line and into 5.0: AI
  search, AI agent platform (AG-UI / A2A / MCP), authorization framework,
  APScheduler-based scheduler, reconcile workflows + run predicates,
  observability, GraphQL evolution, extensibility unlock, and
  developer-experience improvements.

Both decks source their claims from `docs/guides/upgrading/{4.7,4.8,5.0}.md`
so they stay in sync with the canonical upgrade guides. The rendered `.pptx`
is intentionally not committed — rebuild locally with
`presentations/5.0-release/build.sh` (pandoc required).

## What I'm asking for

- Which deck should we keep — or should we merge them into a single longer talk?
- Any factual corrections against the upgrade guides?
- Anything important from the 4.x arc that I missed?

## Test plan

- [ ] Read `presentations/5.0-release/deck.md` — does the 15-minute pacing feel right for operators?
- [ ] Read `presentations/4.0-to-5.0-features/deck.md` — does it land for a mixed audience?
- [ ] (Optional) Run `presentations/5.0-release/build.sh` to render the operator deck to `deck.pptx` and open it in PowerPoint to sanity-check layout and speaker notes
- [ ] Cross-check breaking-change wording against `docs/guides/upgrading/5.0.md`