### PR TITLE
Fix: date filter bind params cast to VARCHAR instead of TIMESTAMPTZ with psycopg3

### DIFF
--- a/test/unit_tests/search/filters/test_date_filters.py
+++ b/test/unit_tests/search/filters/test_date_filters.py
@@ -18,6 +18,7 @@ from datetime import date, datetime
 import pytest
 from pydantic import ValidationError
 from sqlalchemy import String, column
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql.elements import ColumnElement
 
 from orchestrator.core.search.core.types import FilterOp
@@ -27,6 +28,8 @@ from orchestrator.core.search.filters.date_filters import (
     DateValueFilter,
     _validate_date_string,
 )
+
+_psycopg_dialect = postgresql.psycopg.dialect()
 
 pytestmark = pytest.mark.search
 
@@ -243,3 +246,37 @@ def test_date_range_filter_between_sql_contains_start_and_end_values() -> None:
     sql = str(expr.compile(compile_kwargs={"literal_binds": True}))
     assert "2025-03-01" in sql
     assert "2025-09-30" in sql
+
+
+# ---------------------------------------------------------------------------
+# Regression: psycopg3 must not emit ::VARCHAR for date bind parameters
+#
+# psycopg3 is strict about operator type matching. When SQLAlchemy compiles a
+# comparison like `CAST(col AS TIMESTAMPTZ) > self.value` where self.value is
+# a plain Python string, the bind parameter gets typed as VARCHAR and psycopg3
+# raises: "operator does not exist: timestamp with time zone > character varying"
+#
+# The fix is to wrap values in bindparam(..., type_=TIMESTAMP(timezone=True))
+# so the parameter is cast to TIMESTAMPTZ, not VARCHAR.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op, sql_op", _COMPARISON_OPS_AND_SQL)
+def test_date_value_filter_bind_param_is_not_varchar_on_psycopg_dialect(op: FilterOp, sql_op: str) -> None:
+    f = DateValueFilter(op=op, value="1970-01-01")  # type: ignore[arg-type]
+    expr = f.to_expression(_col, "path")
+    sql = str(expr.compile(dialect=_psycopg_dialect))
+    assert "VARCHAR" not in sql, (
+        f"Bind parameter was cast to VARCHAR for op={op!r}; psycopg3 will reject this. SQL: {sql}"
+    )
+    assert "TIMESTAMP" in sql.upper()
+
+
+def test_date_range_filter_bind_params_are_not_varchar_on_psycopg_dialect() -> None:
+    f = DateRangeFilter(op=FilterOp.BETWEEN, value=DateRange(start="2025-01-01", end="2025-12-31"))
+    expr = f.to_expression(_col, "path")
+    sql = str(expr.compile(dialect=_psycopg_dialect))
+    assert "VARCHAR" not in sql, (
+        f"Bind parameters were cast to VARCHAR; psycopg3 will reject this. SQL: {sql}"
+    )
+    assert sql.upper().count("TIMESTAMP") >= 2


### PR DESCRIPTION
## Problem

`DateValueFilter.to_expression` and `DateRangeFilter.to_expression` compare date values directly against a `CAST(col AS TIMESTAMP WITH TIME ZONE)` column:

```python
date_column = sa_cast(column, TIMESTAMP(timezone=True))
return date_column > self.value  # self.value is a Python str
```

When compiled with the psycopg3 dialect, SQLAlchemy types the bind parameter as `VARCHAR` (since `self.value` is a Python `str`), producing:

```sql
CAST(value AS TIMESTAMP WITH TIME ZONE) > %(param_1)s::VARCHAR
```

PostgreSQL rejects this with:

```
operator does not exist: timestamp with time zone > character varying
HINT: No operator matches the given name and argument types. You might need to add explicit type casts.
```

This did not surface before because psycopg2 handled the implicit cast silently. The upgrade to psycopg3 (introduced in 5.0.0) is strict about operator type matching.

## Fix

Wrap `self.value` in `bindparam(None, self.value, type_=TIMESTAMP(timezone=True))` — the same pattern already used in `ltree_filters.py` with `_LQuery`. This tells SQLAlchemy to emit `::TIMESTAMP WITH TIME ZONE` for the parameter instead of `::VARCHAR`.

## Related

- SQLAlchemy issue: https://github.com/sqlalchemy/sqlalchemy/issues/12060
- Same error in letta-ai: https://github.com/cpacker/MemGPT/issues/1343

## Commits

1. **Test** — regression tests that fail on `main` (this commit, failing CI is intentional)
2. **Fix** — apply the `bindparam` fix (coming next)