### PR TITLE
De-deprecate subscription workflows endpoint and enrich with subscription descriptions 

### DIFF
--- a/orchestrator/core/api/api_v1/endpoints/subscriptions.py
+++ b/orchestrator/core/api/api_v1/endpoints/subscriptions.py
@@ -51,7 +51,6 @@ from orchestrator.core.services.subscriptions import (
 from orchestrator.core.settings import app_settings
 from orchestrator.core.targets import Target
 from orchestrator.core.utils.auth import AuthContext
-from orchestrator.core.utils.deprecation_logger import deprecated_endpoint
 from orchestrator.core.utils.get_subscription_dict import get_subscription_dict
 from orchestrator.core.websocket import sync_invalidate_subscription_cache
 from orchestrator.core.workflows import get_workflow
@@ -182,9 +181,6 @@ def subscriptions_search(
     response_model=SubscriptionWorkflowListsSchema,
     response_model_by_alias=True,
     response_model_exclude_none=True,
-    deprecated=True,
-    description="This endpoint is deprecated and will be removed in a future release. Please use the GraphQL query",
-    dependencies=[Depends(deprecated_endpoint)],
 )
 def subscription_workflows_by_id(
     subscription_id: UUID, current_user: OIDCUserModel | None = Depends(authenticate)

--- a/orchestrator/core/schemas/__init__.py
+++ b/orchestrator/core/schemas/__init__.py
@@ -41,6 +41,7 @@ from orchestrator.core.schemas.subscription_descriptions import (
 )
 from orchestrator.core.schemas.workflow import (
     StepSchema,
+    SubscriptionRelationSchema,
     SubscriptionWorkflowListsSchema,
     WorkflowSchema,
 )
@@ -62,6 +63,7 @@ __all__ = (
     "SubscriptionDomainModelSchema",
     "SubscriptionDescriptionBaseSchema",
     "SubscriptionDescriptionSchema",
+    "SubscriptionRelationSchema",
     "SubscriptionSchema",
     "SubscriptionWorkflowListsSchema",
     "SubscriptionIdSchema",

--- a/orchestrator/core/schemas/workflow.py
+++ b/orchestrator/core/schemas/workflow.py
@@ -54,14 +54,18 @@ class WorkflowListItemSchema(OrchestratorBaseModel):
     usable_when: list[Any] | None = None
     status: str | None = None
     action: str | None = None
-    locked_relations: list[SubscriptionRelationSchema] | None = None
-    unterminated_parents: list[SubscriptionRelationSchema] | None = None
-    unterminated_in_use_by_subscriptions: list[SubscriptionRelationSchema] | None = None
+    locked_relations: list[UUID] | None = None
+    locked_relations_detail: list[SubscriptionRelationSchema] | None = None
+    unterminated_parents: list[UUID] | None = None
+    unterminated_parents_detail: list[SubscriptionRelationSchema] | None = None
+    unterminated_in_use_by_subscriptions: list[UUID] | None = None
+    unterminated_in_use_by_subscriptions_detail: list[SubscriptionRelationSchema] | None = None
 
 
 class SubscriptionWorkflowListsSchema(OrchestratorBaseModel):
     reason: str | None = None
-    locked_relations: list[SubscriptionRelationSchema] | None = None
+    locked_relations: list[UUID] | None = None
+    locked_relations_detail: list[SubscriptionRelationSchema] | None = None
     create: list[WorkflowListItemSchema]
     modify: list[WorkflowListItemSchema]
     terminate: list[WorkflowListItemSchema]

--- a/orchestrator/core/schemas/workflow.py
+++ b/orchestrator/core/schemas/workflow.py
@@ -42,6 +42,11 @@ class WorkflowSchema(WorkflowBaseSchema):
     model_config = ConfigDict(from_attributes=True)
 
 
+class SubscriptionRelationSchema(OrchestratorBaseModel):
+    subscription_id: UUID
+    subscription_description: str
+
+
 class WorkflowListItemSchema(OrchestratorBaseModel):
     name: str
     description: str | None = None
@@ -49,14 +54,14 @@ class WorkflowListItemSchema(OrchestratorBaseModel):
     usable_when: list[Any] | None = None
     status: str | None = None
     action: str | None = None
-    locked_relations: list[UUID] | None = None
-    unterminated_parents: list[UUID] | None = None
-    unterminated_in_use_by_subscriptions: list[UUID] | None = None
+    locked_relations: list[SubscriptionRelationSchema] | None = None
+    unterminated_parents: list[SubscriptionRelationSchema] | None = None
+    unterminated_in_use_by_subscriptions: list[SubscriptionRelationSchema] | None = None
 
 
 class SubscriptionWorkflowListsSchema(OrchestratorBaseModel):
     reason: str | None = None
-    locked_relations: list[UUID] | None = None
+    locked_relations: list[SubscriptionRelationSchema] | None = None
     create: list[WorkflowListItemSchema]
     modify: list[WorkflowListItemSchema]
     terminate: list[WorkflowListItemSchema]

--- a/orchestrator/core/schemas/workflow.py
+++ b/orchestrator/core/schemas/workflow.py
@@ -56,9 +56,10 @@ class WorkflowListItemSchema(OrchestratorBaseModel):
     action: str | None = None
     locked_relations: list[UUID] | None = None
     locked_relations_detail: list[SubscriptionRelationSchema] | None = None
-    unterminated_parents: list[UUID] | None = None
-    unterminated_parents_detail: list[SubscriptionRelationSchema] | None = None
-    unterminated_in_use_by_subscriptions: list[UUID] | None = None
+    unterminated_in_use_by_subscriptions: list[UUID] | None = Field(
+        default=None,
+        description="Previously also returned as unterminated_parents (now removed). Use this field instead.",
+    )
     unterminated_in_use_by_subscriptions_detail: list[SubscriptionRelationSchema] | None = None
 
 

--- a/orchestrator/core/services/subscriptions.py
+++ b/orchestrator/core/services/subscriptions.py
@@ -21,7 +21,6 @@ from hashlib import md5
 from typing import Any, TypeVar, overload
 from uuid import UUID
 
-import more_itertools
 import structlog
 from more_itertools import first
 from sqlalchemy import Text, cast, not_, select
@@ -48,6 +47,7 @@ from orchestrator.core.db.queries.subscription import (
 )
 from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.domain.context_cache import cache_subscription_models
+from orchestrator.core.schemas.workflow import SubscriptionRelationSchema
 from orchestrator.core.targets import Target
 from orchestrator.core.types import SubscriptionLifecycle
 from orchestrator.core.utils.datetime import nowtz
@@ -431,26 +431,24 @@ def query_depends_on_subscriptions(subscription_id: UUID, filter_statuses: list[
     )
 
 
-def _terminated_filter(query: Query) -> list[UUID]:
-    return list(
-        more_itertools.flatten(
-            query.filter(SubscriptionTable.status != "terminated").with_entities(SubscriptionTable.subscription_id)
-        )
+def _terminated_filter(query: Query) -> list[SubscriptionRelationSchema]:
+    rows = query.filter(SubscriptionTable.status != "terminated").with_entities(
+        SubscriptionTable.subscription_id, SubscriptionTable.description
     )
+    return [SubscriptionRelationSchema(subscription_id=row[0], subscription_description=row[1]) for row in rows]
 
 
-def _in_sync_filter(query: Query) -> list[UUID]:
-    return list(
-        more_itertools.flatten(
-            query.filter(not_(SubscriptionTable.insync)).with_entities(SubscriptionTable.subscription_id)
-        )
+def _in_sync_filter(query: Query) -> list[SubscriptionRelationSchema]:
+    rows = query.filter(not_(SubscriptionTable.insync)).with_entities(
+        SubscriptionTable.subscription_id, SubscriptionTable.description
     )
+    return [SubscriptionRelationSchema(subscription_id=row[0], subscription_description=row[1]) for row in rows]
 
 
 RELATION_RESOURCE_TYPES: list[str] = []
 
 
-def status_relations(subscription: SubscriptionTable | None) -> dict[str, list[UUID]]:
+def status_relations(subscription: SubscriptionTable | None) -> dict[str, list[SubscriptionRelationSchema]]:
     """Return info about locked subscription dependencies.
 
     This call will be used by the client to determine if it's safe to
@@ -489,7 +487,7 @@ def status_relations(subscription: SubscriptionTable | None) -> dict[str, list[U
     return result
 
 
-def get_relations(subscription_id: UUIDstr) -> dict[str, list[UUID]]:
+def get_relations(subscription_id: UUIDstr) -> dict[str, list[SubscriptionRelationSchema]]:
     subscription_table = db.session.get(
         SubscriptionTable,
         subscription_id,

--- a/orchestrator/core/services/subscriptions.py
+++ b/orchestrator/core/services/subscriptions.py
@@ -545,7 +545,8 @@ def subscription_workflows(subscription: SubscriptionTable) -> dict[str, Any]:
 
         if data["locked_relations"]:
             default_json["reason"] = "subscription.relations_not_in_sync"
-            default_json["locked_relations"] = data["locked_relations"]
+            default_json["locked_relations"] = [r.subscription_id for r in data["locked_relations"]]
+            default_json["locked_relations_detail"] = data["locked_relations"]
 
     workflows: dict[str, Any] = {
         "create": [],
@@ -584,8 +585,14 @@ def subscription_workflows(subscription: SubscriptionTable) -> dict[str, Any]:
                 )
             if blocked_by_depends_on_subscriptions and data["unterminated_in_use_by_subscriptions"]:
                 workflow_json["reason"] = "subscription.no_modify_subscription_in_use_by_others"
-                workflow_json["unterminated_parents"] = data["unterminated_parents"]
-                workflow_json["unterminated_in_use_by_subscriptions"] = data["unterminated_in_use_by_subscriptions"]
+                workflow_json["unterminated_parents"] = [r.subscription_id for r in data["unterminated_parents"]]
+                workflow_json["unterminated_parents_detail"] = data["unterminated_parents"]
+                workflow_json["unterminated_in_use_by_subscriptions"] = [
+                    r.subscription_id for r in data["unterminated_in_use_by_subscriptions"]
+                ]
+                workflow_json["unterminated_in_use_by_subscriptions_detail"] = data[
+                    "unterminated_in_use_by_subscriptions"
+                ]
                 workflow_json["action"] = "terminated" if workflow.target == Target.TERMINATE else "modified"
 
         workflows[workflow.target.lower()].append(workflow_json)

--- a/orchestrator/core/services/subscriptions.py
+++ b/orchestrator/core/services/subscriptions.py
@@ -463,7 +463,7 @@ def status_relations(subscription: SubscriptionTable | None) -> dict[str, list[S
 
     """
     if not subscription:
-        return {"locked_relations": [], "unterminated_parents": [], "unterminated_in_use_by_subscriptions": []}
+        return {"locked_relations": [], "unterminated_in_use_by_subscriptions": []}
     in_use_by_query = query_in_use_by_subscriptions(subscription.subscription_id)
 
     unterminated_in_use_by_subscriptions = _terminated_filter(in_use_by_query)
@@ -475,7 +475,6 @@ def status_relations(subscription: SubscriptionTable | None) -> dict[str, list[S
 
     result = {
         "locked_relations": locked_in_use_by_block_relations + locked_depends_on_block_relations,
-        "unterminated_parents": unterminated_in_use_by_subscriptions,
         "unterminated_in_use_by_subscriptions": unterminated_in_use_by_subscriptions,
     }
 
@@ -585,8 +584,6 @@ def subscription_workflows(subscription: SubscriptionTable) -> dict[str, Any]:
                 )
             if blocked_by_depends_on_subscriptions and data["unterminated_in_use_by_subscriptions"]:
                 workflow_json["reason"] = "subscription.no_modify_subscription_in_use_by_others"
-                workflow_json["unterminated_parents"] = [r.subscription_id for r in data["unterminated_parents"]]
-                workflow_json["unterminated_parents_detail"] = data["unterminated_parents"]
                 workflow_json["unterminated_in_use_by_subscriptions"] = [
                     r.subscription_id for r in data["unterminated_in_use_by_subscriptions"]
                 ]

--- a/test/integration_tests/api/test_subscriptions.py
+++ b/test/integration_tests/api/test_subscriptions.py
@@ -531,7 +531,10 @@ def test_in_use_by_subscriptions_not_insync(seed, test_client):
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == SERVICE_SUBSCRIPTION_ID
+    assert insync_info["locked_relations"][0] == {
+        "subscription_id": SERVICE_SUBSCRIPTION_ID,
+        "subscription_description": "desc",
+    }
 
 
 def test_in_use_by_subscriptions_insync(seed, test_client):
@@ -555,7 +558,10 @@ def test_depends_on_subscriptions_not_insync(seed, test_client):
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == PORT_A_SUBSCRIPTION_ID
+    assert insync_info["locked_relations"][0] == {
+        "subscription_id": PORT_A_SUBSCRIPTION_ID,
+        "subscription_description": "desc",
+    }
 
 
 def test_depends_on_subscriptions_insync(seed, test_client):
@@ -579,7 +585,10 @@ def test_in_use_by_subscriptions_not_insync_direct_relations(seed_with_direct_re
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == SERVICE_SUBSCRIPTION_ID
+    assert insync_info["locked_relations"][0] == {
+        "subscription_id": SERVICE_SUBSCRIPTION_ID,
+        "subscription_description": "desc",
+    }
 
 
 def test_depends_on_subscriptions_not_insync_direct_relations(seed_with_direct_relations, test_client):
@@ -594,7 +603,10 @@ def test_depends_on_subscriptions_not_insync_direct_relations(seed_with_direct_r
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == PORT_A_SUBSCRIPTION_ID
+    assert insync_info["locked_relations"][0] == {
+        "subscription_id": PORT_A_SUBSCRIPTION_ID,
+        "subscription_description": "desc",
+    }
 
 
 def test_depends_on_subscriptions_insync_direct_relations(seed_with_direct_relations, test_client):

--- a/test/integration_tests/api/test_subscriptions.py
+++ b/test/integration_tests/api/test_subscriptions.py
@@ -531,7 +531,8 @@ def test_in_use_by_subscriptions_not_insync(seed, test_client):
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == {
+    assert insync_info["locked_relations"][0] == SERVICE_SUBSCRIPTION_ID
+    assert insync_info["locked_relations_detail"][0] == {
         "subscription_id": SERVICE_SUBSCRIPTION_ID,
         "subscription_description": "desc",
     }
@@ -558,7 +559,8 @@ def test_depends_on_subscriptions_not_insync(seed, test_client):
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == {
+    assert insync_info["locked_relations"][0] == PORT_A_SUBSCRIPTION_ID
+    assert insync_info["locked_relations_detail"][0] == {
         "subscription_id": PORT_A_SUBSCRIPTION_ID,
         "subscription_description": "desc",
     }
@@ -585,7 +587,8 @@ def test_in_use_by_subscriptions_not_insync_direct_relations(seed_with_direct_re
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == {
+    assert insync_info["locked_relations"][0] == SERVICE_SUBSCRIPTION_ID
+    assert insync_info["locked_relations_detail"][0] == {
         "subscription_id": SERVICE_SUBSCRIPTION_ID,
         "subscription_description": "desc",
     }
@@ -603,7 +606,8 @@ def test_depends_on_subscriptions_not_insync_direct_relations(seed_with_direct_r
     insync_info = response.json()
     assert "reason" in insync_info
     assert len(insync_info["locked_relations"]) == 1
-    assert insync_info["locked_relations"][0] == {
+    assert insync_info["locked_relations"][0] == PORT_A_SUBSCRIPTION_ID
+    assert insync_info["locked_relations_detail"][0] == {
         "subscription_id": PORT_A_SUBSCRIPTION_ID,
         "subscription_description": "desc",
     }


### PR DESCRIPTION
## Summary

  De-deprecates the `GET /subscriptions/{subscription_id}/workflows` endpoint and enriches its response with human-readable subscription descriptions alongside the existing UUID lists.

 ### Changes:
  - Removed the `deprecated` flag, deprecation description, and `deprecated_endpoint` dependency from the subscription workflows endpoint
  - Added `SubscriptionRelationSchema` (with `subscription_id` + `subscription_description`) and exported it from `schemas`
  - Added `*_detail` companion fields to `WorkflowListItemSchema` and `SubscriptionWorkflowListsSchema`:
    - `locked_relations_detail: list[SubscriptionRelationSchema]`
    - `unterminated_in_use_by_subscriptions_detail: list[SubscriptionRelationSchema]`
  - Existing UUID-only fields (`locked_relations`, `unterminated_in_use_by_subscriptions`) are preserved for backwards compatibility
  - Removed legacy `unterminated_parents` field (which duplicated `unterminated_in_use_by_subscriptions`)
  - Updated internal helpers `_terminated_filter`, `_in_sync_filter`, `status_relations`, and `get_relations` to return `SubscriptionRelationSchema` objects
  - Added integration tests covering the new `locked_relations_detail` field

  ### Related Issues
  Fixes: https://git.ia.surf.nl/netdev/automation/projects/orchestrator/-/work_items/2775
  Core PR: workfloworchestrator/orchestrator-ui-library#2603



