### PR TITLE
Bug process status stays on running instead of failed

### DIFF
--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -43,7 +43,11 @@ from orchestrator.core.types import BroadcastFunc
 from orchestrator.core.utils.datetime import nowtz
 from orchestrator.core.utils.errors import StartPredicateError, error_state_to_dict
 from orchestrator.core.utils.json import json_dumps, json_loads
-from orchestrator.core.websocket import broadcast_invalidate_status_counts, broadcast_process_update_to_websocket
+from orchestrator.core.websocket import (
+    broadcast_invalidate_status_counts,
+    broadcast_process_update_to_websocket,
+    sync_invalidate_subscription_cache_by_id,
+)
 from orchestrator.core.workflow import (
     CALLBACK_TOKEN_KEY,
     DEFAULT_CALLBACK_PROGRESS_KEY,
@@ -72,6 +76,17 @@ logger = structlog.get_logger(__name__)
 StateMerger = Merger([(dict, ["merge"])], ["override"], ["override"])
 
 SYSTEM_USER = "SYSTEM"
+
+# Terminal statuses that skip the workflow's `resync` step, so its subscription-cache
+# invalidation never runs. `_db_log_step` re-issues the invalidation for these to avoid a stale UI.
+UPDATE_SUB_STATUSES = frozenset(
+    {
+        ProcessStatus.FAILED,
+        ProcessStatus.INCONSISTENT_DATA,
+        ProcessStatus.API_UNAVAILABLE,
+        ProcessStatus.ABORTED,
+    }
+)
 
 _workflow_executor = None
 _active_threadpool_jobs = 0
@@ -342,6 +357,10 @@ def _db_log_step(
 
     if broadcast_func:
         broadcast_func(p.process_id)
+
+    if p.last_status in UPDATE_SUB_STATUSES:
+        for subscription_id in {ps.subscription_id for ps in p.process_subscriptions}:
+            sync_invalidate_subscription_cache_by_id(subscription_id)
 
     return process_state.__class__(current_step.state)
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -77,10 +77,13 @@ StateMerger = Merger([(dict, ["merge"])], ["override"], ["override"])
 
 SYSTEM_USER = "SYSTEM"
 
-# Terminal statuses that skip the workflow's `resync` step, so its subscription-cache
-# invalidation never runs. `_db_log_step` re-issues the invalidation for these to avoid a stale UI.
-UPDATE_SUB_STATUSES = frozenset(
+# Terminal process statuses. Every in-step cache invalidation (`unsync`/`resync`) runs while the
+# process is still RUNNING, so the cache never reflects the terminal status: `done` sets COMPLETED
+# without invalidating, and failed/aborted processes skip `resync` entirely. `_db_log_step` re-issues
+# the invalidation when a process reaches one of these to avoid a stale UI.
+TERMINAL_SUB_STATUSES = frozenset(
     {
+        ProcessStatus.COMPLETED,
         ProcessStatus.FAILED,
         ProcessStatus.INCONSISTENT_DATA,
         ProcessStatus.API_UNAVAILABLE,
@@ -358,7 +361,7 @@ def _db_log_step(
     if broadcast_func:
         broadcast_func(p.process_id)
 
-    if p.last_status in UPDATE_SUB_STATUSES:
+    if p.last_status in TERMINAL_SUB_STATUSES:
         for subscription_id in {ps.subscription_id for ps in p.process_subscriptions}:
             sync_invalidate_subscription_cache_by_id(subscription_id)
 

--- a/orchestrator/core/websocket/__init__.py
+++ b/orchestrator/core/websocket/__init__.py
@@ -107,6 +107,14 @@ async def invalidate_subscription_cache(subscription_id: UUID | UUIDstr, invalid
     await broadcast_invalidate_cache({"type": "subscriptions", "id": str(subscription_id)})
 
 
+def sync_invalidate_subscription_cache_by_id(subscription_id: UUID | UUIDstr) -> None:
+    anyio.run(invalidate_subscription_cache_by_id, subscription_id)
+
+
+async def invalidate_subscription_cache_by_id(subscription_id: UUID | UUIDstr) -> None:
+    await broadcast_invalidate_cache({"type": "subscriptions", "id": str(subscription_id)})
+
+
 async def broadcast_invalidate_status_counts_async() -> None:
     """Broadcast message to invalidate the status counts of the connected websocket clients.
 

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -662,18 +662,22 @@ def process_with_subscription(simple_workflow, generic_subscription_1):
 @pytest.mark.parametrize(
     "state, expected_status",
     [
-        (Failed(Exception("boom")).on_failed(error_state_to_dict), ProcessStatus.FAILED),
-        (Abort({"foo": "bar"}), ProcessStatus.ABORTED),
+        pytest.param(Failed(Exception("boom")).on_failed(error_state_to_dict), ProcessStatus.FAILED, id="failed"),
+        pytest.param(Abort({"foo": "bar"}), ProcessStatus.ABORTED, id="aborted"),
+        pytest.param(Complete({"foo": "bar"}), ProcessStatus.COMPLETED, id="completed"),
     ],
 )
 @mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
-def test_db_log_step_invalidates_subscription_cache_on_failed_end_state(
+def test_db_log_step_invalidates_subscription_cache_on_terminal_end_state(
     mock_invalidate, process_with_subscription, state, expected_status
 ):
-    """Invalidate subscription caches when a process ends in a failed/aborted state.
+    """Invalidate subscription caches when a process reaches a terminal status.
 
-    Such processes skip the workflow's `resync` step, so `_db_log_step` must invalidate the
-    related subscription caches itself (otherwise the UI keeps the stale status).
+    Every in-step cache invalidation (`unsync`/`resync`) runs while the process is still
+    RUNNING, so the cache never reflects the terminal status — `done` (COMPLETED) sets it
+    without invalidating, and failed/aborted processes skip `resync` entirely. `_db_log_step`
+    must invalidate the related subscription caches itself, otherwise the UI keeps the stale
+    RUNNING status.
     """
     process_id, subscription_id = process_with_subscription
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
@@ -690,18 +694,18 @@ def test_db_log_step_invalidates_subscription_cache_on_failed_end_state(
 @pytest.mark.parametrize(
     "state",
     [
-        Success({"foo": "bar"}),
-        Complete({"foo": "bar"}),
-        Suspend({"foo": "bar"}),
+        pytest.param(Success({"foo": "bar"}), id="success-running"),
+        pytest.param(Suspend({"foo": "bar"}), id="suspended"),
     ],
 )
 @mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
-def test_db_log_step_does_not_invalidate_subscription_cache_on_non_failed_state(
+def test_db_log_step_does_not_invalidate_subscription_cache_on_non_terminal_state(
     mock_invalidate, process_with_subscription, state
 ):
-    """Do not invalidate subscription caches for running/completed/suspended states.
+    """Do not invalidate subscription caches for non-terminal states.
 
-    The happy path is already handled by the workflow's `resync` step.
+    A running (`Success`) or suspended process has not reached its final status yet, so there
+    is nothing terminal to reflect — invalidating here would only add cache churn mid-workflow.
     """
     process_id, _ = process_with_subscription
     pstat = ProcessStat(process_id, None, None, None, current_user="user")

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -662,7 +662,7 @@ def process_with_subscription(simple_workflow, generic_subscription_1):
 @pytest.mark.parametrize(
     "state, expected_status",
     [
-        pytest.param(Failed(Exception("boom")).on_failed(error_state_to_dict), ProcessStatus.FAILED, id="failed"),
+        pytest.param(Failed(error_state_to_dict(Exception("boom"))), ProcessStatus.FAILED, id="failed"),
         pytest.param(Abort({"foo": "bar"}), ProcessStatus.ABORTED, id="aborted"),
         pytest.param(Complete({"foo": "bar"}), ProcessStatus.COMPLETED, id="completed"),
     ],

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 from orchestrator.core.api.error_handling import ProblemDetailException
 from orchestrator.core.config.assignee import Assignee
-from orchestrator.core.db import ProcessStepTable, ProcessTable, db
+from orchestrator.core.db import ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.services.executors.threadpool import thread_start_process
@@ -641,6 +641,75 @@ def test_process_log_db_step_complete(simple_workflow):
     assert p.last_step == "step"
     assert p.failed_reason is None
     assert p.assignee == "assignee"
+
+
+@pytest.fixture
+def process_with_subscription(simple_workflow, generic_subscription_1):
+    """A CREATED process linked to a single existing subscription."""
+    process_id = uuid4()
+    p = ProcessTable(
+        process_id=process_id,
+        workflow_id=simple_workflow.workflow_id,
+        last_status=ProcessStatus.CREATED,
+        created_by=SYSTEM_USER,
+    )
+    db.session.add(p)
+    db.session.add(ProcessSubscriptionTable(process_id=process_id, subscription_id=generic_subscription_1))
+    db.session.commit()
+    return process_id, generic_subscription_1
+
+
+@pytest.mark.parametrize(
+    "state, expected_status",
+    [
+        (Failed(Exception("boom")).on_failed(error_state_to_dict), ProcessStatus.FAILED),
+        (Abort({"foo": "bar"}), ProcessStatus.ABORTED),
+    ],
+)
+@mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
+def test_db_log_step_invalidates_subscription_cache_on_failed_end_state(
+    mock_invalidate, process_with_subscription, state, expected_status
+):
+    """Invalidate subscription caches when a process ends in a failed/aborted state.
+
+    Such processes skip the workflow's `resync` step, so `_db_log_step` must invalidate the
+    related subscription caches itself (otherwise the UI keeps the stale status).
+    """
+    process_id, subscription_id = process_with_subscription
+    pstat = ProcessStat(process_id, None, None, None, current_user="user")
+    step = make_step_function(lambda: None, "step", None, Assignee.SYSTEM)
+
+    result = _db_log_step(pstat, step, state)
+
+    assert result.overall_status == expected_status
+    mock_invalidate.assert_called_once()
+    (called_subscription_id,) = mock_invalidate.call_args.args
+    assert str(called_subscription_id) == str(subscription_id)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        Success({"foo": "bar"}),
+        Complete({"foo": "bar"}),
+        Suspend({"foo": "bar"}),
+    ],
+)
+@mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
+def test_db_log_step_does_not_invalidate_subscription_cache_on_non_failed_state(
+    mock_invalidate, process_with_subscription, state
+):
+    """Do not invalidate subscription caches for running/completed/suspended states.
+
+    The happy path is already handled by the workflow's `resync` step.
+    """
+    process_id, _ = process_with_subscription
+    pstat = ProcessStat(process_id, None, None, None, current_user="user")
+    step = make_step_function(lambda: None, "step", None, Assignee.SYSTEM)
+
+    _db_log_step(pstat, step, state)
+
+    mock_invalidate.assert_not_called()
 
 
 def test_process_log_db_step_no_process_id(simple_workflow):

--- a/test/unit_tests/websocket/test_websocket_init.py
+++ b/test/unit_tests/websocket/test_websocket_init.py
@@ -29,6 +29,7 @@ from orchestrator.core.websocket import (
     empty_fn,
     init_websocket_manager,
     invalidate_subscription_cache,
+    invalidate_subscription_cache_by_id,
     is_process_active,
     sync_broadcast_invalidate_cache,
     sync_invalidate_subscription_cache,
@@ -169,6 +170,21 @@ async def test_invalidate_subscription_cache(invalidate_all: bool, expected_call
         mock_wsm.broadcast_data = AsyncMock()
         await invalidate_subscription_cache(uuid4(), invalidate_all=invalidate_all)
         assert mock_wsm.broadcast_data.await_count == expected_call_count
+
+
+@pytest.mark.asyncio
+async def test_invalidate_subscription_cache_by_id():
+    """It must invalidate only the one subscription, not the LIST or the whole `subscriptions` type."""
+    subscription_id = uuid4()
+    with patch("orchestrator.core.websocket.websocket_manager") as mock_wsm:
+        mock_wsm.broadcast_data = AsyncMock()
+
+        await invalidate_subscription_cache_by_id(subscription_id)
+
+        mock_wsm.broadcast_data.assert_awaited_once_with(
+            [WS_CHANNELS.EVENTS],
+            {"name": "invalidateCache", "value": {"type": "subscriptions", "id": str(subscription_id)}},
+        )
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -2658,7 +2658,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-core"
-version = "5.0.4"
+version = "5.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

  Fixes stale subscription status in the UI when a workflow ends. Every in-step cache invalidation (`unsync`/`resync`) runs while the process is still `RUNNING`, so the websocket cache never reflected the terminal status: `done` sets `COMPLETED` without invalidating, and failed/aborted
  processes skip `resync` entirely. As a result the UI kept showing the subscription's process as `Running` after the workflow had failed (or completed).

  ### Changes:
  - `_db_log_step` now broadcasts a cache invalidation for each related subscription when the process reaches a terminal status (`COMPLETED`, `FAILED`, `INCONSISTENT_DATA`, `API_UNAVAILABLE`, `ABORTED`).
  - Added `invalidate_subscription_cache_by_id` (and a sync wrapper) to `orchestrator.core.websocket`, which invalidates only the single subscription's cache entry rather than the whole `subscriptions` type.
  - Tests: parameterized integration tests verifying invalidation fires for terminal end states (`Failed`/`Abort`/`Complete`) and not for non-terminal ones (`Success`/`Suspend`), plus a unit test for the new websocket broadcast.

### As opposed to proposed change in issue

  1. **No breaking change.** The other approach changes the `BroadcastFunc` signature from `UUID` to `ProcessTable`, breaking every consumer that copy-pasted `process_broadcast_fn` from the docs. The current branch leaves that contract untouched and can ship in a patch release.

  2. **Guaranteed correctness in one place.** `_db_log_step` is the single point every executor passes through when the terminal status is written, so one hook covers all paths — versus patching three broadcast paths (queue thread, direct websocket, Celery callback) where a consumer
  overriding `process_broadcast_fn` would silently lose the invalidation.

  ## Related Issue
  Fixes #1624 