### PR TITLE
Capture exception that fails workflow for error tracking

### DIFF
--- a/docs/reference-docs/monitoring/error-tracking.md
+++ b/docs/reference-docs/monitoring/error-tracking.md
@@ -71,6 +71,7 @@ Add the following code to the `main.py` file of the `orchestrator-core` applicat
             my_settings.TRACE_SAMPLE_RATE,
             app.base_settings.SERVICE_NAME,
             app.base_settings.ENVIRONMENT,
+            # before_send=before_send,  # Optional, see section `before_send`
         )
 
     if __name__ == "__main__":
@@ -98,6 +99,7 @@ Add the following code to the `main.py` file of the `orchestrator-core` applicat
             my_settings.TRACE_SAMPLE_RATE,
             app.base_settings.SERVICE_NAME,
             app.base_settings.ENVIRONMENT,
+            # before_send=before_send,  # Optional, see section `before_send`
         )
 
     if __name__ == "__main__":
@@ -128,6 +130,84 @@ def debug_sentry():
 
 !!! warning
     Make sure your environment variable ``ENVIRONMENT`` is **NOT** set to ``local`` when testing the Sentry integration.
+
+## `before_send`
+
+You can define a `before_send` function to perform client-side
+event [filtering](https://docs.sentry.io/platforms/python/configuration/filtering/)
+and [fingerprinting](https://docs.sentry.io/platforms/python/usage/sdk-fingerprinting/).
+
+Filtering can help to ensure you are only submitting errors for actionable application or infrastructure problems.
+
+Small incomplete example implementation of `before_send` for the API:
+
+```py
+from sentry_sdk.types import Event, Hint
+from nwastdlib.graphql.extensions.error_handler_extension import EXTENSION_ERROR_TYPE, ErrorType
+from graphql.error import GraphQLError
+
+CLIENT_GRAPHQL_ERROR_TYPES = frozenset(
+    {
+        ErrorType.NOT_AUTHENTICATED,
+        ErrorType.NOT_AUTHORIZED,
+        ErrorType.NOT_FOUND,
+        ErrorType.BAD_REQUEST,
+    }
+)
+
+def _is_client_graphql_error(exc: GraphQLError) -> bool:
+    """True when a GraphQLError was caused by the caller."""
+    extensions = exc.extensions or {}
+    if extensions.get(EXTENSION_ERROR_TYPE) in CLIENT_GRAPHQL_ERROR_TYPES:
+        return True
+    return False
+
+def before_send_api(event: Event, hint: Hint) -> Event | None:
+    """Sentry ``before_send`` hook to drop or fingerprint an API event."""
+    exc_info = hint.get("exc_info")
+    exception = exc_info[1] if exc_info else None
+
+    match exception:
+        case GraphQLError() if _is_client_graphql_error(exception):
+            return None
+
+    # After allowing an event, you can change it's fingerprint or any other aspect to enhance your issue tracking
+
+    return event
+
+# Usage:
+# `app.add_sentry(before_send=before_send_api)`
+```
+
+Small example for the Celery worker:
+
+```py
+import ims_client
+from orchestrator.core.utils.errors import InconsistentDataError
+from sentry_sdk.types import Event, Hint
+
+
+def before_send_worker(event: Event, hint: Hint) -> Event | None:
+    """Sentry ``before_send`` hook to drop or fingerprint a Worker event."""
+    exc_info = hint.get("exc_info")
+    exception = exc_info[1] if exc_info else None
+
+    match exception:
+        case ims_client.exceptions.NotFoundException():
+            return None
+        case InconsistentDataError():
+            return None
+
+    # After allowing an event, you can change it's fingerprint or any other aspect to enhance your issue tracking
+
+    return event
+
+# Usage:
+#   class OrchestratorWorker(Celery):
+#       def on_init(self) -> None:
+#           if surf_settings.TRACING_ENABLED:
+#               sentry_sdk.init(before_send=before_send_worker, ...)
+```
 
 **See also**
 

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -1551,7 +1551,7 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
             process = process.map(lambda s: s | {"__last_step_started_at": nowtz().timestamp()})
             step_result_process = process.execute_step(step)
         except Exception as e:
-            consolelogger.error("An exception occurred while executing the workflow step.")
+            consolelogger.error("An exception occurred while executing the workflow step.", exc_info=e)
             step_result_process = Failed(e)
 
         # write the new process state after the step execution to the database

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -1558,7 +1558,6 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
         # Convert ErrorState to ErrorDict when Failed or Waiting before writing to the database
         # as bare exceptions are not JSON serializable
         result_to_log = step_result_process.on_failed(error_state_to_dict).on_waiting(error_state_to_dict)
-        result_to_log.on_success(mutationlogger).on_failed(errorlogger).on_waiting(errorlogger)
         result_to_log.on_success(mutationlogger).on_failed(log_workflow_failure).on_waiting(log_workflow_failure)
 
         with transactional(db, logger):

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -1512,9 +1512,9 @@ def log_mutations(old_process_state: State) -> Callable[[State], None]:
     return _log_mutations
 
 
-def errorlogger(error: ErrorDict) -> None:
-    logger.error("Workflow returned an error.", **error)
-
+def log_workflow_failure(error: ErrorDict) -> None:
+    """Log the error state from a failed workflow."""
+    logger.info("Workflow returned an error.", **error)
 
 def invalidate_status_counts() -> None:
     """Broadcast invalidate status counts to the websocket."""
@@ -1559,6 +1559,7 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
         # as bare exceptions are not JSON serializable
         result_to_log = step_result_process.on_failed(error_state_to_dict).on_waiting(error_state_to_dict)
         result_to_log.on_success(mutationlogger).on_failed(errorlogger).on_waiting(errorlogger)
+        result_to_log.on_success(mutationlogger).on_failed(log_workflow_failure).on_waiting(log_workflow_failure)
 
         with transactional(db, logger):
             process = dblogstep(step, result_to_log)

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -44,6 +44,7 @@ from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.config.assignee import Assignee
 from orchestrator.core.db import db, transactional
 from orchestrator.core.services.settings import get_engine_settings_table
+from orchestrator.core.settings import app_settings
 from orchestrator.core.targets import Target
 from orchestrator.core.types import ErrorDict, StepFunc
 from orchestrator.core.utils.auth import Authorizer
@@ -1523,6 +1524,23 @@ def invalidate_status_counts() -> None:
     broadcast_invalidate_status_counts()
 
 
+def capture_workflow_failure(err: Any) -> None:
+    """Capture the exception from a failed workflow.
+
+    This may provide useful insights into application or infra errors.
+    However, this may also cause sentry issues for exceptions that are "business as usual".
+    In that case, you can pass a function `app.add_sentry(before_send=before_send)` in which you can evaluate
+    exceptions and prevent sending them to sentry.
+    https://docs.sentry.io/platforms/python/configuration/filtering/
+    """
+    match err:
+        case Exception() if app_settings.TRACING_ENABLED:
+            import sentry_sdk
+            sentry_sdk.capture_exception(err)
+        case _:
+            pass
+
+
 def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFuncInternal) -> Process:
     """Execute the workflow steps one by one until a Process state other than Success or Skipped is reached."""
     consolelogger = cond_bind(logger, starting_process.unwrap(), "reporter", "created_by")
@@ -1559,6 +1577,9 @@ def _exec_steps(steps: StepList, starting_process: Process, dblogstep: StepLogFu
         # as bare exceptions are not JSON serializable
         result_to_log = step_result_process.on_failed(error_state_to_dict).on_waiting(error_state_to_dict)
         result_to_log.on_success(mutationlogger).on_failed(log_workflow_failure).on_waiting(log_workflow_failure)
+
+        # Capture the original exception that caused the workflow to fail
+        step_result_process.on_failed(capture_workflow_failure)
 
         with transactional(db, logger):
             process = dblogstep(step, result_to_log)


### PR DESCRIPTION
## Summary

* Adapt workflow error logging to capture the exception that failed a workflow. This allows for more fine-grained error tracking in Sentry, and client-side filtering with `before_send=`
* Pass the exception to `consolelogger.error("An exception occurred while executing the workflow step.")` for unexpected exceptions
