### PR TITLE
Fix date comparisons in search endpoints

### DIFF
--- a/orchestrator/core/search/filters/date_filters.py
+++ b/orchestrator/core/search/filters/date_filters.py
@@ -26,8 +26,7 @@ def _validate_date_string(v: Any) -> Any:
     if not isinstance(v, str):
         return v
     try:
-        datetime.fromisoformat(v)
-        return v
+        return datetime.fromisoformat(v)
     except Exception as exc:
         raise ValueError("is not a valid ISO-8601 date or datetime string") from exc
 

--- a/test/unit_tests/search/filters/test_date_filters.py
+++ b/test/unit_tests/search/filters/test_date_filters.py
@@ -57,9 +57,9 @@ _COMPARISON_OPS_AND_SQL = [
         pytest.param("2025-01-01T00:00:00+00:00", id="datetime-tz"),
     ],
 )
-def test_validate_date_string_valid_iso_strings_pass_through(value: str) -> None:
+def test_validate_date_string_valid_iso_strings_coerced_to_datetime(value: str) -> None:
     result = _validate_date_string(value)
-    assert result == value
+    assert result == datetime.fromisoformat(value)
 
 
 @pytest.mark.parametrize(
@@ -108,8 +108,8 @@ def test_validate_date_string_non_string_passes_through_unchanged(value: object)
 )
 def test_date_range_valid_constructs(start: str, end: str) -> None:
     r = DateRange(start=start, end=end)
