### PR TITLE
feat: add workflow guide endpoint

### DIFF
--- a/orchestrator/core/api/api_v1/api.py
+++ b/orchestrator/core/api/api_v1/api.py
@@ -31,6 +31,7 @@ from orchestrator.core.api.api_v1.endpoints import (
     subscriptions,
     translations,
     user,
+    workflow_guides,
     workflows,
     ws,
 )
@@ -87,6 +88,12 @@ api_router.include_router(
     translations.router,
     prefix="/translations",
     tags=["Core", "Translations"],
+)
+api_router.include_router(
+    workflow_guides.router,
+    prefix="/workflow_guides",
+    tags=["Core", "Workflow Guides"],
+    dependencies=[Depends(authorize)],
 )
 api_router.include_router(
     ws.router, prefix="/ws", tags=["Core", "Events"]

--- a/orchestrator/core/api/api_v1/endpoints/workflow_guides.py
+++ b/orchestrator/core/api/api_v1/endpoints/workflow_guides.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/orchestrator/core/api/api_v1/endpoints/workflow_guides.py
+++ b/orchestrator/core/api/api_v1/endpoints/workflow_guides.py
@@ -1,0 +1,32 @@
+# Copyright 2019-2020 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+
+from fastapi import Path
+from fastapi.routing import APIRouter
+
+from orchestrator.core.api.error_handling import raise_status
+from orchestrator.core.services.workflow_guides import get_workflow_guide
+
+router = APIRouter()
+
+
+@router.get("/{workflow_name}", response_model=str)
+def get_workflow_guide_by_name(
+    workflow_name: str = Path(..., pattern=r"^[a-z][a-z0-9_]*$"),
+) -> str:
+    guide = get_workflow_guide(workflow_name)
+    if guide is None:
+        raise_status(HTTPStatus.NOT_FOUND, f"No workflow guide found for '{workflow_name}'")
+    return guide

--- a/orchestrator/core/services/workflow_guides.py
+++ b/orchestrator/core/services/workflow_guides.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/orchestrator/core/services/workflow_guides.py
+++ b/orchestrator/core/services/workflow_guides.py
@@ -1,0 +1,26 @@
+# Copyright 2019-2020 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from orchestrator.core.settings import app_settings
+
+
+def get_workflow_guide(workflow_name: str) -> str | None:
+    """Return the Markdown guide for a workflow, or None if not found."""
+    if not app_settings.WORKFLOW_GUIDE_DIR:
+        return None
+
+    guide_file = app_settings.WORKFLOW_GUIDE_DIR / f"{workflow_name}.md"
+    if not guide_file.exists():
+        return None
+
+    return guide_file.read_text(encoding="utf-8")

--- a/orchestrator/core/settings.py
+++ b/orchestrator/core/settings.py
@@ -99,6 +99,7 @@ class AppSettings(BaseSettings):
     TRACING_ENABLED: bool = False
     TRACE_HOST: str = "http://localhost:4317"
     TRANSLATIONS_DIR: Path | None = None
+    WORKFLOW_GUIDE_DIR: Path | None = None
     WEBSOCKET_BROADCASTER_URL: SecretStr = "memory://"  # type: ignore
     ENABLE_WEBSOCKETS: bool = True
     DISABLE_INSYNC_CHECK: bool = False

--- a/test/unit_tests/services/test_workflow_guides.py
+++ b/test/unit_tests/services/test_workflow_guides.py
@@ -1,0 +1,71 @@
+# Copyright 2019-2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import tempfile
+
+import pytest
+
+from orchestrator.core.services.workflow_guides import get_workflow_guide
+from orchestrator.core.settings import app_settings
+
+
+@pytest.fixture()
+def guide_dir():
+    """Temporary directory configured as WORKFLOW_GUIDE_DIR, restored after the test."""
+    original = app_settings.WORKFLOW_GUIDE_DIR
+    with tempfile.TemporaryDirectory() as tmp:
+        app_settings.WORKFLOW_GUIDE_DIR = pathlib.Path(tmp)
+        yield pathlib.Path(tmp)
+    app_settings.WORKFLOW_GUIDE_DIR = original
+
+
+@pytest.fixture()
+def no_guide_dir():
+    """Ensure WORKFLOW_GUIDE_DIR is None for the duration of the test."""
+    original = app_settings.WORKFLOW_GUIDE_DIR
+    app_settings.WORKFLOW_GUIDE_DIR = None
+    yield
+    app_settings.WORKFLOW_GUIDE_DIR = original
+
+
+def test_returns_none_when_guide_dir_not_configured(no_guide_dir):
+    assert get_workflow_guide("some_workflow") is None
+
+
+def test_returns_none_when_guide_file_missing(guide_dir):
+    assert get_workflow_guide("nonexistent_workflow") is None
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "content"),
+    [
+        pytest.param("create_network", "# Create Network\n\nStep 1: ...", id="simple-guide"),
+        pytest.param("modify_service", "# Modify Service\n\n- Step A\n- Step B", id="multiline-guide"),
+        pytest.param("empty_workflow", "", id="empty-file"),
+    ],
+)
+def test_returns_guide_content_when_file_exists(guide_dir, workflow_name, content):
+    (guide_dir / f"{workflow_name}.md").write_text(content, encoding="utf-8")
+    assert get_workflow_guide(workflow_name) == content
+
+
+def test_does_not_return_guide_for_different_workflow(guide_dir):
+    (guide_dir / "workflow_a.md").write_text("Guide A", encoding="utf-8")
+    assert get_workflow_guide("workflow_b") is None
+
+
+def test_guide_content_is_read_as_utf8(guide_dir):
+    content = "# Gids\n\nStap één: configureer het netwerk."
+    (guide_dir / "dutch_workflow.md").write_text(content, encoding="utf-8")
+    assert get_workflow_guide("dutch_workflow") == content


### PR DESCRIPTION
Adds GET /api/workflow_guides/{workflow_name} to serve Markdown user guides for workflows. Guides are read from a configurable directory set via the new WORKFLOW_GUIDE_DIR app setting (same pattern as TRANSLATIONS_DIR). Returns 404 when the setting is unset or no guide file exists for the requested workflow name.

## Summary
<!-- A summary of your changes -->

## Related Issues
Fixes # (issue number)

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [ ] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
