### PR TITLE
Improve MCP tool surface with ToolAnnotations and expose curated GET endpoints

### DIFF
--- a/docs/reference-docs/mcp.md
+++ b/docs/reference-docs/mcp.md
@@ -43,6 +43,12 @@ The default toolset covers the typical agent flow:
 | `search_subscriptions`                    | Search subscriptions with typed filters              |
 | `get_subscription_details`                | Get a flat header for a subscription                 |
 | `list_products`                           | List products                                        |
+| `get_product`                             | Get one product definition by id                     |
+| `get_product_block`                       | Get one product block definition by id               |
+| `get_resource_type`                       | Get one resource type definition by id               |
+| `get_workflow_by_id`                      | Get one workflow definition by id                    |
+| `get_subscription_domain_model`           | Get a subscription's full product-block tree (large) |
+| `get_process_status_counts`               | Aggregate process/task counts grouped by status      |
 
 Tool names map 1:1 to the route's `operation_id`; tool descriptions come from the route's docstring; parameter schemas come from the route's Pydantic request model.
 
@@ -77,9 +83,22 @@ Guidelines:
 * **Write a docstring** — this becomes the tool description the LLM sees. Be explicit about preconditions and side effects.
 * **Use typed Pydantic models** for inputs/outputs — the parameter schema is derived from them.
 * **Add `AgentTag.LARGE`** when the response may contain many records, so clients can warn the agent to narrow before calling.
+* **Tag read-only `POST`/`PUT` routes `AgentTag.READONLY`** and irreversible mutations `AgentTag.DESTRUCTIVE` — these drive the tool's annotations (see below).
 * Prefer placing LLM-specific routes in `orchestrator/core/api/api_v1/endpoints/mcp_tools.py`. Use this when the existing REST shape is not LLM-friendly (e.g. flat positional filters, deprecated routes, oversized payloads). See the module docstring for the rationale of each existing curated tool.
 
 Routes without `AgentTag.EXPOSED` are excluded from the MCP surface, regardless of whether they are public REST endpoints.
+
+## Tool annotations
+
+Every generated tool carries [MCP `ToolAnnotations`](https://modelcontextprotocol.io/) so clients can reason about safety (e.g. auto-approve reads). They are stamped by `orchestrator.core.mcp.server._annotate` (the fastmcp `mcp_component_fn` hook), derived from each route's HTTP method plus its `AgentTag`s:
+
+* `readOnlyHint` — `GET` routes, or any route tagged `AgentTag.READONLY`.
+* `idempotentHint` — read-only routes, or `PUT`/`DELETE`.
+* `destructiveHint` — `DELETE` routes, or any route tagged `AgentTag.DESTRUCTIVE`.
+* `openWorldHint` — always `False` (the orchestrator acts on its own database, not an open external world).
+* `title` — a humanized form of the `operation_id` (e.g. `get_process_status` → "Get Process Status").
+
+The curated read tools in `mcp_tools.py` are `POST` routes, so they must be tagged `AgentTag.READONLY` to be marked safe; an irreversible action such as `abort_workflow_process` is tagged `AgentTag.DESTRUCTIVE`.
 
 ## Implementation
 

--- a/docs/reference-docs/mcp.md
+++ b/docs/reference-docs/mcp.md
@@ -37,7 +37,9 @@ The default toolset covers the typical agent flow:
 | `list_workflows`                          | Discover available workflows                         |
 | `get_workflow_form`                       | Fetch a workflow's input form (page by page)         |
 | `get_subscription_available_workflows`    | List workflows available on a subscription          |
-| `create_workflow` / `resume_process`      | Start or resume a process                            |
+| `create_workflow`                         | Start a new workflow process                         |
+| `resume_workflow_process`                 | Resume a suspended process with form input           |
+| `abort_workflow_process`                  | Abort a running process (irreversible)               |
 | `get_process_status`                      | Inspect a running/suspended process                  |
 | `list_recent_processes`                   | List recent processes (with typed filters)           |
 | `search_subscriptions`                    | Search subscriptions with typed filters              |

--- a/orchestrator/core/agent_tags.py
+++ b/orchestrator/core/agent_tags.py
@@ -30,3 +30,9 @@ class AgentTag(str, Enum):
 
     LARGE = "agent-large"
     """Signal: may return many records; agent should narrow before calling."""
+
+    READONLY = "agent-readonly"
+    """Signal: a non-GET route that does NOT mutate state (read-only tool)."""
+
+    DESTRUCTIVE = "agent-destructive"
+    """Signal: an irreversible mutation (e.g. abort, delete)."""

--- a/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
+++ b/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
@@ -86,7 +86,7 @@ router = APIRouter()
 @router.post(
     "/list_workflows",
     response_model=list[WorkflowSchema],
-    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE, AgentTag.READONLY],
     operation_id="list_workflows",
 )
 def list_workflows_endpoint(params: ListWorkflowsRequest) -> list[WorkflowSchema]:
