### PR TITLE
1517 scheduler form check authorize always returns true

### DIFF
--- a/orchestrator/core/api/api_v1/endpoints/schedules.py
+++ b/orchestrator/core/api/api_v1/endpoints/schedules.py
@@ -73,7 +73,15 @@ async def update_scheduled_task(
 
 
 @router.delete("/", status_code=HTTPStatus.OK)
-async def delete_scheduled_task(payload: APSchedulerJobDelete) -> dict[str, str]:
+async def delete_scheduled_task(
+    payload: APSchedulerJobDelete, user_model: OIDCUserModel | None = Depends(authenticate)
+) -> dict[str, str]:
     """Delete a scheduled task."""
+    if not (workflow_table := get_workflow_by_workflow_id(str(payload.workflow_id))):
+        raise_status(HTTPStatus.NOT_FOUND, "Task does not exist")
+
+    task = get_workflow(workflow_table.name)
+
+    await validate_schedule_authorization(task, user_model)
     add_scheduled_task_to_queue(payload)
     return {"message": "Added to Delete Queue", "status": "DELETED"}

--- a/orchestrator/core/api/api_v1/endpoints/schedules.py
+++ b/orchestrator/core/api/api_v1/endpoints/schedules.py
@@ -23,6 +23,7 @@ from orchestrator.core.schedules.service import add_scheduled_task_to_queue, get
 from orchestrator.core.schemas.schedules import APSchedulerJobCreate, APSchedulerJobDelete, APSchedulerJobUpdate
 from orchestrator.core.security import authenticate
 from orchestrator.core.services.workflows import get_workflow_by_workflow_id
+from orchestrator.core.utils.auth import AuthContext
 from orchestrator.core.workflow import Workflow
 from orchestrator.core.workflows import get_workflow
 
@@ -34,7 +35,8 @@ router: APIRouter = APIRouter()
 async def validate_schedule_authorization(task: Workflow | None, user_model: OIDCUserModel | None) -> None:
     if not task:
         raise_status(HTTPStatus.NOT_FOUND, "Task does not exist")
-    if not await task.authorize_callback(user_model):
+    context = AuthContext(user=user_model, workflow=task, action="start_workflow")
+    if not await task.authorize_callback(context):
         raise_status(HTTPStatus.FORBIDDEN, f"User is not authorized to manage schedule with '{task.name}' task")
 
 

--- a/orchestrator/core/forms/scheduler_form.py
+++ b/orchestrator/core/forms/scheduler_form.py
@@ -26,6 +26,7 @@ from orchestrator.core.db import db
 from orchestrator.core.db.models import WorkflowTable
 from orchestrator.core.forms.validators import Choice
 from orchestrator.core.forms.validators.timestamp import to_timestamp_field
+from orchestrator.core.utils.auth import AuthContext
 from orchestrator.core.workflow import Workflow, default_user_inputs
 from orchestrator.core.workflows import get_workflow
 from pydantic_forms.types import FormGenerator, FormGeneratorAsync, State
@@ -98,20 +99,17 @@ def get_cron_kwargs(form_data: dict) -> dict:
     }
 
 
-def _check_authorize(workflow: Workflow, user_model: OIDCUserModel | None) -> bool:
-    result = workflow.authorize_callback(user_model)
-    if asyncio.iscoroutine(result):
-        result.close()
-        return True
-    return bool(result)
+async def _check_authorize(workflow: Workflow, user_model: OIDCUserModel | None) -> bool:
+    context = AuthContext(user=user_model, workflow=workflow, action="start_workflow")
+    return await workflow.authorize_callback(context)
 
 
-def get_tasks(user_model: OIDCUserModel | None) -> dict[str, tuple[Workflow, UUID, str]]:
+async def get_tasks(user_model: OIDCUserModel | None) -> dict[str, tuple[Workflow, UUID, str]]:
     tasks = db.session.scalars(select(WorkflowTable))
     return {
         task_row.name: (workflow, task_row.workflow_id, task_row.description)
         for task_row in tasks
-        if (workflow := get_workflow(task_row.name)) and _check_authorize(workflow, user_model)
+        if (workflow := get_workflow(task_row.name)) and await _check_authorize(workflow, user_model)
     }
 
 
@@ -141,7 +139,7 @@ async def configure_schedule_form(state: State) -> FormGeneratorAsync:
 
     _model_config = ConfigDict(title="Create new schedule")
     user_model = OIDCUserModel(**_user_model) if (_user_model := state.get("user_model")) else None
-    tasks = get_tasks(user_model)
+    tasks = await get_tasks(user_model)
     task_choices = {name: description for name, (_, _, description) in tasks.items()}
 
     class ScheduleTaskChoiceForm(FormPage):

