### PR TITLE
Fix search FieldType interpreting number string as a date

### DIFF
--- a/orchestrator/core/search/core/types.py
+++ b/orchestrator/core/search/core/types.py
@@ -179,8 +179,6 @@ class FieldType(str, Enum):
     def _infer_from_str(cls, val: str) -> "FieldType":
         if is_uuid(val):
             return cls.UUID
-        if is_iso_date(val):
-            return cls.DATETIME
         if is_bool_string(val):
             return cls.BOOLEAN
         if val.isdigit():
@@ -189,7 +187,10 @@ class FieldType(str, Enum):
             float(val)
             return cls.FLOAT
         except ValueError:
-            return cls.STRING
+            pass
+        if is_iso_date(val):
+            return cls.DATETIME
+        return cls.STRING
 
     @classmethod
     def from_type_hint(cls, type_hint: object) -> "FieldType":

--- a/test/unit_tests/search/test_type_mapping.py
+++ b/test/unit_tests/search/test_type_mapping.py
@@ -95,3 +95,21 @@ def test_enum_types():
 
     assert FieldType.from_type_hint(TestStringEnum) == FieldType.STRING
     assert FieldType.from_type_hint(TestIntEnum) == FieldType.INTEGER
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_field_type"),
+    [
+        pytest.param("1000", FieldType.INTEGER, id="number-not-date"),
+        pytest.param("42", FieldType.INTEGER, id="number-small"),
+        pytest.param("10102026", FieldType.INTEGER, id="number-like-date"),
+        pytest.param("3.14", FieldType.FLOAT, id="float-string"),
+        pytest.param("true", FieldType.BOOLEAN, id="bool-true"),
+        pytest.param("false", FieldType.BOOLEAN, id="bool-false"),
+        pytest.param("2024-01-15", FieldType.DATETIME, id="iso-date"),
+        pytest.param("2024-01-15T10:30:00", FieldType.DATETIME, id="iso-datetime"),
+        pytest.param("hello", FieldType.STRING, id="plain-string"),
+    ],
+)
+def test_infer_from_string_value(value, expected_field_type):
+    assert FieldType.infer(value) == expected_field_type


### PR DESCRIPTION
the interpreted number string results in a "not a valid date" error. this will now first check if the string is an `int` or `float` before checking if it a `date`.

Closes: https://github.com/workfloworchestrator/orchestrator-core/issues/1657