### PR TITLE
1506 bug migration generation failing

### DIFF
--- a/orchestrator/core/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/core/cli/domain_gen_helpers/helpers.py
@@ -65,6 +65,20 @@ def map_create_product_to_product_block_relations(model_diffs: dict[str, dict[st
     return generic_mapper("missing_product_blocks_in_db", model_diffs)
 
 
+def _block_type_matches(
+    block_type: type[ProductBlockModel] | tuple[type[ProductBlockModel], ...],
+    block_to_find_in_props: str,
+) -> bool:
+    """Check if a depends-on product block field matches the wanted block name.
+
+    ``_get_depends_on_product_block_types`` returns a single product block type for plain
+    fields, but a ``tuple`` of types when the field is a non-Optional ``Union`` (e.g.
+    ``port: CorePortBlock | CoreLAGPortBlock``). Both shapes must be matched on ``name``.
+    """
+    block_types = block_type if isinstance(block_type, tuple) else (block_type,)
+    return any(getattr(bt, "name", None) == block_to_find_in_props for bt in block_types)
+
+
 def format_block_relation_to_dict(
     model_name: str,
     block_to_find_in_props: str,
@@ -73,7 +87,7 @@ def format_block_relation_to_dict(
 ) -> BlockRelationDict:
     model = models[model_name]
     block_props = model._get_depends_on_product_block_types()
-    props = {k for k, v in block_props.items() if v.name == block_to_find_in_props}  # type: ignore
+    props = {k for k, v in block_props.items() if _block_type_matches(v, block_to_find_in_props)}
 
     if len(props) > 1 and not confirm_warnings:
         noqa_print("WARNING: Relating a Product Block multiple times is not supported by this migrator!")

--- a/orchestrator/core/cli/domain_gen_helpers/helpers.py
+++ b/orchestrator/core/cli/domain_gen_helpers/helpers.py
@@ -67,35 +67,36 @@ def map_create_product_to_product_block_relations(model_diffs: dict[str, dict[st
 
 def _block_type_matches(
     block_type: type[ProductBlockModel] | tuple[type[ProductBlockModel], ...],
-    block_to_find_in_props: str,
+    target_block_name: str,
 ) -> bool:
-    """Check if a depends-on product block field matches the wanted block name.
+    """Return whether a depends-on field references the product block ``target_block_name``.
 
-    ``_get_depends_on_product_block_types`` returns a single product block type for plain
-    fields, but a ``tuple`` of types when the field is a non-Optional ``Union`` (e.g.
-    ``port: CorePortBlock | CoreLAGPortBlock``). Both shapes must be matched on ``name``.
+    ``_get_depends_on_product_block_types`` returns one of two shapes: a single product
+    block type for a plain field, or a ``tuple`` of types for a non-Optional ``Union``
+    field (e.g. ``port: CorePortBlock | CoreLAGPortBlock``). This helper normalises both
+    to a tuple and returns ``True`` if any member's ``name`` equals ``target_block_name``.
     """
     block_types = block_type if isinstance(block_type, tuple) else (block_type,)
-    return any(getattr(bt, "name", None) == block_to_find_in_props for bt in block_types)
+    return any(getattr(bt, "name", None) == target_block_name for bt in block_types)
 
 
 def format_block_relation_to_dict(
     model_name: str,
-    block_to_find_in_props: str,
+    target_block_name: str,
     models: dict[str, type[SubscriptionModel]] | dict[str, type[ProductBlockModel]],
     confirm_warnings: bool,
 ) -> BlockRelationDict:
     model = models[model_name]
     block_props = model._get_depends_on_product_block_types()
-    props = {k for k, v in block_props.items() if _block_type_matches(v, block_to_find_in_props)}
+    props = {k for k, v in block_props.items() if _block_type_matches(v, target_block_name)}
 
     if len(props) > 1 and not confirm_warnings:
         noqa_print("WARNING: Relating a Product Block multiple times is not supported by this migrator!")
         noqa_print(
             "You will need to create your own migration to create a Product Block Instance for each attribute that is related"
         )
-        noqa_print(f"Product Block '{block_to_find_in_props}' has been related multiple times to '{model_name}'")
-        noqa_print(f"Attributes the block ('{block_to_find_in_props}') has been related with: {', '.join(props)}")
+        noqa_print(f"Product Block '{target_block_name}' has been related multiple times to '{model_name}'")
+        noqa_print(f"Attributes the block ('{target_block_name}') has been related with: {', '.join(props)}")
         noqa_print(f"The relation will only be added to the first attribute ('{first(props)}') want to continue?")
 
         if _prompt_user_menu([("yes", "yes"), ("no", "no")]) == "no":

--- a/test/unit_tests/cli/test_domain_gen_helpers.py
+++ b/test/unit_tests/cli/test_domain_gen_helpers.py
@@ -1,0 +1,85 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from orchestrator.core.cli.domain_gen_helpers.helpers import (
+    _block_type_matches,
+    format_block_relation_to_dict,
+    map_create_product_block_relations,
+)
+from orchestrator.core.domain.base import ProductBlockModel
+
+
+class LeafA(ProductBlockModel, product_block_name="LeafA"):
+    a: int | None = None
+
+
+class LeafB(ProductBlockModel, product_block_name="LeafB"):
+    b: int | None = None
+
+
+class LeafC(ProductBlockModel, product_block_name="LeafC"):
+    c: int | None = None
+
+
+class ContainerBlockInactive(ProductBlockModel, product_block_name="ContainerBlock"):
+    # Non-Optional union: `_get_depends_on_product_block_types` yields a tuple of types.
+    union_block: LeafA | LeafB | None = None
+    single_block: LeafC | None = None
+
+
+class ContainerBlock(ContainerBlockInactive):
+    union_block: LeafA | LeafB
+    single_block: LeafC
+
+
+MODELS = {"ContainerBlock": ContainerBlock}
+
+@pytest.mark.parametrize(
+    "block_type, block_to_find, expected",
+    [
+        pytest.param(LeafA, "LeafA", True, id="single-match"),
+        pytest.param(LeafA, "LeafB", False, id="single-no-match"),
+        pytest.param((LeafA, LeafB), "LeafA", True, id="union-match-first"),
+        pytest.param((LeafA, LeafB), "LeafB", True, id="union-match-second"),
+        pytest.param((LeafA, LeafB), "LeafC", False, id="union-no-match"),
+        pytest.param((), "LeafA", False, id="empty-tuple"),
+    ],
+)
+def test_block_type_matches(block_type, block_to_find, expected):
+    assert _block_type_matches(block_type, block_to_find) is expected
+
+
+@pytest.mark.parametrize(
+    "block_to_find, expected_attribute",
+    [
+        pytest.param("LeafC", "single_block", id="single-block-relation"),
+        # Regression: a union member must resolve to the union attribute instead of crashing.
+        pytest.param("LeafA", "union_block", id="union-block-relation-first-member"),
+        pytest.param("LeafB", "union_block", id="union-block-relation-second-member"),
+    ],
+)
+def test_format_block_relation_to_dict_resolves_attribute(block_to_find, expected_attribute):
+    result = format_block_relation_to_dict("ContainerBlock", block_to_find, MODELS, confirm_warnings=False)
+
+    assert result == {"name": "ContainerBlock", "attribute_name": expected_attribute}
+
+
+def test_map_create_product_block_relations_handles_union_member():
+    """End-to-end mapper call that previously raised AttributeError on the tuple value."""
+    model_diffs = {"ContainerBlock": {"missing_product_blocks_in_db": {"LeafB"}}}
+
+    relations = map_create_product_block_relations(model_diffs, MODELS, confirm_warnings=False)
+
+    assert relations == {"LeafB": [{"name": "ContainerBlock", "attribute_name": "union_block"}]}


### PR DESCRIPTION
## Summary
- Fixes `db migrate-domain-models` crashing with AttributeError: `tuple` object has no attribute `name` by handling product-block fields typed as non-Optional unions (e.g. `port: CorePortBlock | CoreLAGPortBlock`),
  which `_get_depends_on_product_block_types` returns as a tuple of types.
- Adds a `_block_type_matches` helper in `domain_gen_helpers/helpers.py` plus `test_domain_gen_helpers.py` covering single, union, no-match, and empty-tuple cases.

## Related Issues
Fixes #1506 