@@ -105,7 +105,7 @@ def list_workflows_endpoint(params: ListWorkflowsRequest) -> list[WorkflowSchema
 @router.post(
     "/get_workflow_form",
     response_model=WorkflowFormPage,
-    tags=[AgentTag.EXPOSED],
+    tags=[AgentTag.EXPOSED, AgentTag.READONLY],
     operation_id="get_workflow_form",
 )
 def get_workflow_form_endpoint(params: GetWorkflowFormRequest) -> WorkflowFormPage:
@@ -138,7 +138,7 @@ def get_workflow_form_endpoint(params: GetWorkflowFormRequest) -> WorkflowFormPa
 @router.post(
     "/get_subscription_available_workflows",
     response_model=SubscriptionWorkflowListsSchema,
-    tags=[AgentTag.EXPOSED],
+    tags=[AgentTag.EXPOSED, AgentTag.READONLY],
     operation_id="get_subscription_available_workflows",
 )
 def get_subscription_available_workflows_endpoint(params: SubscriptionIdRequest) -> SubscriptionWorkflowListsSchema:
@@ -159,7 +159,7 @@ def get_subscription_available_workflows_endpoint(params: SubscriptionIdRequest)
 @router.post(
     "/get_process_status",
     response_model=ProcessStatusResponse,
-    tags=[AgentTag.EXPOSED],
+    tags=[AgentTag.EXPOSED, AgentTag.READONLY],
     operation_id="get_process_status",
 )
 def get_process_status_endpoint(params: ProcessIdRequest) -> ProcessStatusResponse:
@@ -190,7 +190,7 @@ def get_process_status_endpoint(params: ProcessIdRequest) -> ProcessStatusRespon
 @router.post(
     "/list_recent_processes",
     response_model=list[ProcessSummary],
-    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE, AgentTag.READONLY],
     operation_id="list_recent_processes",
 )
 def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[ProcessSummary]:
@@ -227,7 +227,7 @@ def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[P
 @router.post(
     "/get_subscription_details",
     response_model=SubscriptionDetailsResponse,
-    tags=[AgentTag.EXPOSED],
+    tags=[AgentTag.EXPOSED, AgentTag.READONLY],
     operation_id="get_subscription_details",
 )
 def get_subscription_details_endpoint(params: SubscriptionIdRequest) -> SubscriptionDetailsResponse:
@@ -262,7 +262,7 @@ def get_subscription_details_endpoint(params: SubscriptionIdRequest) -> Subscrip
 @router.post(
     "/search_subscriptions",
     response_model=list[SubscriptionSearchResult],
-    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE, AgentTag.READONLY],
     operation_id="search_subscriptions",
 )
 def search_subscriptions_endpoint(params: SearchSubscriptionsRequest) -> list[SubscriptionSearchResult]:

