### PR TITLE
Support contains filter for search endpoints

### DIFF
--- a/orchestrator/core/schemas/search_requests.py
+++ b/orchestrator/core/schemas/search_requests.py
@@ -22,7 +22,7 @@ from orchestrator.core.search.query.mixins import StructuredOrderBy
 from orchestrator.core.search.query.queries import SelectQuery
 
 # Keys that identify an ES DSL query at the top level
-_ES_DSL_KEYS = frozenset({"term", "range", "wildcard", "exists", "bool"})
+_ES_DSL_KEYS = frozenset({"term", "range", "wildcard", "regexp", "exists", "bool"})
 _ES_QUERY_ADAPTER: TypeAdapter[ElasticQuery] = TypeAdapter(ElasticQuery)
 
 

--- a/orchestrator/core/search/core/types.py
+++ b/orchestrator/core/search/core/types.py
@@ -94,6 +94,9 @@ class FilterOp(str, Enum):
     NOT_HAS_COMPONENT = "not_has_component"  # Path doesn't contain segment
     ENDS_WITH = "ends_with"
 
+    CONTAINS = "regexp"
+    NOT_CONTAINS = "not_regexp"
+
 
 class EntityType(str, Enum):
     SUBSCRIPTION = "SUBSCRIPTION"

--- a/orchestrator/core/search/filters/__init__.py
+++ b/orchestrator/core/search/filters/__init__.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 from .base import (
+    ContainsFilter,
     EqualityFilter,
     FilterCondition,
     FilterTree,
@@ -30,6 +31,7 @@ __all__ = [
     "FilterTree",
     "FilterCondition",
     "StringFilter",
+    "ContainsFilter",
     "EqualityFilter",
     # Filters for specific value types
     "NumericValueFilter",

--- a/orchestrator/core/search/filters/base.py
+++ b/orchestrator/core/search/filters/base.py
@@ -58,11 +58,21 @@ class StringFilter(BaseModel):
         return self
 
 
+class ContainsFilter(BaseModel):
+    op: Literal[FilterOp.CONTAINS, FilterOp.NOT_CONTAINS]
+    value: str
+
+    def to_expression(self, column: SQLAColumn, path: str) -> ColumnElement[bool]:
+        expr = column.op("~*")(self.value)
+        return expr if self.op == FilterOp.CONTAINS else ~expr
+
+
 # Order matters! Ambiguous ops (like 'eq') are resolved by first matching filter
 FilterCondition = (
     DateFilter  # DATETIME
     | NumericFilter  # INT/FLOAT
     | StringFilter  # STRING TODO: convert to hybrid search?
+    | ContainsFilter  # STRING
     | LtreeFilter  # Path
     | EqualityFilter  # BOOLEAN/UUID/BLOCK/RESOURCE_TYPE - most generic, try last
 )

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from orchestrator.core.search.core.types import BooleanOperator, FieldType, FilterOp, UIType
 from orchestrator.core.search.filters.base import (
+    ContainsFilter,
     EqualityFilter,
     FilterTree,
     PathFilter,
@@ -46,6 +47,8 @@ _INVERT_OP: dict[FilterOp, FilterOp] = {
     FilterOp.GTE: FilterOp.LT,
     FilterOp.LT: FilterOp.GTE,
     FilterOp.LTE: FilterOp.GT,
+    FilterOp.CONTAINS: FilterOp.NOT_CONTAINS,
+    FilterOp.NOT_CONTAINS: FilterOp.CONTAINS,
 }
 
 
@@ -90,6 +93,12 @@ class WildcardQuery(BaseModel):
     wildcard: dict[str, dict[str, str]] = Field(min_length=1, max_length=1)
 
 
+class RegexpQuery(BaseModel):
+    """``{"regexp": {"field": "pattern"}}`` or ``{"regexp": {"field": {"value": "pattern"}}}``."""
+
+    regexp: dict[str, Any] = Field(min_length=1, max_length=1)
+
+
 class ExistsQuery(BaseModel):
     """``{"exists": {"field": "name"}}``."""
 
@@ -115,7 +124,7 @@ class BoolClause(BaseModel):
 
 
 ElasticQuery = Annotated[
-    TermQuery | RangeQuery | WildcardQuery | ExistsQuery | BoolQuery,
+    TermQuery | RangeQuery | WildcardQuery | RegexpQuery | ExistsQuery | BoolQuery,
     Field(discriminator=None),
 ]
 
@@ -187,6 +196,17 @@ def _translate_wildcard(query: WildcardQuery) -> PathFilter:
     )
 
 
+def _translate_regexp(query: RegexpQuery) -> PathFilter:
+    """Convert a regexp query to a PathFilter with ContainsFilter."""
+    field, spec = next(iter(query.regexp.items()))
+    pattern = spec.get("value", "") if isinstance(spec, dict) else str(spec)
+    return PathFilter(
+        path=field,
+        condition=ContainsFilter(op=FilterOp.CONTAINS, value=pattern),
+        value_kind=UIType.STRING,
+    )
+
+
 def _translate_exists(query: ExistsQuery) -> PathFilter:
     """Convert an exists query to a PathFilter with LtreeFilter(ENDS_WITH)."""
     field_name = query.exists["field"]
@@ -202,7 +222,7 @@ def _invert_path_filter(pf: PathFilter) -> PathFilter:
     match pf.condition:
         case EqualityFilter(op=op, value=value):
             return pf.model_copy(update={"condition": EqualityFilter(op=_INVERT_OP[op], value=value)})  # type: ignore[arg-type]
-        case DateValueFilter(op=op) | NumericValueFilter(op=op):
+        case DateValueFilter(op=op) | NumericValueFilter(op=op) | ContainsFilter(op=op):
             return pf.model_copy(update={"condition": pf.condition.model_copy(update={"op": _INVERT_OP[op]})})
         case _:
             # For range/string/ltree filters, we cannot simply invert.
@@ -230,7 +250,7 @@ def _invert_range_to_or(
 def _negate_node(node: FilterTree | PathFilter) -> FilterTree | PathFilter:
     """Negate a single translated node for must_not semantics."""
     match node:
-        case PathFilter(condition=EqualityFilter() | DateValueFilter() | NumericValueFilter()):
+        case PathFilter(condition=EqualityFilter() | DateValueFilter() | NumericValueFilter() | ContainsFilter()):
             return _invert_path_filter(node)
         case PathFilter(condition=DateRangeFilter(value=range_val)):
             return _invert_range_to_or(node, range_val, DateValueFilter)
@@ -254,6 +274,8 @@ def _translate_node(query: ElasticQuery) -> FilterTree | PathFilter:
             return _translate_range(query)
         case WildcardQuery():
             return _translate_wildcard(query)
+        case RegexpQuery():
+            return _translate_regexp(query)
         case ExistsQuery():
             return _translate_exists(query)
         case BoolQuery():

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -22,10 +22,11 @@ from pydantic import TypeAdapter, ValidationError
 from orchestrator.core.schemas.search_requests import SearchRequest
 from orchestrator.core.search.core.types import BooleanOperator, FilterOp, UIType
 from orchestrator.core.search.filters import FilterTree, PathFilter
-from orchestrator.core.search.filters.base import EqualityFilter, StringFilter
+from orchestrator.core.search.filters.base import ContainsFilter, EqualityFilter, StringFilter
 from orchestrator.core.search.filters.date_filters import DateRangeFilter, DateValueFilter
 from orchestrator.core.search.filters.elastic_dsl import (
     ElasticQuery,
+    _invert_path_filter,
     elastic_to_filter_tree,
 )
 from orchestrator.core.search.filters.ltree_filters import LtreeFilter
@@ -365,6 +366,19 @@ def test_must_not_wildcard_passes_through() -> None:
     assert leaf.condition.op == FilterOp.LIKE
 
 
+def test_invert_path_filter_non_invertible_passes_through() -> None:
+    """_invert_path_filter returns the PathFilter unchanged for non-invertible conditions."""
+    from orchestrator.core.search.core.types import UIType
+
+    pf = PathFilter(
+        path="description",
+        condition=StringFilter(op=FilterOp.LIKE, value="%fiber%"),
+        value_kind=UIType.STRING,
+    )
+    result = _invert_path_filter(pf)
+    assert result == pf
+
+
 def test_must_not_nested_bool_passes_through() -> None:
     """Complex sub-trees in must_not are passed through as-is."""
     es = ElasticQueryAdapter.validate_python(
@@ -546,3 +560,77 @@ def test_search_request_accepts_filter_tree() -> None:
 def test_search_request_accepts_none_filters() -> None:
     request = SearchRequest()
     assert request.filters is None
+
+
+# ---------------------------------------------------------------------------
+# contains queries (ES DSL: regexp)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "es_dsl, expected_pattern",
+    [
+        pytest.param(
+            {"regexp": {"description": ".*LIR.*"}},
+            ".*LIR.*",
+            id="string-value",
+        ),
+        pytest.param(
+            {"regexp": {"description": {"value": ".*LIR.*"}}},
+            ".*LIR.*",
+            id="dict-value",
+        ),
+        pytest.param(
+            {"regexp": {"subscription.description": {"value": "^surf.*"}}},
+            "^surf.*",
+            id="dotted-path-dict-value",
+        ),
+    ],
+)
+def test_contains_translation(es_dsl: dict[str, Any], expected_pattern: str) -> None:
+    leaf = _parse_and_get_leaf(es_dsl)
+    assert isinstance(leaf.condition, ContainsFilter)
+    assert leaf.condition.op == FilterOp.CONTAINS
+    assert leaf.condition.value == expected_pattern
+    assert leaf.value_kind == UIType.STRING
+
+
+def test_contains_multi_field_raises() -> None:
+    with pytest.raises(ValidationError, match="too_long"):
+        ElasticQueryAdapter.validate_python({"regexp": {"a": "x", "b": "y"}})
+
+
+def test_must_not_contains_inverts_to_not_contains() -> None:
+    leaf = _parse_and_get_leaf({"bool": {"must_not": [{"regexp": {"description": ".*LIR.*"}}]}})
+    assert isinstance(leaf.condition, ContainsFilter)
+    assert leaf.condition.op == FilterOp.NOT_CONTAINS
+    assert leaf.condition.value == ".*LIR.*"
+
+
+def test_must_not_not_contains_inverts_to_contains() -> None:
+    es = ElasticQueryAdapter.validate_python(
+        {
+            "bool": {
+                "must_not": [
+                    {
+                        "regexp": {"description": ".*LIR.*"},
+                    }
+                ]
+            }
+        }
+    )
+    tree = elastic_to_filter_tree(es)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert isinstance(leaf.condition, ContainsFilter)
+    assert leaf.condition.op == FilterOp.NOT_CONTAINS
+
+
+def test_search_request_accepts_contains_filter() -> None:
+    request = SearchRequest(filters={"regexp": {"subscription.description": {"value": ".*fiber.*"}}})  # type: ignore[arg-type]
+    assert isinstance(request.filters, FilterTree)
+    assert len(request.filters.children) == 1
+    leaf = request.filters.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert isinstance(leaf.condition, ContainsFilter)
+    assert leaf.condition.op == FilterOp.CONTAINS

--- a/test/unit_tests/search/filters/test_filters.py
+++ b/test/unit_tests/search/filters/test_filters.py
@@ -15,9 +15,10 @@
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import String, column
 
 from orchestrator.core.search.core.types import BooleanOperator, FilterOp
-from orchestrator.core.search.filters import FilterTree, PathFilter, StringFilter
+from orchestrator.core.search.filters import ContainsFilter, FilterTree, PathFilter, StringFilter
 
 pytestmark = pytest.mark.search
 
@@ -128,3 +129,37 @@ def test_get_all_paths_from_nested_tree(nested_filter_tree: FilterTree) -> None:
 def test_get_all_leaves_from_nested_tree(nested_filter_tree: FilterTree) -> None:
     leaves = nested_filter_tree.get_all_leaves()
     assert len(leaves) == 3
+
+
+# ---------------------------------------------------------------------------
+# ContainsFilter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(FilterOp.CONTAINS, id="contains"),
+        pytest.param(FilterOp.NOT_CONTAINS, id="not-contains"),
+    ],
+)
+def test_contains_filter_valid(op) -> None:
+    f = ContainsFilter(op=op, value=".*LIR.*")
+    assert f.op == op
+    assert f.value == ".*LIR.*"
+
+
+@pytest.mark.parametrize(
+    "op, expect_not",
+    [
+        pytest.param(FilterOp.CONTAINS, False, id="contains"),
+        pytest.param(FilterOp.NOT_CONTAINS, True, id="not-contains"),
+    ],
+)
+def test_contains_filter_to_expression_sql(op, expect_not) -> None:
+    f = ContainsFilter(op=op, value=".*LIR.*")
+    expr = f.to_expression(column("value", String), "path")
+    sql = str(expr.compile(compile_kwargs={"literal_binds": True}))
+    assert "~*" in sql
+    assert "LIR" in sql
+    assert ("NOT" in sql.upper()) == expect_not


### PR DESCRIPTION
- convert elastic dsl 'regexp' to contains filtering in postgresql.
- add unit tests.

Closes: https://github.com/workfloworchestrator/orchestrator-core/issues/1687