-    assert r.start == start
-    assert r.end == end
+    assert r.start == datetime.fromisoformat(start)
+    assert r.end == datetime.fromisoformat(end)
 
 
 @pytest.mark.parametrize(
@@ -156,7 +156,7 @@ def test_date_range_invalid_date_raises_validation_error(start: str, end: str) -
 def test_date_value_filter_valid_ops_construct(op: FilterOp) -> None:
     f = DateValueFilter(op=op, value="2025-06-15")  # type: ignore[arg-type]
     assert f.op == op
-    assert f.value == "2025-06-15"
+    assert f.value == datetime(2025, 6, 15)
 
 
 @pytest.mark.parametrize(
@@ -199,8 +199,8 @@ def test_date_value_filter_to_expression_uses_timestamp_cast(op: FilterOp, sql_o
 def test_date_range_filter_valid_range_constructs() -> None:
     f = DateRangeFilter(op=FilterOp.BETWEEN, value=DateRange(start="2025-01-01", end="2025-12-31"))
     assert f.op == FilterOp.BETWEEN
-    assert f.value.start == "2025-01-01"
-    assert f.value.end == "2025-12-31"
+    assert f.value.start == datetime(2025, 1, 1)
+    assert f.value.end == datetime(2025, 12, 31)
 
 
 def test_date_range_filter_invalid_op_raises() -> None:

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -13,6 +13,7 @@
 
 """Tests for orchestrator.core.search.filters.elastic_dsl: Elasticsearch DSL to FilterTree conversion, including term, range, wildcard, exists, and bool queries."""
 
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -75,16 +76,16 @@ def test_term_preserves_path() -> None:
 
 
 @pytest.mark.parametrize(
-    "es_op, value, expected_filter_type, expected_op, expected_value_kind",
+    "es_op, value, expected_filter_type, expected_op, expected_value_kind, expected_value",
     [
-        pytest.param("gt", "2025-01-01", DateValueFilter, FilterOp.GT, UIType.DATETIME, id="date-gt"),
-        pytest.param("gte", "2025-06-15", DateValueFilter, FilterOp.GTE, UIType.DATETIME, id="date-gte"),
-        pytest.param("lt", "2025-12-31", DateValueFilter, FilterOp.LT, UIType.DATETIME, id="date-lt"),
-        pytest.param("lte", "2025-03-01", DateValueFilter, FilterOp.LTE, UIType.DATETIME, id="date-lte"),
-        pytest.param("gt", 100, NumericValueFilter, FilterOp.GT, UIType.NUMBER, id="num-gt"),
-        pytest.param("gte", 0, NumericValueFilter, FilterOp.GTE, UIType.NUMBER, id="num-gte"),
-        pytest.param("lt", 9999, NumericValueFilter, FilterOp.LT, UIType.NUMBER, id="num-lt"),
-        pytest.param("lte", 1000, NumericValueFilter, FilterOp.LTE, UIType.NUMBER, id="num-lte"),
+        pytest.param("gt", "2025-01-01", DateValueFilter, FilterOp.GT, UIType.DATETIME, datetime(2025, 1, 1), id="date-gt"),
+        pytest.param("gte", "2025-06-15", DateValueFilter, FilterOp.GTE, UIType.DATETIME, datetime(2025, 6, 15), id="date-gte"),
+        pytest.param("lt", "2025-12-31", DateValueFilter, FilterOp.LT, UIType.DATETIME, datetime(2025, 12, 31), id="date-lt"),
+        pytest.param("lte", "2025-03-01", DateValueFilter, FilterOp.LTE, UIType.DATETIME, datetime(2025, 3, 1), id="date-lte"),
+        pytest.param("gt", 100, NumericValueFilter, FilterOp.GT, UIType.NUMBER, 100, id="num-gt"),
+        pytest.param("gte", 0, NumericValueFilter, FilterOp.GTE, UIType.NUMBER, 0, id="num-gte"),
+        pytest.param("lt", 9999, NumericValueFilter, FilterOp.LT, UIType.NUMBER, 9999, id="num-lt"),
+        pytest.param("lte", 1000, NumericValueFilter, FilterOp.LTE, UIType.NUMBER, 1000, id="num-lte"),
     ],
 )
 def test_range_single_bound(
@@ -93,27 +94,35 @@ def test_range_single_bound(
     expected_filter_type: type,
     expected_op: FilterOp,
     expected_value_kind: UIType,
+    expected_value: Any,
 ) -> None:
     leaf = _parse_and_get_leaf({"range": {"field": {es_op: value}}})
     assert isinstance(leaf.condition, expected_filter_type)
     assert leaf.condition.op == expected_op
-    assert leaf.condition.value == value
+    assert leaf.condition.value == expected_value
     assert leaf.value_kind == expected_value_kind
 
 
 @pytest.mark.parametrize(
-    "start, end, expected_filter_type, expected_value_kind",
+    "start, end, expected_filter_type, expected_value_kind, expected_start, expected_end",
     [
-        pytest.param("2025-01-01", "2025-12-31", DateRangeFilter, UIType.DATETIME, id="date-between"),
-        pytest.param(100, 10000, NumericRangeFilter, UIType.NUMBER, id="numeric-between"),
+        pytest.param("2025-01-01", "2025-12-31", DateRangeFilter, UIType.DATETIME, datetime(2025, 1, 1), datetime(2025, 12, 31), id="date-between"),
+        pytest.param(100, 10000, NumericRangeFilter, UIType.NUMBER, 100, 10000, id="numeric-between"),
     ],
 )
-def test_range_between(start: Any, end: Any, expected_filter_type: type, expected_value_kind: UIType) -> None:
+def test_range_between(
+    start: Any,
+    end: Any,
+    expected_filter_type: type,
+    expected_value_kind: UIType,
+    expected_start: Any,
+    expected_end: Any,
+) -> None:
     leaf = _parse_and_get_leaf({"range": {"field": {"gte": start, "lte": end}}})
     assert isinstance(leaf.condition, expected_filter_type)
     assert leaf.condition.op == FilterOp.BETWEEN
-    assert leaf.condition.value.start == start
-    assert leaf.condition.value.end == end
+    assert leaf.condition.value.start == expected_start
+    assert leaf.condition.value.end == expected_end
     assert leaf.value_kind == expected_value_kind
 
 
@@ -338,11 +347,11 @@ def test_must_not_date_between_inverts_to_or() -> None:
     assert isinstance(lo, PathFilter)
     assert isinstance(lo.condition, DateValueFilter)
     assert lo.condition.op == FilterOp.LT
-    assert lo.condition.value == "2025-01-01"
+    assert lo.condition.value == datetime(2025, 1, 1)
     assert isinstance(hi, PathFilter)
     assert isinstance(hi.condition, DateValueFilter)
     assert hi.condition.op == FilterOp.GT
-    assert hi.condition.value == "2025-12-31"
+    assert hi.condition.value == datetime(2025, 12, 31)
 
 
 def test_must_not_wildcard_passes_through() -> None:


### PR DESCRIPTION
the dates are used in the DB as str for comparisons against datetime db types which breaks it.
the error that it returns: `operator does not exist: timestamp with time zone < character varying`
to fix it I changed `_validate_date_string` to return the iso formatted date.

Closes: https://github.com/workfloworchestrator/orchestrator-core/issues/1680