--- a/orchestrator/core/api/api_v1/endpoints/processes.py
+++ b/orchestrator/core/api/api_v1/endpoints/processes.py
@@ -367,7 +367,7 @@ async def resume_all_processes_endpoint(request: Request, user: str = Depends(us
     "/{process_id}/abort",
     response_model=None,
     status_code=HTTPStatus.NO_CONTENT,
-    tags=[AgentTag.EXPOSED],
+    tags=[AgentTag.EXPOSED, AgentTag.DESTRUCTIVE],
     operation_id="abort_workflow_process",
 )
 def abort_process_endpoint(process_id: UUID, request: Request, user: str = Depends(user_name)) -> None:

--- a/orchestrator/core/api/api_v1/endpoints/processes.py
+++ b/orchestrator/core/api/api_v1/endpoints/processes.py
@@ -414,9 +414,17 @@ async def _patch_process(data: ProcessPatchSchema, process: ProcessTable) -> Pro
     return process
 
 
-@router.get("/status-counts", response_model=ProcessStatusCounts)
+@router.get(
+    "/status-counts",
+    response_model=ProcessStatusCounts,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_process_status_counts",
+)
 def status_counts() -> ProcessStatusCounts:
-    """Retrieve status counts for processes and tasks."""
+    """Get aggregate counts of processes and tasks grouped by status.
+
+    Cheap dashboard-style summary; use before listing to gauge system state.
+    """
 
     stmt = (
         select(ProcessTable)

--- a/orchestrator/core/api/api_v1/endpoints/processes.py
+++ b/orchestrator/core/api/api_v1/endpoints/processes.py
@@ -199,6 +199,11 @@ async def new_process(
     user: str = Depends(user_name),
     user_model: OIDCUserModel | None = Depends(authenticate),
 ) -> dict[str, UUID]:
+    """Start a new workflow process by its workflow key.
+
+    Provide the workflow's filled form pages as ``json_data`` (build them with
+    ``get_workflow_form``). Returns the id of the created process.
+    """
     broadcast_func = api_broadcast_process_data(request)
 
     workflow = get_workflow(workflow_key)
@@ -244,6 +249,11 @@ async def resume_process_endpoint(
     user: str = Depends(user_name),
     user_model: OIDCUserModel | None = Depends(authenticate),
 ) -> None:
+    """Resume a SUSPENDED workflow process with the next page of form input.
+
+    Provide the awaited input as ``json_data`` — fetch its schema from
+    ``get_process_status`` for the suspended process.
+    """
     process = await asyncio.to_thread(_get_process, process_id)
 
     pstat = load_process(process)
@@ -371,6 +381,7 @@ async def resume_all_processes_endpoint(request: Request, user: str = Depends(us
     operation_id="abort_workflow_process",
 )
 def abort_process_endpoint(process_id: UUID, request: Request, user: str = Depends(user_name)) -> None:
+    """Abort a running workflow process. This is irreversible."""
     process = _get_process(process_id)
 
     broadcast_func = api_broadcast_process_data(request)

--- a/orchestrator/core/api/api_v1/endpoints/product_blocks.py
+++ b/orchestrator/core/api/api_v1/endpoints/product_blocks.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from fastapi.param_functions import Body
 from fastapi.routing import APIRouter
 
+from orchestrator.core.agent_tags import AgentTag
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import db
 from orchestrator.core.db.models import ProductBlockTable
@@ -25,8 +26,14 @@ from orchestrator.core.schemas.product_block import ProductBlockPatchSchema, Pro
 router = APIRouter()
 
 
-@router.get("/{product_block_id}", response_model=ProductBlockSchema)
+@router.get(
+    "/{product_block_id}",
+    response_model=ProductBlockSchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_product_block",
+)
 def get_product_block_description(product_block_id: UUID) -> str:
+    """Get a single product block definition by id, including its resource types."""
     product_block = db.session.get(ProductBlockTable, product_block_id)
     if product_block is None:
         raise_status(HTTPStatus.NOT_FOUND)

--- a/orchestrator/core/api/api_v1/endpoints/products.py
+++ b/orchestrator/core/api/api_v1/endpoints/products.py
@@ -40,6 +40,7 @@ router = APIRouter()
     operation_id="list_products",
 )
 def fetch(tag: str | None = None, product_type: str | None = None) -> list[ProductSchema]:
+    """List products, optionally filtered by ``tag`` or ``product_type``."""
     stmt = select(ProductTable).options(
         selectinload(ProductTable.workflows),
         selectinload(ProductTable.fixed_inputs),

--- a/orchestrator/core/api/api_v1/endpoints/products.py
+++ b/orchestrator/core/api/api_v1/endpoints/products.py
@@ -56,8 +56,14 @@ def fetch(tag: str | None = None, product_type: str | None = None) -> list[Produ
 @router.get(
     "/{product_id}",
     response_model=ProductSchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_product",
 )
 def product_by_id(product_id: UUID) -> ProductTable:
+    """Get a single product by id, including fixed inputs, product blocks and workflows.
+
+    Use after ``list_products`` to inspect one product's full definition.
+    """
     product = _product_by_id(product_id)
     if not product:
         raise_status(HTTPStatus.NOT_FOUND, f"Product id {product_id} not found")

--- a/orchestrator/core/api/api_v1/endpoints/resource_types.py
+++ b/orchestrator/core/api/api_v1/endpoints/resource_types.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from fastapi.param_functions import Body
 from fastapi.routing import APIRouter
 
+from orchestrator.core.agent_tags import AgentTag
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import db
 from orchestrator.core.db.models import ResourceTypeTable
@@ -25,8 +26,14 @@ from orchestrator.core.schemas.resource_type import ResourceTypePatchSchema, Res
 router = APIRouter()
 
 
-@router.get("/{resource_type_id}", response_model=ResourceTypeSchema)
+@router.get(
+    "/{resource_type_id}",
+    response_model=ResourceTypeSchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_resource_type",
+)
 def get_resource_type_description(resource_type_id: UUID) -> str:
+    """Get a single resource type definition by id."""
     resource_type = db.session.get(ResourceTypeTable, resource_type_id)
     if resource_type is None:
         raise_status(HTTPStatus.NOT_FOUND)

--- a/orchestrator/core/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/core/api/api_v1/endpoints/subscriptions.py
@@ -13,6 +13,7 @@
 
 """Module that implements subscription related API endpoints."""
 
+import itertools
 from http import HTTPStatus
 from typing import Any
 from uuid import UUID
@@ -26,6 +27,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from oauth2_lib.fastapi import OIDCUserModel
+from orchestrator.core.agent_tags import AgentTag
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.api.helpers import add_response_range, add_subscription_search_query_filter
 from orchestrator.core.db import (
@@ -78,23 +80,30 @@ def _delete_process_subscriptions(process_subscriptions: list[ProcessSubscriptio
             _delete_subscription_tree(subscription)
 
 
+def _apply_auth_reason(workflow_dict: dict[str, Any], current_user: OIDCUserModel | None) -> None:
+    """Stamp ``workflow_dict`` with an insufficient-permissions reason when the user cannot run it."""
+    workflow = get_workflow(workflow_dict["name"])
+    if workflow is None:
+        return
+
+    context = AuthContext(user=current_user, workflow=workflow, action="start_workflow")
+    if (
+        not workflow.authorize_callback(context)  # The current user isn't allowed to run this workflow
+        and "reason" not in workflow_dict  # and there isn't already a reason why this workflow cannot run
+    ):
+        workflow_dict["reason"] = "subscription.insufficient_workflow_permissions"
+
+
 def _authorized_subscription_workflows(
     subscription: SubscriptionTable, current_user: OIDCUserModel | None
 ) -> dict[str, list[dict[str, list[Any] | str]]]:
     subscription_workflows_dict = subscription_workflows(subscription)
 
-    for workflow_target in Target.values():
-        for workflow_dict in subscription_workflows_dict[workflow_target.lower()]:
-            workflow = get_workflow(workflow_dict["name"])
-            if not workflow:
-                continue
-
-            context = AuthContext(user=current_user, workflow=workflow, action="start_workflow")
-            if (
-                not workflow.authorize_callback(context)  # The current user isn't allowed to run this workflow
-                and "reason" not in workflow_dict  # and there isn't already a reason why this workflow cannot run
-            ):
-                workflow_dict["reason"] = "subscription.insufficient_workflow_permissions"
+    all_workflow_dicts = itertools.chain.from_iterable(
+        subscription_workflows_dict[target.lower()] for target in Target.values()
+    )
+    for workflow_dict in all_workflow_dicts:
+        _apply_auth_reason(workflow_dict, current_user)
 
     return subscription_workflows_dict
 
@@ -102,10 +111,19 @@ def _authorized_subscription_workflows(
 @router.get(
     "/domain-model/{subscription_id}",
     response_model=SubscriptionDomainModelSchema | None,
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="get_subscription_domain_model",
 )
 async def subscription_details_by_id_with_domain_model(
     request: Request, subscription_id: UUID, response: Response, filter_owner_relations: bool = True
 ) -> dict[str, Any] | None:
+    """Get a subscription's full domain model: the nested product-block tree and relations.
+
+    LARGE: returns the entire instantiated product-block tree. Prefer
+    ``get_subscription_details`` for a flat header; use this only when the full
+    tree is required.
+    """
+
     def _build_response(model: dict, etag: str) -> dict[str, Any] | None:
         if etag == request.headers.get("If-None-Match"):
             response.status_code = HTTPStatus.NOT_MODIFIED

--- a/orchestrator/core/api/api_v1/endpoints/workflows.py
+++ b/orchestrator/core/api/api_v1/endpoints/workflows.py
@@ -17,6 +17,7 @@ from uuid import UUID
 from fastapi.param_functions import Body
 from fastapi.routing import APIRouter
 
+from orchestrator.core.agent_tags import AgentTag
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import db
 from orchestrator.core.db.models import WorkflowTable
@@ -25,8 +26,14 @@ from orchestrator.core.schemas.workflow import WorkflowPatchSchema, WorkflowSche
 router = APIRouter()
 
 
-@router.get("/{workflow_id}", response_model=WorkflowSchema)
+@router.get(
+    "/{workflow_id}",
+    response_model=WorkflowSchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_workflow_by_id",
+)
 def get_workflow_description(workflow_id: UUID) -> str:
+    """Get a single workflow definition by id (name, target, description, steps)."""
     workflow = db.session.get(WorkflowTable, workflow_id)
     if workflow is None:
         raise_status(HTTPStatus.NOT_FOUND)

--- a/orchestrator/core/mcp/server.py
+++ b/orchestrator/core/mcp/server.py
@@ -35,11 +35,16 @@ re-injects it. See https://github.com/jlowin/fastmcp/issues/2817.
 Transport: streamable HTTP.
 """
 
+from typing import TYPE_CHECKING
+
 import httpx
 from fastapi import FastAPI
 from starlette.applications import Starlette
 
 from orchestrator.core.agent_tags import AgentTag
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
 
 MCP_MOUNT_PATH = "/mcp"
 
@@ -60,6 +65,26 @@ async def _forward_auth_header(request: httpx.Request) -> None:
             request.headers[key] = value
 
 
+def build_mcp(app: FastAPI) -> "FastMCP":  # noqa: F821 (lazy import below)
+    """Construct the configured ``FastMCP`` for ``app`` without mounting it.
+
+    Extracted so tests can build the exact same server (route maps, component
+    customization, auth-forwarding hook) the application uses at runtime.
+    """
+    from fastmcp import FastMCP
+    from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+    return FastMCP.from_fastapi(
+        app=app,
+        name="orchestrator-core-mcp",
+        route_maps=[
+            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+        httpx_client_kwargs={"event_hooks": {"request": [_forward_auth_header]}},
+    )
+
+
 def mount_mcp(app: FastAPI) -> Starlette:
     """Auto-generate MCP tools from ``app``'s routes, mount at ``/mcp``, return the sub-app.
 
@@ -72,19 +97,7 @@ def mount_mcp(app: FastAPI) -> Starlette:
     ``mcp_app.router.lifespan_context(parent)`` from inside the parent's
     own lifespan context manager.
     """
-    from fastmcp import FastMCP
-    from fastmcp.server.providers.openapi import MCPType, RouteMap
-
-    mcp = FastMCP.from_fastapi(
-        app=app,
-        name="orchestrator-core-mcp",
-        route_maps=[
-            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
-            RouteMap(mcp_type=MCPType.EXCLUDE),
-        ],
-        httpx_client_kwargs={"event_hooks": {"request": [_forward_auth_header]}},
-    )
-
+    mcp = build_mcp(app)
     mcp_app = mcp.http_app(path="/", transport="http")
     app.mount(MCP_MOUNT_PATH, mcp_app)
     return mcp_app

--- a/orchestrator/core/mcp/server.py
+++ b/orchestrator/core/mcp/server.py
@@ -45,6 +45,7 @@ from orchestrator.core.agent_tags import AgentTag
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+    from fastmcp.utilities.openapi import HTTPRoute
 
 MCP_MOUNT_PATH = "/mcp"
 
@@ -65,6 +66,42 @@ async def _forward_auth_header(request: httpx.Request) -> None:
             request.headers[key] = value
 
 
+def _humanize(name: str) -> str:
+    """Turn an ``operation_id`` into a human-readable tool title.
+
+    ``get_process_status`` -> ``Get Process Status``.
+    """
+    return name.replace("_", " ").title()
+
+
+def _annotate(route: "HTTPRoute", component: object) -> None:
+    """Stamp ``ToolAnnotations`` on each generated tool (``mcp_component_fn`` hook).
+
+    Read/idempotent/destructive hints are inferred from the HTTP method, with
+    ``AgentTag.READONLY`` / ``AgentTag.DESTRUCTIVE`` overriding for POST/PUT
+    routes that don't follow method semantics (e.g. the curated POST read
+    tools). ``openWorldHint`` is always ``False`` — the orchestrator operates
+    on its own database, not an open external world.
+    """
+    from fastmcp.server.providers.openapi import OpenAPITool
+    from mcp.types import ToolAnnotations
+
+    if not isinstance(component, OpenAPITool):
+        return
+
+    tags = set(route.tags)
+    method = route.method.upper()
+    read_only = method == "GET" or AgentTag.READONLY.value in tags
+    destructive = method == "DELETE" or AgentTag.DESTRUCTIVE.value in tags
+    component.annotations = ToolAnnotations(
+        title=_humanize(component.name),
+        readOnlyHint=read_only,
+        idempotentHint=read_only or method in {"PUT", "DELETE"},
+        destructiveHint=destructive,
+        openWorldHint=False,
+    )
+
+
 def build_mcp(app: FastAPI) -> "FastMCP":  # noqa: F821 (lazy import below)
     """Construct the configured ``FastMCP`` for ``app`` without mounting it.
 
@@ -81,6 +118,7 @@ def build_mcp(app: FastAPI) -> "FastMCP":  # noqa: F821 (lazy import below)
             RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
             RouteMap(mcp_type=MCPType.EXCLUDE),
         ],
+        mcp_component_fn=_annotate,
         httpx_client_kwargs={"event_hooks": {"request": [_forward_auth_header]}},
     )
 

--- a/orchestrator/core/mcp/server.py
+++ b/orchestrator/core/mcp/server.py
@@ -102,7 +102,7 @@ def _annotate(route: "HTTPRoute", component: object) -> None:
     )
 
 
-def build_mcp(app: FastAPI) -> "FastMCP":  # noqa: F821 (lazy import below)
+def build_mcp(app: FastAPI) -> "FastMCP":  # noqa: F821 (TYPE_CHECKING-only import; string annotation)
     """Construct the configured ``FastMCP`` for ``app`` without mounting it.
 
     Extracted so tests can build the exact same server (route maps, component

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -95,27 +95,11 @@ def test_all_expected_routes_carry_agent_tag(app_with_agent_routes: FastAPI) -> 
 
 @pytest.mark.asyncio
 async def test_fastmcp_introspects_all_expected_tools(app_with_agent_routes: FastAPI) -> None:
-    """``FastMCP.from_fastapi`` produces exactly the expected tools from the tagged routes.
-
-    Filtering uses ``RouteMap`` precedence: routes carrying ``AgentTag.EXPOSED``
-    map to ``MCPType.TOOL``, everything else falls through to ``EXCLUDE``.
-
-    Each tool's ``parameters`` is also asserted to contain a ``properties``
-    object, this verifies that fastmcp successfully derived a JSON schema
-    from each route's pydantic models and path/query parameters.
-    """
+    """``build_mcp`` produces exactly the expected tools from the tagged routes."""
     pytest.importorskip("fastmcp")
-    from fastmcp import FastMCP
-    from fastmcp.server.providers.openapi import MCPType, RouteMap
+    from orchestrator.core.mcp.server import build_mcp
 
-    mcp = FastMCP.from_fastapi(
-        app=app_with_agent_routes,
-        name="orchestrator-core-mcp-test",
-        route_maps=[
-            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
-            RouteMap(mcp_type=MCPType.EXCLUDE),
-        ],
-    )
+    mcp = build_mcp(app_with_agent_routes)
 
     tools = await mcp.list_tools()
     tool_names = {tool.name for tool in tools}

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -188,3 +188,14 @@ async def test_all_tools_have_title_and_closed_world(app_with_agent_routes: Fast
         assert tool.annotations is not None, name
         assert tool.annotations.title, name
         assert tool.annotations.openWorldHint is False, name
+
+
+def test_exposed_routes_have_docstrings(app_with_agent_routes: FastAPI) -> None:
+    """Every agent-exposed route has a non-empty docstring (its MCP tool description)."""
+    missing = [
+        getattr(route, "path", "")
+        for route in app_with_agent_routes.routes
+        if (AgentTag.EXPOSED.value in (getattr(route, "tags", None) or []))
+        and not ((getattr(getattr(route, "endpoint", None), "__doc__", "") or "").strip())
+    ]
+    assert not missing, f"agent-exposed routes missing a docstring: {missing}"

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -110,3 +110,50 @@ async def test_fastmcp_introspects_all_expected_tools(app_with_agent_routes: Fas
     for tool in tools:
         assert isinstance(tool.parameters, dict), f"tool {tool.name} has non-dict parameters"
         assert "properties" in tool.parameters, f"tool {tool.name} parameters missing 'properties'"
+
+
+async def _tools_by_name(app: FastAPI) -> dict[str, object]:
+    from orchestrator.core.mcp.server import build_mcp
+
+    mcp = build_mcp(app)
+    return {tool.name: tool for tool in await mcp.list_tools()}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_name, read_only, idempotent, destructive",
+    [
+        pytest.param("get_process_status", True, True, False, id="readonly-post"),
+        pytest.param("search_subscriptions", True, True, False, id="readonly-search-post"),
+        pytest.param("list_products", True, True, False, id="readonly-get"),
+        pytest.param("create_workflow", False, False, False, id="write-post"),
+        pytest.param("resume_workflow_process", False, True, False, id="idempotent-put"),
+        pytest.param("abort_workflow_process", False, True, True, id="destructive-put"),
+    ],
+)
+async def test_tool_annotations(
+    app_with_agent_routes: FastAPI,
+    tool_name: str,
+    read_only: bool,
+    idempotent: bool,
+    destructive: bool,
+) -> None:
+    """Each tool's ToolAnnotations reflect its method + AgentTag signals."""
+    pytest.importorskip("fastmcp")
+    tool = (await _tools_by_name(app_with_agent_routes))[tool_name]
+    ann = tool.annotations
+    assert ann is not None
+    assert ann.readOnlyHint is read_only
+    assert ann.idempotentHint is idempotent
+    assert ann.destructiveHint is destructive
+    assert ann.openWorldHint is False
+
+
+@pytest.mark.asyncio
+async def test_all_tools_have_title_and_closed_world(app_with_agent_routes: FastAPI) -> None:
+    """Every tool gets a non-empty humanized title and openWorldHint=False."""
+    pytest.importorskip("fastmcp")
+    for name, tool in (await _tools_by_name(app_with_agent_routes)).items():
+        assert tool.annotations is not None, name
+        assert tool.annotations.title, name
+        assert tool.annotations.openWorldHint is False, name

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -25,11 +25,16 @@ These tests verify that:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from fastapi import FastAPI
 
 from orchestrator.core.agent_tags import AgentTag
 from orchestrator.core.api.api_v1.endpoints import mcp_tools, processes, products
+
+if TYPE_CHECKING:
+    from fastmcp.tools.tool import Tool
 
 # All tool names must match the ``operation_id`` on each tagged route.
 EXPECTED_TOOL_NAMES = {
@@ -112,7 +117,7 @@ async def test_fastmcp_introspects_all_expected_tools(app_with_agent_routes: Fas
         assert "properties" in tool.parameters, f"tool {tool.name} parameters missing 'properties'"
 
 
-async def _tools_by_name(app: FastAPI) -> dict[str, object]:
+async def _tools_by_name(app: FastAPI) -> dict[str, Tool]:
     from orchestrator.core.mcp.server import build_mcp
 
     mcp = build_mcp(app)

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -18,8 +18,10 @@ These tests verify that:
 1. The agent-tagged REST routes carry ``AgentTag.EXPOSED`` and have
    stable ``operation_id`` values that map 1:1 to the MCP tool names.
 2. ``FastMCP.from_fastapi`` introspects the FastAPI app's routes, derives
-   input schemas from their pydantic models, and produces exactly the 11
+   input schemas from their pydantic models, and produces exactly the 17
    tools we expect via ``RouteMap`` tag-based filtering.
+3. Each tool carries ``ToolAnnotations`` (read-only/idempotent/destructive
+   hints + a humanized title) derived from its HTTP method and ``AgentTag``s.
 
 """
 
@@ -153,6 +155,11 @@ async def _tools_by_name(app: FastAPI) -> dict[str, Tool]:
         pytest.param("resume_workflow_process", False, True, False, id="idempotent-put"),
         pytest.param("abort_workflow_process", False, True, True, id="destructive-put"),
         pytest.param("get_product", True, True, False, id="readonly-get-by-id"),
+        pytest.param("get_product_block", True, True, False, id="readonly-product-block"),
+        pytest.param("get_resource_type", True, True, False, id="readonly-resource-type"),
+        pytest.param("get_workflow_by_id", True, True, False, id="readonly-workflow"),
+        pytest.param("get_subscription_domain_model", True, True, False, id="readonly-domain-model"),
+        pytest.param("get_process_status_counts", True, True, False, id="readonly-status-counts"),
     ],
 )
 async def test_tool_annotations(

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -31,7 +31,15 @@ import pytest
 from fastapi import FastAPI
 
 from orchestrator.core.agent_tags import AgentTag
-from orchestrator.core.api.api_v1.endpoints import mcp_tools, processes, products
+from orchestrator.core.api.api_v1.endpoints import (
+    mcp_tools,
+    processes,
+    product_blocks,
+    products,
+    resource_types,
+    subscriptions,
+    workflows,
+)
 
 if TYPE_CHECKING:
     from fastmcp.tools.tool import Tool
@@ -49,6 +57,12 @@ EXPECTED_TOOL_NAMES = {
     "list_recent_processes",
     "get_subscription_details",
     "search_subscriptions",
+    "get_product",  # GET /api/products/{product_id}
+    "get_product_block",  # GET /api/product_blocks/{product_block_id}
+    "get_resource_type",  # GET /api/resource_types/{resource_type_id}
+    "get_workflow_by_id",  # GET /api/workflows/{workflow_id}
+    "get_subscription_domain_model",  # GET /api/subscriptions/domain-model/{subscription_id}
+    "get_process_status_counts",  # GET /api/processes/status-counts
 }
 
 
@@ -85,6 +99,10 @@ def app_with_agent_routes() -> FastAPI:
     app.include_router(processes.router, prefix="/api/processes")
     app.include_router(products.router, prefix="/api/products")
     app.include_router(mcp_tools.router, prefix="/api/agent")
+    app.include_router(workflows.router, prefix="/api/workflows")
+    app.include_router(product_blocks.router, prefix="/api/product_blocks")
+    app.include_router(resource_types.router, prefix="/api/resource_types")
+    app.include_router(subscriptions.router, prefix="/api/subscriptions")
     app.dependency_overrides[authenticate] = lambda: None
     app.dependency_overrides[authorize] = lambda: None
     return app
@@ -93,9 +111,9 @@ def app_with_agent_routes() -> FastAPI:
 def test_all_expected_routes_carry_agent_tag(app_with_agent_routes: FastAPI) -> None:
     """Every expected MCP tool name has a route tagged ``AgentTag.EXPOSED``."""
     found = _agent_tagged_routes(app_with_agent_routes)
-    assert (
-        set(found) == EXPECTED_TOOL_NAMES
-    ), f"missing: {EXPECTED_TOOL_NAMES - set(found)}, extra: {set(found) - EXPECTED_TOOL_NAMES}"
+    assert set(found) == EXPECTED_TOOL_NAMES, (
+        f"missing: {EXPECTED_TOOL_NAMES - set(found)}, extra: {set(found) - EXPECTED_TOOL_NAMES}"
+    )
 
 
 @pytest.mark.asyncio
@@ -108,9 +126,9 @@ async def test_fastmcp_introspects_all_expected_tools(app_with_agent_routes: Fas
 
     tools = await mcp.list_tools()
     tool_names = {tool.name for tool in tools}
-    assert (
-        tool_names == EXPECTED_TOOL_NAMES
-    ), f"missing: {EXPECTED_TOOL_NAMES - tool_names}, extra: {tool_names - EXPECTED_TOOL_NAMES}"
+    assert tool_names == EXPECTED_TOOL_NAMES, (
+        f"missing: {EXPECTED_TOOL_NAMES - tool_names}, extra: {tool_names - EXPECTED_TOOL_NAMES}"
+    )
 
     for tool in tools:
         assert isinstance(tool.parameters, dict), f"tool {tool.name} has non-dict parameters"
@@ -134,6 +152,7 @@ async def _tools_by_name(app: FastAPI) -> dict[str, Tool]:
         pytest.param("create_workflow", False, False, False, id="write-post"),
         pytest.param("resume_workflow_process", False, True, False, id="idempotent-put"),
         pytest.param("abort_workflow_process", False, True, True, id="destructive-put"),
+        pytest.param("get_product", True, True, False, id="readonly-get-by-id"),
     ],
 )
 async def test_tool_annotations(

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -8,3 +8,6 @@ reflected  # noqa
 exc_type  # noqa
 exc_val  # noqa
 exc_tb  # noqa
+
+# TYPE_CHECKING import used only as a string annotation (mcp/server.py)
+HTTPRoute  # noqa


### PR DESCRIPTION
## Summary

Improves how the auto-generated MCP server presents tools to LLM agents, and widens read coverage — weighted toward tool-selection quality.

- **ToolAnnotations on every tool.** A new `mcp_component_fn` hook (`_annotate` in `orchestrator/core/mcp/server.py`) stamps `readOnlyHint` / `idempotentHint` / `destructiveHint` / `openWorldHint=False` plus a humanized `title` on each generated tool. Hints are inferred from the HTTP method and overridden by two new signal tags, `AgentTag.READONLY` / `AgentTag.DESTRUCTIVE`. This fixes the fact that the curated read tools are POST routes and were previously indistinguishable from writes.
- **Six curated GET endpoints exposed as tools:** `get_product`, `get_product_block`, `get_resource_type`, `get_workflow_by_id`, `get_subscription_domain_model` (`LARGE`), `get_process_status_counts`. Each gained an `operation_id` and an LLM-oriented docstring.
- **Backfilled correctness:** `READONLY` on the 7 curated POST read-tools, `DESTRUCTIVE` on `abort_workflow_process`, and docstrings added to 4 previously-undocumented exposed tools (`create_workflow`, `resume_workflow_process`, `abort_workflow_process`, `list_products`).
- Operational/UI GETs (health, translations, search typeahead, settings) are intentionally **not** exposed, to protect selection accuracy.
- `build_mcp(app)` extracted so tests exercise the real configuration. Docs in `docs/reference-docs/mcp.md` updated.

## Test plan

- [x] `uv run --extra mcp pytest test/unit_tests/mcp/test_mcp.py` — 16 tests pass (17-tool membership, parametrized annotation truth-table, docstring guardrail).
- [x] `uv run mypy` on all touched modules — clean.
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [ ] `uv run pytest test/integration_tests/api/test_subscriptions.py` — covers the `_authorized_subscription_workflows` refactor; **not run locally** (needs Docker for the Postgres testcontainer). The refactor is behavior-preserving (itertools flatten + early-return helper replacing a `continue`), but please confirm in CI.

## Notes

- `_authorized_subscription_workflows` (subscriptions.py) was refactored from a nested loop to `itertools.chain.from_iterable` + a helper, because a style hook blocked editing the file otherwise. Semantically identical; aligns with the project's style rules.