### PR TITLE
Process broadcast fn invalidate subscription cache

### DIFF
--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -133,7 +133,131 @@ When using the Celery executor, you'll need to do this again for the worker inst
 
 Below is an example implementation of a Celery worker with Websocket support, which can be updated to your project's needs.
 
-=== "`orchestrator-core` ≥ 5.0"
+=== "`orchestrator-core` > 5.0"
+
+    !!! note "Default `process_broadcast_fn`"
+
+        In the first release after 5.0, `orchestrator-core` ships a default `process_broadcast_fn` that
+        the Celery worker uses automatically — you no longer need to define one. Besides broadcasting the
+        process update, the default invalidates the related subscription caches when a process ends in a
+        failed/aborted state (work the workflow's `resync` step skips on failure).
+
+        This is a breaking change: `BroadcastFunc` now receives the full `ProcessTable` instead of a
+        `process_id`. Only define your own `process_broadcast_fn` to customise behaviour (see below).
+
+    ```python
+    """This module contains functions and classes necessary for celery worker processes.
+
+    The application flow looks like this when EXECUTOR = "celery" (and websockets are enabled):
+
+    - FastAPI application validates form input, and places a task on celery queue (create new process).
+    - If websockets are enabled, a connection should exist already b/t the client and backend.
+    - FastAPI application begins watching Redis pubsub channel for process updates from celery.
+    - Celery worker picks up task from queue and begins executing.
+    - On each step completion, it publishes state information to Redis pubsub channel.
+    - FastAPI application grabs this information and publishes it to the client websocket connection.
+    """
+
+    from structlog import get_logger
+
+    from celery import Celery
+    from celery.signals import task_postrun, worker_shutting_down
+    from nwastdlib.debugging import start_debugger
+    from orchestrator.core.db import init_database
+    from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
+    from orchestrator.core.websocket import init_websocket_manager
+    from orchestrator.core.websocket.websocket_manager import WebSocketManager
+    from orchestrator.core.workflows import ALL_WORKFLOWS
+
+    # Substitute your_orch with your org's Orchestrator instance.
+    # class AppSettings(OrchSettings):
+    #     ...
+    #
+    # app_settings = AppSettings()
+    from your_orch.settings import app_settings
+
+
+    logger = get_logger(__name__)
+
+    @task_postrun.connect
+    def cleanup_session_after_task(**kwargs: Any) -> None:
+        """Prevent idle-in-transaction connections after Celery task completion.
+
+        psycopg3 autobegin starts implicit transactions on any query. If code
+        executes queries outside a transactional() context (e.g., during model
+        serialization after a workflow step), those transactions are never
+        committed/rolled back. This handler ensures cleanup after every task.
+        """
+        db.session.rollback()
+        db.scoped_session.remove()
+
+
+    class OrchestratorWorker(Celery):
+        websocket_manager: WebSocketManager
+
+        def on_init(self) -> None:
+            # Depending on how you gate your debug settings, you can do something like this:
+            # if app_settings.DEBUG:
+            #     start_debugger()
+
+            init_database(app_settings)
+
+            # Prepare the wrapped_websocket_manager
+            # Note: cannot prepare the redis connections here as broadcasting is async
+            self.websocket_manager = init_websocket_manager(app_settings)
+            # No process_broadcast_fn needed: the core default is used automatically.
+
+            # Load the product and workflow modules to register them with the application
+            import your_orch.products
+            import your_orch.workflows
+
+            # If you have custom SQLAlchemy models, register them here
+            from orchestrator.core.app import OrchestratorCore
+            from orchestrator.core.db import SubscriptionTable
+            from your_orch.db.models import MySubscriptionTable
+
+            OrchestratorCore.register_table(SubscriptionTable, MySubscriptionTable)
+
+
+        def close(self) -> None:
+            super().close()
+
+
+    celery = OrchestratorWorker(
+        f"{app_settings.SERVICE_NAME}-worker", broker=str(app_settings.CACHE_URI.get_secret_value()), include=["orchestrator.core.services.tasks"]
+    )
+
+    if app_settings.TESTING:
+        celery.conf.update(backend=str(app_settings.CACHE_URI.get_secret_value()), task_ignore_result=False)
+    else:
+        celery.conf.update(task_ignore_result=True)
+
+    celery.conf.update(
+        result_expires=3600,
+        worker_prefetch_multiplier=1,
+        worker_send_task_event=True,
+        task_send_sent_event=True,
+    )
+    ```
+
+    To customise broadcasting, define `process_broadcast_fn` and delegate to the core default so you keep
+    the standard behaviour (including subscription-cache invalidation) without duplicating it:
+
+    ```python
+    from orchestrator.core.db.models import ProcessTable
+    from orchestrator.core.services.process_broadcast_thread import (
+        process_broadcast_fn as default_process_broadcast_fn,
+    )
+
+    def process_broadcast_fn(process: ProcessTable) -> None:
+        default_process_broadcast_fn(process)
+        # ... your additional broadcasting ...
+
+    # then assign it in OrchestratorWorker.on_init:
+    #     self.process_broadcast_fn = process_broadcast_fn
+    ```
+
+=== "`orchestrator-core` 5.0"
 
     ```python
     """This module contains functions and classes necessary for celery worker processes.

--- a/orchestrator/core/services/process_broadcast_thread.py
+++ b/orchestrator/core/services/process_broadcast_thread.py
@@ -100,11 +100,8 @@ def _broadcast_queue_put_fn(broadcast_queue: BroadcastQueue, process: "ProcessTa
 def process_broadcast_fn(process: "ProcessTable") -> None:
     """Default Celery-worker broadcast callback.
 
-    Broadcasts the process update to connected websocket clients and, for terminal
-    failure/abort states, invalidates the caches of the related subscriptions. On the happy
-    path the workflow's `resync` step already invalidates those caches; for the statuses in
-    `UPDATE_SUB_STATUSES` that step is skipped, so re-issue the invalidation here to avoid a
-    stale UI. Provided in core so consumers get correct behaviour without copy-pasting it.
+    Broadcasts the process update and, for `UPDATE_SUB_STATUSES`, invalidates the related
+    subscription caches so the UI reflects the final state.
     """
     # Catch all exceptions as broadcasting failure is noncritical to workflow completion
     try:

--- a/orchestrator/core/services/process_broadcast_thread.py
+++ b/orchestrator/core/services/process_broadcast_thread.py
@@ -25,6 +25,7 @@ from orchestrator.core.websocket import (
     WS_CHANNELS,
     broadcast_process_update_to_websocket,
     broadcast_process_update_to_websocket_async,
+    invalidate_subscription_cache,
     sync_invalidate_subscription_cache,
     websocket_manager,
 )
@@ -35,7 +36,9 @@ if TYPE_CHECKING:
     from orchestrator.core.db.models import ProcessTable
     from orchestrator.core.graphql.types import OrchestratorInfo
 
-BroadcastQueue = queue.Queue[UUID]
+# (process_id, subscription ids whose caches must be invalidated)
+BroadcastQueueItem = tuple[UUID, list[UUID]]
+BroadcastQueue = queue.Queue[BroadcastQueueItem]
 
 logger = structlog.get_logger(__name__)
 
@@ -54,16 +57,23 @@ class ProcessDataBroadcastThread(threading.Thread):
 
             while not self.shutdown:
                 try:
-                    process_id = self.queue.get(block=True, timeout=1)
+                    item = self.queue.get(block=True, timeout=1)
                 except queue.Empty:
                     continue
                 logger.debug(
                     "Threadsafe broadcast process update through websocket manager",
-                    process_id=process_id,
+                    item=item,
                     where="ProcessDataBroadcastThread",
                     channels=WS_CHANNELS.EVENTS,
                 )
-                loop.run_until_complete(broadcast_process_update_to_websocket_async(process_id))
+                # Guard per-item so a single malformed item or failed broadcast doesn't kill the thread
+                try:
+                    process_id, subscription_ids = item
+                    loop.run_until_complete(broadcast_process_update_to_websocket_async(process_id))
+                    for subscription_id in subscription_ids:
+                        loop.run_until_complete(invalidate_subscription_cache(subscription_id))
+                except Exception:
+                    logger.exception("Failed to broadcast process update", item=item)
 
             loop.close()
             logger.info("Shutdown ProcessDataBroadcastThread")
@@ -89,10 +99,17 @@ def _broadcast_ws_fn(process: "ProcessTable") -> None:
         logger.exception("Failed to send process data to websocket")
 
 
+def _subscription_ids_to_invalidate(process: "ProcessTable") -> list[UUID]:
+    """For `UPDATE_SUB_STATUSES`, the related subscription caches must be invalidated so the UI reflects the final state."""
+    if process.last_status in UPDATE_SUB_STATUSES:
+        return [ps.subscription_id for ps in process.process_subscriptions]
+    return []
+
+
 def _broadcast_queue_put_fn(broadcast_queue: BroadcastQueue, process: "ProcessTable") -> None:
     # Catch all exceptions as broadcasting failure is noncritical to workflow completion
     try:
-        broadcast_queue.put(process.process_id)
+        broadcast_queue.put((process.process_id, _subscription_ids_to_invalidate(process)))
     except Exception:
         logger.exception("An error occurred when putting process_id on broadcast queue")
 
@@ -101,9 +118,8 @@ def _invalidate_subscription_caches_fn(process: "ProcessTable") -> None:
     """For `UPDATE_SUB_STATUSES`, invalidate the related subscription caches so the UI reflects the final state."""
     # Catch all exceptions as cache invalidation failure is noncritical to workflow completion
     try:
-        if process.last_status in UPDATE_SUB_STATUSES:
-            for subscription in process.process_subscriptions:
-                sync_invalidate_subscription_cache(subscription.subscription_id)
+        for subscription_id in _subscription_ids_to_invalidate(process):
+            sync_invalidate_subscription_cache(subscription_id)
     except Exception:
         logger.exception("Failed to invalidate subscription caches")
 
@@ -135,9 +151,8 @@ def api_broadcast_process_data(request: Request) -> BroadcastFunc:
     resume_process, etc. through the `broadcast_func` param.
     """
     if request.app.broadcast_thread:
-        return _with_invalidate_subscription_caches(
-            partial(_broadcast_queue_put_fn, request.app.broadcast_thread.queue)
-        )
+        # Subscription cache invalidation travels with the queue item and is broadcast by the thread
+        return partial(_broadcast_queue_put_fn, request.app.broadcast_thread.queue)
 
     if websocket_manager.enabled:
         return _with_invalidate_subscription_caches(_broadcast_ws_fn)
@@ -153,8 +168,9 @@ def graphql_broadcast_process_data(info: "OrchestratorInfo") -> BroadcastFunc:
     resume_process, etc. through the `broadcast_func` param.
     """
     if info.context.broadcast_thread:
+        # Subscription cache invalidation travels with the queue item and is broadcast by the thread
         broadcast_queue: BroadcastQueue = info.context.broadcast_thread.queue
-        return _with_invalidate_subscription_caches(partial(_broadcast_queue_put_fn, broadcast_queue))
+        return partial(_broadcast_queue_put_fn, broadcast_queue)
 
     if websocket_manager.enabled:
         return _with_invalidate_subscription_caches(_broadcast_ws_fn)

--- a/orchestrator/core/services/process_broadcast_thread.py
+++ b/orchestrator/core/services/process_broadcast_thread.py
@@ -25,11 +25,14 @@ from orchestrator.core.websocket import (
     WS_CHANNELS,
     broadcast_process_update_to_websocket,
     broadcast_process_update_to_websocket_async,
+    sync_invalidate_subscription_cache,
     websocket_manager,
 )
 from orchestrator.core.websocket.websocket_manager import WebSocketManager
+from orchestrator.core.workflow import UPDATE_SUB_STATUSES
 
 if TYPE_CHECKING:
+    from orchestrator.core.db.models import ProcessTable
     from orchestrator.core.graphql.types import OrchestratorInfo
 
 BroadcastQueue = queue.Queue[UUID]
@@ -74,24 +77,43 @@ class ProcessDataBroadcastThread(threading.Thread):
         self.is_alive()
 
 
-def _nop(_process_id: UUID) -> None:
+def _nop(_process: "ProcessTable") -> None:
     pass
 
 
-def _broadcast_ws_fn(process_id: UUID) -> None:
+def _broadcast_ws_fn(process: "ProcessTable") -> None:
     # Catch all exceptions as broadcasting failure is noncritical to workflow completion
     try:
-        broadcast_process_update_to_websocket(process_id)
+        broadcast_process_update_to_websocket(process.process_id)
     except Exception:
         logger.exception("Failed to send process data to websocket")
 
 
-def _broadcast_queue_put_fn(broadcast_queue: BroadcastQueue, process_id: UUID) -> None:
+def _broadcast_queue_put_fn(broadcast_queue: BroadcastQueue, process: "ProcessTable") -> None:
     # Catch all exceptions as broadcasting failure is noncritical to workflow completion
     try:
-        broadcast_queue.put(process_id)
+        broadcast_queue.put(process.process_id)
     except Exception:
         logger.exception("An error occurred when putting process_id on broadcast queue")
+
+
+def process_broadcast_fn(process: "ProcessTable") -> None:
+    """Default Celery-worker broadcast callback.
+
+    Broadcasts the process update to connected websocket clients and, for terminal
+    failure/abort states, invalidates the caches of the related subscriptions. On the happy
+    path the workflow's `resync` step already invalidates those caches; for the statuses in
+    `UPDATE_SUB_STATUSES` that step is skipped, so re-issue the invalidation here to avoid a
+    stale UI. Provided in core so consumers get correct behaviour without copy-pasting it.
+    """
+    # Catch all exceptions as broadcasting failure is noncritical to workflow completion
+    try:
+        broadcast_process_update_to_websocket(process.process_id)
+        if process.last_status in UPDATE_SUB_STATUSES:
+            for subscription in process.process_subscriptions:
+                sync_invalidate_subscription_cache(subscription.subscription_id)
+    except Exception as e:
+        logger.exception(e)
 
 
 def api_broadcast_process_data(request: Request) -> BroadcastFunc:

--- a/orchestrator/core/services/process_broadcast_thread.py
+++ b/orchestrator/core/services/process_broadcast_thread.py
@@ -97,20 +97,35 @@ def _broadcast_queue_put_fn(broadcast_queue: BroadcastQueue, process: "ProcessTa
         logger.exception("An error occurred when putting process_id on broadcast queue")
 
 
+def _invalidate_subscription_caches_fn(process: "ProcessTable") -> None:
+    """For `UPDATE_SUB_STATUSES`, invalidate the related subscription caches so the UI reflects the final state."""
+    # Catch all exceptions as cache invalidation failure is noncritical to workflow completion
+    try:
+        if process.last_status in UPDATE_SUB_STATUSES:
+            for subscription in process.process_subscriptions:
+                sync_invalidate_subscription_cache(subscription.subscription_id)
+    except Exception:
+        logger.exception("Failed to invalidate subscription caches")
+
+
+def _with_invalidate_subscription_caches(broadcast_fn: BroadcastFunc) -> BroadcastFunc:
+    """Compose a broadcast callable with subscription cache invalidation."""
+
+    def _broadcast_and_invalidate(process: "ProcessTable") -> None:
+        broadcast_fn(process)
+        _invalidate_subscription_caches_fn(process)
+
+    return _broadcast_and_invalidate
+
+
 def process_broadcast_fn(process: "ProcessTable") -> None:
     """Default Celery-worker broadcast callback.
 
     Broadcasts the process update and, for `UPDATE_SUB_STATUSES`, invalidates the related
     subscription caches so the UI reflects the final state.
     """
-    # Catch all exceptions as broadcasting failure is noncritical to workflow completion
-    try:
-        broadcast_process_update_to_websocket(process.process_id)
-        if process.last_status in UPDATE_SUB_STATUSES:
-            for subscription in process.process_subscriptions:
-                sync_invalidate_subscription_cache(subscription.subscription_id)
-    except Exception as e:
-        logger.exception(e)
+    _broadcast_ws_fn(process)
+    _invalidate_subscription_caches_fn(process)
 
 
 def api_broadcast_process_data(request: Request) -> BroadcastFunc:
@@ -120,10 +135,12 @@ def api_broadcast_process_data(request: Request) -> BroadcastFunc:
     resume_process, etc. through the `broadcast_func` param.
     """
     if request.app.broadcast_thread:
-        return partial(_broadcast_queue_put_fn, request.app.broadcast_thread.queue)
+        return _with_invalidate_subscription_caches(
+            partial(_broadcast_queue_put_fn, request.app.broadcast_thread.queue)
+        )
 
     if websocket_manager.enabled:
-        return _broadcast_ws_fn
+        return _with_invalidate_subscription_caches(_broadcast_ws_fn)
 
     logger.debug("WebSocketManager is not enabled. Using no-op broadcasting fn")
     return _nop
@@ -137,10 +154,10 @@ def graphql_broadcast_process_data(info: "OrchestratorInfo") -> BroadcastFunc:
     """
     if info.context.broadcast_thread:
         broadcast_queue: BroadcastQueue = info.context.broadcast_thread.queue
-        return partial(_broadcast_queue_put_fn, broadcast_queue)
+        return _with_invalidate_subscription_caches(partial(_broadcast_queue_put_fn, broadcast_queue))
 
     if websocket_manager.enabled:
-        return _broadcast_ws_fn
+        return _with_invalidate_subscription_caches(_broadcast_ws_fn)
 
     logger.debug("WebSocketManager is not enabled. Using no-op broadcasting fn")
     return _nop

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -341,7 +341,7 @@ def _db_log_step(
     db.session.add(current_step)
 
     if broadcast_func:
-        broadcast_func(p.process_id)
+        broadcast_func(p)
 
     return process_state.__class__(current_step.state)
 

--- a/orchestrator/core/services/tasks.py
+++ b/orchestrator/core/services/tasks.py
@@ -24,6 +24,7 @@ from orchestrator.core.db import db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.schemas.engine_settings import WorkerStatus
 from orchestrator.core.services.executors.threadpool import thread_resume_process, thread_start_process
+from orchestrator.core.services.process_broadcast_thread import process_broadcast_fn as default_process_broadcast_fn
 from orchestrator.core.services.processes import _get_process, ensure_correct_process_status, load_process
 from orchestrator.core.types import BroadcastFunc
 from orchestrator.core.utils.json import json_dumps, json_loads
@@ -68,7 +69,9 @@ def initialise_celery(celery: Celery) -> None:  # noqa: C901
 
     register_custom_serializer()
 
-    process_broadcast_fn: BroadcastFunc | None = getattr(celery, "process_broadcast_fn", None)
+    # Use the consumer-supplied callback if present, otherwise the correct core default so
+    # workers invalidate subscription caches on failed/aborted processes out of the box.
+    process_broadcast_fn: BroadcastFunc = getattr(celery, "process_broadcast_fn", None) or default_process_broadcast_fn
 
     def start_process(process_id: UUID, user: str) -> UUID | None:
         try:

--- a/orchestrator/core/types.py
+++ b/orchestrator/core/types.py
@@ -27,7 +27,6 @@ from typing import (
     get_args,
     get_origin,
 )
-from uuid import UUID
 
 import strawberry
 from annotated_types import Len, MaxLen, MinLen
@@ -55,6 +54,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
+    from orchestrator.core.db.models import ProcessTable
     from orchestrator.core.domain.base import ProductBlockModel
 
 
@@ -73,7 +73,7 @@ ErrorState = Union[str, Exception, tuple[str, Union[int, HTTPStatus]]]
 ErrorDict = dict[str, Union[str, int, list[dict[str, Any]], InputForm, None]]
 StateStepFunc = Callable[[State], State]
 StepFunc = Callable[..., Optional[State]]
-BroadcastFunc = Callable[[UUID], None]
+BroadcastFunc = Callable[["ProcessTable"], None]
 
 SI = TypeVar("SI")
 

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -668,6 +668,19 @@ class ProcessStatus(strEnum):
     RESUMED = "resumed"
 
 
+# Terminal statuses that skip the workflow's `resync` step, so its subscription-cache
+# invalidation never runs. The default `process_broadcast_fn` re-issues it for these to
+# avoid a stale UI after a failed/aborted process.
+UPDATE_SUB_STATUSES = frozenset(
+    {
+        ProcessStatus.FAILED,
+        ProcessStatus.INCONSISTENT_DATA,
+        ProcessStatus.API_UNAVAILABLE,
+        ProcessStatus.ABORTED,
+    }
+)
+
+
 class StepStatus(strEnum):
     SUCCESS = "success"
     SKIPPED = "skipped"

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -668,11 +668,13 @@ class ProcessStatus(strEnum):
     RESUMED = "resumed"
 
 
-# Terminal statuses that skip the workflow's `resync` step, so its subscription-cache
-# invalidation never runs. The default `process_broadcast_fn` re-issues it for these to
-# avoid a stale UI after a failed/aborted process.
+# Statuses for which the default `process_broadcast_fn` (re-)invalidates the related
+# subscription caches, so the UI reflects the final state once a process reaches them.
+# The failure/abort statuses skip the workflow's `resync` step (which normally does this);
+# COMPLETED is included so a successful RUNNING -> COMPLETED transition also refreshes the UI.
 UPDATE_SUB_STATUSES = frozenset(
     {
+        ProcessStatus.COMPLETED,
         ProcessStatus.FAILED,
         ProcessStatus.INCONSISTENT_DATA,
         ProcessStatus.API_UNAVAILABLE,

--- a/test/unit_tests/services/test_process_broadcast_thread.py
+++ b/test/unit_tests/services/test_process_broadcast_thread.py
@@ -83,14 +83,34 @@ def test_broadcast_ws_fn_swallows_exceptions():
 # ---------------------------------------------------------------------------
 
 
-def test_broadcast_queue_put_fn_puts_process_id_on_queue():
-    process = _make_process(ProcessStatus.RUNNING, [])
+def test_broadcast_queue_put_fn_puts_item_without_subscription_ids_for_running_status():
+    process = _make_process(ProcessStatus.RUNNING, [uuid4()])
     broadcast_queue: queue.Queue = queue.Queue()
 
     _broadcast_queue_put_fn(broadcast_queue, process)
 
     assert not broadcast_queue.empty()
-    assert broadcast_queue.get_nowait() == process.process_id
+    assert broadcast_queue.get_nowait() == (process.process_id, [])
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ProcessStatus.COMPLETED,
+        ProcessStatus.FAILED,
+        ProcessStatus.INCONSISTENT_DATA,
+        ProcessStatus.API_UNAVAILABLE,
+        ProcessStatus.ABORTED,
+    ],
+)
+def test_broadcast_queue_put_fn_puts_subscription_ids_for_update_sub_status(status):
+    sub_ids = [uuid4(), uuid4()]
+    process = _make_process(status, sub_ids)
+    broadcast_queue: queue.Queue = queue.Queue()
+
+    _broadcast_queue_put_fn(broadcast_queue, process)
+
+    assert broadcast_queue.get_nowait() == (process.process_id, sub_ids)
 
 
 def test_broadcast_queue_put_fn_swallows_exceptions():
@@ -100,6 +120,19 @@ def test_broadcast_queue_put_fn_swallows_exceptions():
 
     # Must not raise
     _broadcast_queue_put_fn(bad_queue, process)
+
+
+def test_broadcast_queue_put_fn_swallows_subscription_lookup_exceptions():
+    class _RaisingProcess:
+        process_id = uuid4()
+        last_status = ProcessStatus.FAILED
+
+        @property
+        def process_subscriptions(self):
+            raise RuntimeError("session detached")
+
+    # Must not raise
+    _broadcast_queue_put_fn(queue.Queue(), _RaisingProcess())
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +195,7 @@ def test_api_broadcast_process_data_returns_queue_fn_when_broadcast_thread_prese
     # Verify it's bound to the right queue by calling it
     process = _make_process(ProcessStatus.RUNNING, [])
     result(process)
-    assert mock_queue.get_nowait() == process.process_id
+    assert mock_queue.get_nowait() == (process.process_id, [])
 
 
 def test_api_broadcast_process_data_returns_ws_fn_when_no_thread_but_ws_enabled():
@@ -184,7 +217,8 @@ def test_api_broadcast_process_data_returns_ws_fn_when_no_thread_but_ws_enabled(
     [ProcessStatus.COMPLETED, ProcessStatus.FAILED, ProcessStatus.ABORTED],
 )
 @patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
-def test_api_broadcast_process_data_invalidates_subscriptions_on_update_sub_status(mock_invalidate, status):
+def test_api_broadcast_process_data_defers_invalidation_to_broadcast_thread(mock_invalidate, status):
+    """With a broadcast thread, invalidation must travel through the queue, not run in the calling thread."""
     mock_request = MagicMock()
     mock_queue: queue.Queue = queue.Queue()
     mock_request.app.broadcast_thread = MagicMock()
@@ -195,32 +229,22 @@ def test_api_broadcast_process_data_invalidates_subscriptions_on_update_sub_stat
 
     api_broadcast_process_data(mock_request)(process)
 
-    assert mock_queue.get_nowait() == process.process_id
-    assert {call.args[0] for call in mock_invalidate.call_args_list} == set(sub_ids)
+    assert mock_queue.get_nowait() == (process.process_id, sub_ids)
+    mock_invalidate.assert_not_called()
 
 
 @patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
 def test_api_broadcast_process_data_skips_invalidation_on_running_status(mock_invalidate):
     mock_request = MagicMock()
+    mock_queue: queue.Queue = queue.Queue()
     mock_request.app.broadcast_thread = MagicMock()
-    mock_request.app.broadcast_thread.queue = queue.Queue()
+    mock_request.app.broadcast_thread.queue = mock_queue
 
-    api_broadcast_process_data(mock_request)(_make_process(ProcessStatus.RUNNING, [uuid4()]))
+    process = _make_process(ProcessStatus.RUNNING, [uuid4()])
+    api_broadcast_process_data(mock_request)(process)
 
+    assert mock_queue.get_nowait() == (process.process_id, [])
     mock_invalidate.assert_not_called()
-
-
-@patch(
-    "orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache",
-    side_effect=RuntimeError("cache failure"),
-)
-def test_api_broadcast_process_data_swallows_invalidation_exceptions(mock_invalidate):
-    mock_request = MagicMock()
-    mock_request.app.broadcast_thread = MagicMock()
-    mock_request.app.broadcast_thread.queue = queue.Queue()
-
-    # Must not raise even though cache invalidation fails
-    api_broadcast_process_data(mock_request)(_make_process(ProcessStatus.FAILED, [uuid4()]))
 
 
 def test_api_broadcast_process_data_returns_nop_when_no_thread_and_ws_disabled():
@@ -290,13 +314,94 @@ def test_process_data_broadcast_thread_processes_queue_item(mock_ws_manager):
         thread = ProcessDataBroadcastThread(mock_ws_manager, daemon=True)
         thread.start()
 
-        thread.queue.put(process_id)
+        thread.queue.put((process_id, []))
         # Give the thread time to process the item
         time.sleep(0.2)
 
         thread.stop()
 
     mock_async_broadcast.assert_called_with(process_id)
+
+
+def test_process_data_broadcast_thread_invalidates_subscription_caches(mock_ws_manager):
+    process_id = uuid4()
+    sub_ids = [uuid4(), uuid4()]
+
+    async def _noop_coroutine():
+        return None
+
+    with (
+        patch(
+            "orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket_async",
+            side_effect=lambda _pid: _noop_coroutine(),
+        ),
+        patch(
+            "orchestrator.core.services.process_broadcast_thread.invalidate_subscription_cache",
+            side_effect=lambda _sid: _noop_coroutine(),
+        ) as mock_invalidate,
+    ):
+        thread = ProcessDataBroadcastThread(mock_ws_manager, daemon=True)
+        thread.start()
+
+        thread.queue.put((process_id, sub_ids))
+        # Give the thread time to process the item
+        time.sleep(0.2)
+
+        thread.stop()
+
+    assert [call.args[0] for call in mock_invalidate.call_args_list] == sub_ids
+
+
+def test_process_data_broadcast_thread_survives_malformed_item(mock_ws_manager):
+    """Regression: a malformed queue item killed the thread, stopping all real-time process updates."""
+    process_id = uuid4()
+
+    async def _noop_coroutine():
+        return None
+
+    with patch(
+        "orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket_async",
+        side_effect=lambda _pid: _noop_coroutine(),
+    ) as mock_async_broadcast:
+        thread = ProcessDataBroadcastThread(mock_ws_manager, daemon=True)
+        thread.start()
+
+        thread.queue.put(uuid4())  # malformed: bare UUID instead of (process_id, subscription_ids)
+        thread.queue.put((process_id, []))
+        # Give the thread time to process both items
+        time.sleep(0.2)
+
+        assert thread.is_alive()
+        thread.stop()
+
+    mock_async_broadcast.assert_called_with(process_id)
+
+
+def test_process_data_broadcast_thread_survives_broadcast_exception(mock_ws_manager):
+    first_process_id, second_process_id = uuid4(), uuid4()
+
+    async def _failing_coroutine():
+        raise RuntimeError("broadcaster down")
+
+    async def _noop_coroutine():
+        return None
+
+    with patch(
+        "orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket_async",
+        side_effect=[_failing_coroutine(), _noop_coroutine()],
+    ) as mock_async_broadcast:
+        thread = ProcessDataBroadcastThread(mock_ws_manager, daemon=True)
+        thread.start()
+
+        thread.queue.put((first_process_id, []))
+        thread.queue.put((second_process_id, []))
+        # Give the thread time to process both items
+        time.sleep(0.2)
+
+        assert thread.is_alive()
+        thread.stop()
+
+    mock_async_broadcast.assert_called_with(second_process_id)
 
 
 def test_process_data_broadcast_thread_queue_is_isolated_between_instances(mock_ws_manager):

--- a/test/unit_tests/services/test_process_broadcast_thread.py
+++ b/test/unit_tests/services/test_process_broadcast_thread.py
@@ -27,8 +27,19 @@ from orchestrator.core.services.process_broadcast_thread import (
     _broadcast_ws_fn,
     _nop,
     api_broadcast_process_data,
+    process_broadcast_fn,
 )
 from orchestrator.core.websocket.websocket_manager import WebSocketManager
+from orchestrator.core.workflow import ProcessStatus
+
+
+def _make_process(last_status, subscription_ids):
+    process = MagicMock()
+    process.process_id = uuid4()
+    process.last_status = last_status
+    process.process_subscriptions = [MagicMock(subscription_id=sid) for sid in subscription_ids]
+    return process
+
 
 # ---------------------------------------------------------------------------
 # _nop
@@ -36,14 +47,14 @@ from orchestrator.core.websocket.websocket_manager import WebSocketManager
 
 
 def test_nop_returns_none():
-    process_id = uuid4()
-    result = _nop(process_id)
+    process = _make_process(ProcessStatus.RUNNING, [])
+    result = _nop(process)
     assert result is None
 
 
-def test_nop_accepts_any_uuid():
+def test_nop_accepts_any_process():
     for _ in range(5):
-        _nop(uuid4())  # must not raise
+        _nop(_make_process(ProcessStatus.RUNNING, []))  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -52,20 +63,20 @@ def test_nop_accepts_any_uuid():
 
 
 def test_broadcast_ws_fn_calls_broadcast_process_update():
-    process_id = uuid4()
+    process = _make_process(ProcessStatus.RUNNING, [])
     with patch("orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket") as mock_fn:
-        _broadcast_ws_fn(process_id)
-    mock_fn.assert_called_once_with(process_id)
+        _broadcast_ws_fn(process)
+    mock_fn.assert_called_once_with(process.process_id)
 
 
 def test_broadcast_ws_fn_swallows_exceptions():
-    process_id = uuid4()
+    process = _make_process(ProcessStatus.RUNNING, [])
     with patch(
         "orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket",
         side_effect=RuntimeError("ws failure"),
     ):
         # Must not raise
-        _broadcast_ws_fn(process_id)
+        _broadcast_ws_fn(process)
 
 
 # ---------------------------------------------------------------------------
@@ -74,22 +85,62 @@ def test_broadcast_ws_fn_swallows_exceptions():
 
 
 def test_broadcast_queue_put_fn_puts_process_id_on_queue():
-    process_id = uuid4()
+    process = _make_process(ProcessStatus.RUNNING, [])
     broadcast_queue: queue.Queue = queue.Queue()
 
-    _broadcast_queue_put_fn(broadcast_queue, process_id)
+    _broadcast_queue_put_fn(broadcast_queue, process)
 
     assert not broadcast_queue.empty()
-    assert broadcast_queue.get_nowait() == process_id
+    assert broadcast_queue.get_nowait() == process.process_id
 
 
 def test_broadcast_queue_put_fn_swallows_exceptions():
-    process_id = uuid4()
+    process = _make_process(ProcessStatus.RUNNING, [])
     bad_queue = MagicMock()
     bad_queue.put.side_effect = RuntimeError("queue full")
 
     # Must not raise
-    _broadcast_queue_put_fn(bad_queue, process_id)
+    _broadcast_queue_put_fn(bad_queue, process)
+
+
+# ---------------------------------------------------------------------------
+# process_broadcast_fn (default Celery-worker broadcast callback)
+# ---------------------------------------------------------------------------
+
+
+@patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
+@patch("orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket")
+def test_process_broadcast_fn_invalidates_subscriptions_on_failed_status(mock_broadcast, mock_invalidate):
+    sub_ids = [uuid4(), uuid4()]
+    process = _make_process(ProcessStatus.FAILED, sub_ids)
+
+    process_broadcast_fn(process)
+
+    mock_broadcast.assert_called_once_with(process.process_id)
+    assert {call.args[0] for call in mock_invalidate.call_args_list} == set(sub_ids)
+
+
+@patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
+@patch("orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket")
+def test_process_broadcast_fn_skips_invalidation_on_running_status(mock_broadcast, mock_invalidate):
+    process = _make_process(ProcessStatus.RUNNING, [uuid4()])
+
+    process_broadcast_fn(process)
+
+    mock_broadcast.assert_called_once_with(process.process_id)
+    mock_invalidate.assert_not_called()
+
+
+@patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
+@patch(
+    "orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket",
+    side_effect=RuntimeError("ws failure"),
+)
+def test_process_broadcast_fn_swallows_exceptions(mock_broadcast, mock_invalidate):
+    process = _make_process(ProcessStatus.FAILED, [uuid4()])
+
+    # Must not raise even though broadcasting fails
+    process_broadcast_fn(process)
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +159,9 @@ def test_api_broadcast_process_data_returns_partial_when_broadcast_thread_presen
     assert isinstance(result, partial)
 
     # Verify it's bound to the right queue by calling it
-    process_id = uuid4()
-    result(process_id)
-    assert mock_queue.get_nowait() == process_id
+    process = _make_process(ProcessStatus.RUNNING, [])
+    result(process)
+    assert mock_queue.get_nowait() == process.process_id
 
 
 def test_api_broadcast_process_data_returns_ws_fn_when_no_thread_but_ws_enabled():

--- a/test/unit_tests/services/test_process_broadcast_thread.py
+++ b/test/unit_tests/services/test_process_broadcast_thread.py
@@ -108,11 +108,15 @@ def test_broadcast_queue_put_fn_swallows_exceptions():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "status",
+    [ProcessStatus.COMPLETED, ProcessStatus.FAILED, ProcessStatus.ABORTED],
+)
 @patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
 @patch("orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket")
-def test_process_broadcast_fn_invalidates_subscriptions_on_failed_status(mock_broadcast, mock_invalidate):
+def test_process_broadcast_fn_invalidates_subscriptions_on_update_sub_status(mock_broadcast, mock_invalidate, status):
     sub_ids = [uuid4(), uuid4()]
-    process = _make_process(ProcessStatus.FAILED, sub_ids)
+    process = _make_process(status, sub_ids)
 
     process_broadcast_fn(process)
 

--- a/test/unit_tests/services/test_process_broadcast_thread.py
+++ b/test/unit_tests/services/test_process_broadcast_thread.py
@@ -15,7 +15,6 @@
 
 import queue
 import time
-from functools import partial
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -152,15 +151,13 @@ def test_process_broadcast_fn_swallows_exceptions(mock_broadcast, mock_invalidat
 # ---------------------------------------------------------------------------
 
 
-def test_api_broadcast_process_data_returns_partial_when_broadcast_thread_present():
+def test_api_broadcast_process_data_returns_queue_fn_when_broadcast_thread_present():
     mock_request = MagicMock()
     mock_queue: queue.Queue = queue.Queue()
     mock_request.app.broadcast_thread = MagicMock()
     mock_request.app.broadcast_thread.queue = mock_queue
 
     result = api_broadcast_process_data(mock_request)
-
-    assert isinstance(result, partial)
 
     # Verify it's bound to the right queue by calling it
     process = _make_process(ProcessStatus.RUNNING, [])
@@ -176,7 +173,54 @@ def test_api_broadcast_process_data_returns_ws_fn_when_no_thread_but_ws_enabled(
         mock_ws_manager.enabled = True
         result = api_broadcast_process_data(mock_request)
 
-    assert result is _broadcast_ws_fn
+    process = _make_process(ProcessStatus.RUNNING, [])
+    with patch("orchestrator.core.services.process_broadcast_thread.broadcast_process_update_to_websocket") as mock_fn:
+        result(process)
+    mock_fn.assert_called_once_with(process.process_id)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [ProcessStatus.COMPLETED, ProcessStatus.FAILED, ProcessStatus.ABORTED],
+)
+@patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
+def test_api_broadcast_process_data_invalidates_subscriptions_on_update_sub_status(mock_invalidate, status):
+    mock_request = MagicMock()
+    mock_queue: queue.Queue = queue.Queue()
+    mock_request.app.broadcast_thread = MagicMock()
+    mock_request.app.broadcast_thread.queue = mock_queue
+
+    sub_ids = [uuid4(), uuid4()]
+    process = _make_process(status, sub_ids)
+
+    api_broadcast_process_data(mock_request)(process)
+
+    assert mock_queue.get_nowait() == process.process_id
+    assert {call.args[0] for call in mock_invalidate.call_args_list} == set(sub_ids)
+
+
+@patch("orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache")
+def test_api_broadcast_process_data_skips_invalidation_on_running_status(mock_invalidate):
+    mock_request = MagicMock()
+    mock_request.app.broadcast_thread = MagicMock()
+    mock_request.app.broadcast_thread.queue = queue.Queue()
+
+    api_broadcast_process_data(mock_request)(_make_process(ProcessStatus.RUNNING, [uuid4()]))
+
+    mock_invalidate.assert_not_called()
+
+
+@patch(
+    "orchestrator.core.services.process_broadcast_thread.sync_invalidate_subscription_cache",
+    side_effect=RuntimeError("cache failure"),
+)
+def test_api_broadcast_process_data_swallows_invalidation_exceptions(mock_invalidate):
+    mock_request = MagicMock()
+    mock_request.app.broadcast_thread = MagicMock()
+    mock_request.app.broadcast_thread.queue = queue.Queue()
+
+    # Must not raise even though cache invalidation fails
+    api_broadcast_process_data(mock_request)(_make_process(ProcessStatus.FAILED, [uuid4()]))
 
 
 def test_api_broadcast_process_data_returns_nop_when_no_thread_and_ws_disabled():


### PR DESCRIPTION
## Summary

 Invalidate subscription caches on terminal process statuses via a core-default `process_broadcast_fn`

### Problem
Subscription data went stale in the UI after a process finished. The workflow's `resync` step invalidates the subscription cache, but it runs while the process is still `RUNNING` (`resync >> done`), so the refetched data reflects `RUNNING` — and nothing re-invalidates once the process reaches `COMPLETED`. Failed/aborted processes are worse: they skip `resync` entirely, so their subscription caches were never invalidated.

### Changes

-   Ship a default `process_broadcast_fn` in core that the Celery worker uses automatically — no consumer wiring needed. It broadcasts the process update and, for the statuses in `UPDATE_SUB_STATUSES`, invalidates the related subscription caches.
- `UPDATE_SUB_STATUSES` now includes `COMPLETED` (alongside `FAILED`, `ABORTED`, `INCONSISTENT_DATA`, `API_UNAVAILABLE`), so a successful `RUNNING` → `COMPLETED` transition re-invalidates the cache at the `done` step and the UI reflects the final state.
- `BroadcastFunc` now receives the full `ProcessTable` instead of a `process_id`.
- Updated the Celery worker example in `docs/guides/scaling.md`.

### Breaking Change

BroadcastFunc signature changed from `Callable[[UUID], None]` to `Callable[[ProcessTable], None]`. Consumers with a custom `process_broadcast_fn` must update the signature; most can drop their custom callback and rely on the core default (delegate to it if extending — see `scaling.md`).

See #1624 