--- a/test/integration_tests/api/test_schedules.py
+++ b/test/integration_tests/api/test_schedules.py
@@ -204,16 +204,21 @@ def test_update_scheduled_task_unauthorized(
 
 
 @patch("orchestrator.core.api.api_v1.endpoints.schedules.add_scheduled_task_to_queue")
-def test_delete_scheduled_task(mock_add, test_client):
+@patch("orchestrator.core.api.api_v1.endpoints.schedules.get_workflow_by_workflow_id")
+def test_delete_scheduled_task(mock_get_workflow_by_workflow_id, mock_add, test_client):
+    @workflow(target=Target.SYSTEM, authorize_callback=_allow)
+    def delete_task_wf():
+        return init >> done
+
     body = {
         "schedule_id": str(uuid4()),
         "workflow_id": str(uuid4()),
-        "name": None,
-        "trigger": None,
-        "trigger_kwargs": None,
     }
 
-    response = test_client.request("DELETE", "/api/schedules/", json=body)
+    mock_get_workflow_by_workflow_id.return_value = WorkflowTable(name="delete_task_wf")
+
+    with WorkflowInstanceForTests(delete_task_wf, "delete_task_wf"):
+        response = test_client.request("DELETE", "/api/schedules/", json=body)
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == snapshot(
@@ -223,3 +228,41 @@ def test_delete_scheduled_task(mock_add, test_client):
         }
     )
     mock_add.assert_called_once()
+
+
+def test_delete_scheduled_task_task_not_found(test_client):
+    body = {
+        "schedule_id": str(uuid4()),
+        "workflow_id": str(uuid4()),
+    }
+
+    response = test_client.request("DELETE", "/api/schedules/", json=body)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.json() == snapshot({"detail": "Task does not exist", "status": 404, "title": "Not Found"})
+
+
+@patch("orchestrator.core.api.api_v1.endpoints.schedules.get_workflow_by_workflow_id")
+def test_delete_scheduled_task_unauthorized(mock_get_workflow_by_workflow_id, test_client):
+    @workflow(target=Target.SYSTEM, authorize_callback=_disallow)
+    def unauthorized_delete_wf():
+        return init >> done
+
+    body = {
+        "schedule_id": str(uuid4()),
+        "workflow_id": str(uuid4()),
+    }
+
+    mock_get_workflow_by_workflow_id.return_value = WorkflowTable(name="unauthorized_delete_wf")
+
+    with WorkflowInstanceForTests(unauthorized_delete_wf, "unauthorized_delete_wf"):
+        response = test_client.request("DELETE", "/api/schedules/", json=body)
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert response.json() == snapshot(
+        {
+            "detail": "User is not authorized to manage schedule with 'unauthorized_delete_wf' task",
+            "status": 403,
+            "title": "Forbidden",
+        }
+    )

--- a/test/unit_tests/forms/test_scheduler_form.py
+++ b/test/unit_tests/forms/test_scheduler_form.py
@@ -1,0 +1,87 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from orchestrator.core.forms.scheduler_form import _check_authorize
+from orchestrator.core.utils.auth import AuthContext
+from orchestrator.core.workflow import begin, done, step, workflow
+
+
+@step("noop")
+def noop():
+    return {}
+
+
+async def allow_all(context: AuthContext) -> bool:
+    return True
+
+
+async def deny_all(context: AuthContext) -> bool:
+    return False
+
+
+async def allow_by_username(context: AuthContext) -> bool:
+    if not context.user:
+        return False
+    return context.user.user_name == "admin"
+
+
+class FakeUser:
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def user_name(self) -> str:
+        return self._name
+
+
+@pytest.fixture()
+def allowed_workflow():
+    @workflow(authorize_callback=allow_all)
+    def allowed_wf():
+        return begin >> noop >> done
+
+    return allowed_wf
+
+
+@pytest.fixture()
+def denied_workflow():
+    @workflow(authorize_callback=deny_all)
+    def denied_wf():
+        return begin >> noop >> done
+
+    return denied_wf
+
+
+@pytest.fixture()
+def username_workflow():
+    @workflow(authorize_callback=allow_by_username)
+    def username_wf():
+        return begin >> noop >> done
+
+    return username_wf
+
+
+async def test_check_authorize_allows(allowed_workflow):
+    assert await _check_authorize(allowed_workflow, None) is True
+
+
+async def test_check_authorize_denies(denied_workflow):
+    assert await _check_authorize(denied_workflow, None) is False
+
+
+async def test_check_authorize_passes_auth_context(username_workflow):
+    assert await _check_authorize(username_workflow, FakeUser("admin")) is True
+    assert await _check_authorize(username_workflow, FakeUser("nobody")) is False
+    assert await _check_authorize(username_workflow, None) is False


### PR DESCRIPTION
## Summary

- Updated '_check_authorize' function  so  that it awaits the result of asynchronuous function and does not always return True (and thus always authorizes the scheduling of tasks)
- Updated delete endpoint to enforce authorization for deleting scheduled tasks
- Added unit tests

## Related Issues
Fixes #1638