### PR TITLE
Support single query object in bool clause of search endpoints

### DIFF
--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from orchestrator.core.search.core.types import BooleanOperator, FieldType, FilterOp, UIType
 from orchestrator.core.search.filters.base import (
@@ -115,6 +115,12 @@ class BoolClause(BaseModel):
     must: list[ElasticQuery] = Field(default_factory=list)
     should: list[ElasticQuery] = Field(default_factory=list)
     must_not: list[ElasticQuery] = Field(default_factory=list)
+
+    @field_validator("must", "should", "must_not", mode="before")
+    @classmethod
+    def _coerce_single_to_list(cls, v: Any) -> Any:
+        """Accept a single query object where ES also allows a list."""
+        return [v] if isinstance(v, dict) else v
 
     @model_validator(mode="after")
     def _validate_not_empty(self) -> BoolClause:

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -330,6 +330,23 @@ def test_range_no_recognised_bounds_raises() -> None:
         elastic_to_filter_tree(es)
 
 
+@pytest.mark.parametrize(
+    "clause_key",
+    [
+        pytest.param("must", id="must"),
+        pytest.param("should", id="should"),
+        pytest.param("must_not", id="must_not"),
+    ],
+)
+def test_bool_clause_accepts_single_query_object(clause_key: str) -> None:
+    """A bare query dict (not wrapped in a list) is accepted, matching ES behaviour."""
+    es = ElasticQueryAdapter.validate_python(
+        {"bool": {clause_key: {"term": {"subscription.status": "active"}}}}
+    )
+    tree = elastic_to_filter_tree(es)
+    assert len(tree.children) == 1
+
+
 # ---------------------------------------------------------------------------
 # must_not edge cases
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2658,7 +2658,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-core"
-version = "5.0.4"
+version = "5.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
The bool clause only allows for lists whilst it should also allow a single object.  
added a field validator that converts single objects into a list.

[you can find more about bool clause in elastic docs](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-bool-query)  
  
Closes: https://github.com/workfloworchestrator/orchestrator-core/issues/1649