### PR TITLE
Bug process status stays on running instead of failed

### DIFF
--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -96,7 +96,7 @@ def thread_start_process(
     # Trigger the task in the current thread or threadpool (depends on executor mode).
     pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
     _safe_logstep_with_func = partial(safe_logstep, broadcast_func=broadcast_func)
-    return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func))
+    return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func), broadcast_func)
 
 
 def thread_resume_process(
@@ -137,7 +137,7 @@ def thread_resume_process(
 
     # Trigger the task in the current thread or threadpool (depends on executor mode).
     _safe_logstep_prep = partial(safe_logstep, broadcast_func=broadcast_func)
-    _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_prep))
+    _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_prep), broadcast_func)
     return pstat.process_id
 
 

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -96,7 +96,7 @@ def thread_start_process(
     # Trigger the task in the current thread or threadpool (depends on executor mode).
     pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
     _safe_logstep_with_func = partial(safe_logstep, broadcast_func=broadcast_func)
-    return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func), broadcast_func)
+    return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func), broadcast_func=broadcast_func)
 
 
 def thread_resume_process(
@@ -137,7 +137,7 @@ def thread_resume_process(
 
     # Trigger the task in the current thread or threadpool (depends on executor mode).
     _safe_logstep_prep = partial(safe_logstep, broadcast_func=broadcast_func)
-    _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_prep), broadcast_func)
+    _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_prep), broadcast_func=broadcast_func)
     return pstat.process_id
 
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -46,7 +46,6 @@ from orchestrator.core.utils.json import json_dumps, json_loads
 from orchestrator.core.websocket import (
     broadcast_invalidate_status_counts,
     broadcast_process_update_to_websocket,
-    sync_invalidate_subscription_cache_by_id,
 )
 from orchestrator.core.workflow import (
     CALLBACK_TOKEN_KEY,
@@ -77,26 +76,22 @@ StateMerger = Merger([(dict, ["merge"])], ["override"], ["override"])
 
 SYSTEM_USER = "SYSTEM"
 
-# Terminal process statuses. Every in-step cache invalidation (`unsync`/`resync`) runs while the
-# process is still RUNNING, so the cache never reflects the terminal status: `done` sets COMPLETED
-# without invalidating, and failed/aborted processes skip `resync` entirely. `_db_log_step` re-issues
-# the invalidation when a process reaches one of these to avoid a stale UI.
-TERMINAL_SUB_STATUSES = frozenset(
-    {
-        ProcessStatus.COMPLETED,
-        ProcessStatus.FAILED,
-        ProcessStatus.INCONSISTENT_DATA,
-        ProcessStatus.API_UNAVAILABLE,
-        ProcessStatus.ABORTED,
-    }
-)
-
 _workflow_executor = None
 _active_threadpool_jobs = 0
 _active_jobs_lock = threading.Lock()
 
 START_WORKFLOW_REMOVED_ERROR_MSG = "This workflow cannot be started because it has been removed"
 RESUME_WORKFLOW_REMOVED_ERROR_MSG = "This workflow cannot be resumed because it has been removed"
+
+
+def _safe_broadcast_process_update(process_id: UUID, broadcast_func: BroadcastFunc | None) -> None:
+    if not broadcast_func:
+        return
+
+    try:
+        broadcast_func(process_id)
+    except Exception:
+        logger.exception("Failed to broadcast process update", process_id=process_id)
 
 
 def get_execution_context() -> dict[ExecutorFunction, Callable]:
@@ -361,10 +356,6 @@ def _db_log_step(
     if broadcast_func:
         broadcast_func(p.process_id)
 
-    if p.last_status in TERMINAL_SUB_STATUSES:
-        for subscription_id in {ps.subscription_id for ps in p.process_subscriptions}:
-            sync_invalidate_subscription_cache_by_id(subscription_id)
-
     return process_state.__class__(current_step.state)
 
 
@@ -447,7 +438,7 @@ def _get_process(process_id: UUID) -> ProcessTable:
     return process
 
 
-def _run_process_async(process_id: UUID, f: Callable) -> UUID:
+def _run_process_async(process_id: UUID, f: Callable, broadcast_func: BroadcastFunc | None = None) -> UUID:
 
     def run() -> WFProcess:
         with _ActiveJobTracker():
@@ -462,6 +453,7 @@ def _run_process_async(process_id: UUID, f: Callable) -> UUID:
                         raise
                     finally:
                         db.session.commit()
+                    _safe_broadcast_process_update(process_id, broadcast_func)
             except Exception as ex:
                 # We lost access to database here, so we can only log
                 logger.exception("Unknown workflow failure", process_id=process_id)

--- a/orchestrator/core/websocket/__init__.py
+++ b/orchestrator/core/websocket/__init__.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 from typing import Any, cast
 from urllib.parse import urlparse
 from uuid import UUID
@@ -18,6 +19,7 @@ import anyio
 from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
+from nwastdlib.asyncio import gather_nice
 from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.settings import AppSettings, app_settings
 from orchestrator.core.websocket.websocket_manager import WebSocketManager
@@ -171,16 +173,15 @@ async def broadcast_process_update_to_websocket_async(
     await broadcast_invalidate_cache({"type": "processes", "id": "LIST"})
     await broadcast_invalidate_cache({"type": "processes", "id": str(process_id)})
 
-    with db.database_scope():
-        process = db.session.get(ProcessTable, process_id, options=[selectinload(ProcessTable.process_subscriptions)])
+    process = await asyncio.to_thread(db.session.get, ProcessTable, process_id, options=[selectinload(ProcessTable.process_subscriptions)])
 
-        subscription_ids = set()
+    subscription_ids = set()
 
-        if process is not None and process.last_status in _TERMINAL_PROCESS_STATUSES:
-            subscription_ids = {ps.subscription_id for ps in process.process_subscriptions}
+    if process is not None and process.last_status in _TERMINAL_PROCESS_STATUSES:
+        subscription_ids = {ps.subscription_id for ps in process.process_subscriptions}
 
-    for subscription_id in subscription_ids:
-        await invalidate_subscription_cache_by_id(subscription_id)
+    tasks = [invalidate_subscription_cache_by_id(subscription_id) for subscription_id in subscription_ids]
+    await gather_nice(tasks, limit=10)
 
 
 __all__ = [

--- a/orchestrator/core/websocket/__init__.py
+++ b/orchestrator/core/websocket/__init__.py
@@ -15,8 +15,10 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import anyio
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
+from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.settings import AppSettings, app_settings
 from orchestrator.core.websocket.websocket_manager import WebSocketManager
 from orchestrator.core.workflow import ProcessStatus
@@ -32,6 +34,17 @@ class WS_CHANNELS:
     ALL_PROCESSES = "processes"
     ENGINE_SETTINGS = "engine-settings"
     EVENTS = "events"
+
+
+_TERMINAL_PROCESS_STATUSES = frozenset(
+    {
+        ProcessStatus.COMPLETED,
+        ProcessStatus.FAILED,
+        ProcessStatus.INCONSISTENT_DATA,
+        ProcessStatus.API_UNAVAILABLE,
+        ProcessStatus.ABORTED,
+    }
+)
 
 
 async def empty_fn(*args: tuple, **kwargs: dict[str, Any]) -> None:
@@ -107,10 +120,6 @@ async def invalidate_subscription_cache(subscription_id: UUID | UUIDstr, invalid
     await broadcast_invalidate_cache({"type": "subscriptions", "id": str(subscription_id)})
 
 
-def sync_invalidate_subscription_cache_by_id(subscription_id: UUID | UUIDstr) -> None:
-    anyio.run(invalidate_subscription_cache_by_id, subscription_id)
-
-
 async def invalidate_subscription_cache_by_id(subscription_id: UUID | UUIDstr) -> None:
     await broadcast_invalidate_cache({"type": "subscriptions", "id": str(subscription_id)})
 
@@ -147,8 +156,7 @@ def broadcast_process_update_to_websocket(
         )
         return
 
-    sync_broadcast_invalidate_cache({"type": "processes", "id": "LIST"})
-    sync_broadcast_invalidate_cache({"type": "processes", "id": str(process_id)})
+    anyio.run(broadcast_process_update_to_websocket_async, process_id)
 
 
 async def broadcast_process_update_to_websocket_async(
@@ -162,6 +170,17 @@ async def broadcast_process_update_to_websocket_async(
 
     await broadcast_invalidate_cache({"type": "processes", "id": "LIST"})
     await broadcast_invalidate_cache({"type": "processes", "id": str(process_id)})
+
+    with db.database_scope():
+        process = db.session.get(ProcessTable, process_id, options=[selectinload(ProcessTable.process_subscriptions)])
+
+        subscription_ids = set()
+
+        if process is not None and process.last_status in _TERMINAL_PROCESS_STATUSES:
+            subscription_ids = {ps.subscription_id for ps in process.process_subscriptions}
+
+    for subscription_id in subscription_ids:
+        await invalidate_subscription_cache_by_id(subscription_id)
 
 
 __all__ = [

--- a/test/integration_tests/api/test_processes_ws.py
+++ b/test/integration_tests/api/test_processes_ws.py
@@ -306,8 +306,10 @@ def test_websocket_process_list_multiple_workflows(test_client, test_workflow, t
 
             num_wf1_steps = 4  # 4 steps, then suspend
             num_wf2_steps = 5
+            num_wf1_broadcasts = num_wf1_steps + 1  # Final post-commit broadcast after suspend
+            num_wf2_broadcasts = num_wf2_steps + 1  # Final post-commit broadcast after complete
 
-            num_ws_messages = (num_wf1_steps + num_wf2_steps) * 2  # 2 messages per completed step
+            num_ws_messages = (num_wf1_broadcasts + num_wf2_broadcasts) * 2  # process + list per broadcast
 
             # Checks if the correct messages are send, without order for which workflow.
             while True:
@@ -334,14 +336,14 @@ def test_websocket_process_list_multiple_workflows(test_client, test_workflow, t
     for message in process_1_cache_invalidation_messages:
         assert message == {"name": "invalidateCache", "value": {"type": "processes", "id": test_workflow_1_pid}}
 
-    assert len(process_1_cache_invalidation_messages) == num_wf1_steps
+    assert len(process_1_cache_invalidation_messages) == num_wf1_broadcasts
 
     for message in process_2_cache_invalidation_messages:
         assert message == {"name": "invalidateCache", "value": {"type": "processes", "id": test_workflow_2_pid}}
 
-    assert len(process_2_cache_invalidation_messages) == num_wf2_steps
+    assert len(process_2_cache_invalidation_messages) == num_wf2_broadcasts
 
     for message in list_invalidation_messages:
         assert message == {"name": "invalidateCache", "value": {"type": "processes", "id": "LIST"}}
 
-    assert len(list_invalidation_messages) == num_wf1_steps + num_wf2_steps
+    assert len(list_invalidation_messages) == num_wf1_broadcasts + num_wf2_broadcasts

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 from orchestrator.core.api.error_handling import ProblemDetailException
 from orchestrator.core.config.assignee import Assignee
-from orchestrator.core.db import ProcessStepTable, ProcessTable, db
+from orchestrator.core.db import ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.services.executors.threadpool import thread_start_process
@@ -641,6 +641,151 @@ def test_process_log_db_step_complete(simple_workflow):
     assert p.last_step == "step"
     assert p.failed_reason is None
     assert p.assignee == "assignee"
+
+
+@pytest.fixture
+def process_with_subscription(simple_workflow, generic_subscription_1):
+    """A CREATED process linked to a single existing subscription."""
+    process_id = uuid4()
+    p = ProcessTable(
+        process_id=process_id,
+        workflow_id=simple_workflow.workflow_id,
+        last_status=ProcessStatus.CREATED,
+        created_by=SYSTEM_USER,
+    )
+    db.session.add(p)
+    db.session.add(ProcessSubscriptionTable(process_id=process_id, subscription_id=generic_subscription_1))
+    db.session.commit()
+    return process_id, generic_subscription_1
+
+
+def test_run_process_async_broadcasts_after_status_commit(simple_workflow):
+    """The final workflow broadcast must see the committed terminal process status.
+
+    The websocket broadcast path opens a fresh DB scope to decide whether subscription caches
+    should be invalidated. If the callback runs before commit, that scope still sees RUNNING and
+    skips the terminal invalidation, leaving the UI with a stale running status.
+    """
+    process_id = uuid4()
+    p = ProcessTable(
+        process_id=process_id,
+        workflow_id=simple_workflow.workflow_id,
+        last_status=ProcessStatus.RUNNING,
+        created_by=SYSTEM_USER,
+    )
+    db.session.add(p)
+    db.session.commit()
+
+    observed_statuses = []
+
+    def broadcast_func(broadcast_process_id):
+        with db.database_scope():
+            process = db.session.get(ProcessTable, broadcast_process_id)
+            observed_statuses.append(process.last_status)
+
+    def run_func():
+        process = db.session.get(ProcessTable, process_id)
+        process.last_status = ProcessStatus.COMPLETED
+        return Complete({"foo": "bar"})
+
+    _run_process_async(process_id, run_func, broadcast_func=broadcast_func)
+
+    assert observed_statuses == [ProcessStatus.COMPLETED]
+
+
+def test_run_process_async_swallows_final_broadcast_exception(simple_workflow):
+    process_id = uuid4()
+    p = ProcessTable(
+        process_id=process_id,
+        workflow_id=simple_workflow.workflow_id,
+        last_status=ProcessStatus.RUNNING,
+        created_by=SYSTEM_USER,
+    )
+    db.session.add(p)
+    db.session.commit()
+
+    def run_func():
+        process = db.session.get(ProcessTable, process_id)
+        process.last_status = ProcessStatus.COMPLETED
+        return Complete({"foo": "bar"})
+
+    _run_process_async(process_id, run_func, broadcast_func=MagicMock(side_effect=RuntimeError("websocket failed")))
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        pytest.param(ProcessStatus.FAILED, id="failed"),
+        pytest.param(ProcessStatus.ABORTED, id="aborted"),
+        pytest.param(ProcessStatus.COMPLETED, id="completed"),
+        pytest.param(ProcessStatus.INCONSISTENT_DATA, id="inconsistent-data"),
+        pytest.param(ProcessStatus.API_UNAVAILABLE, id="api-unavailable"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_broadcast_process_update_async_invalidates_subscription_cache_on_terminal_status(
+    terminal_status, process_with_subscription
+):
+    """broadcast_process_update_to_websocket_async invalidates subscription caches for terminal statuses.
+
+    Every in-step cache invalidation (`unsync`/`resync`) runs while the process is still
+    RUNNING, so the cache never reflects the terminal status. The broadcast function re-issues
+    the invalidation when a process reaches a terminal status to avoid a stale UI.
+    """
+    from orchestrator.core.websocket import broadcast_process_update_to_websocket_async
+
+    process_id, subscription_id = process_with_subscription
+    process = db.session.get(ProcessTable, process_id)
+    process.last_status = terminal_status
+    db.session.commit()
+
+    with mock.patch("orchestrator.core.websocket.websocket_manager") as mock_wsm, mock.patch(
+        "orchestrator.core.websocket.invalidate_subscription_cache_by_id"
+    ) as mock_invalidate:
+        mock_wsm.enabled = True
+        mock_wsm.broadcast_data = mock.AsyncMock()
+        mock_invalidate.return_value = None
+
+        await broadcast_process_update_to_websocket_async(process_id)
+
+    mock_invalidate.assert_called_once()
+    (called_subscription_id,) = mock_invalidate.call_args.args
+    assert str(called_subscription_id) == str(subscription_id)
+
+
+@pytest.mark.parametrize(
+    "non_terminal_status",
+    [
+        pytest.param(ProcessStatus.RUNNING, id="running"),
+        pytest.param(ProcessStatus.SUSPENDED, id="suspended"),
+        pytest.param(ProcessStatus.WAITING, id="waiting"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_broadcast_process_update_async_does_not_invalidate_subscription_cache_on_non_terminal_status(
+    non_terminal_status, process_with_subscription
+):
+    """Do not invalidate subscription caches for non-terminal statuses.
+
+    A running, suspended, or waiting process has not reached its final status yet, so there
+    is nothing terminal to reflect — invalidating here would only add cache churn mid-workflow.
+    """
+    from orchestrator.core.websocket import broadcast_process_update_to_websocket_async
+
+    process_id, _ = process_with_subscription
+    process = db.session.get(ProcessTable, process_id)
+    process.last_status = non_terminal_status
+    db.session.commit()
+
+    with mock.patch("orchestrator.core.websocket.websocket_manager") as mock_wsm, mock.patch(
+        "orchestrator.core.websocket.invalidate_subscription_cache_by_id"
+    ) as mock_invalidate:
+        mock_wsm.enabled = True
+        mock_wsm.broadcast_data = mock.AsyncMock()
+
+        await broadcast_process_update_to_websocket_async(process_id)
+
+    mock_invalidate.assert_not_called()
 
 
 def test_process_log_db_step_no_process_id(simple_workflow):

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 from orchestrator.core.api.error_handling import ProblemDetailException
 from orchestrator.core.config.assignee import Assignee
-from orchestrator.core.db import ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
+from orchestrator.core.db import ProcessStepTable, ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.services.executors.threadpool import thread_start_process
@@ -641,79 +641,6 @@ def test_process_log_db_step_complete(simple_workflow):
     assert p.last_step == "step"
     assert p.failed_reason is None
     assert p.assignee == "assignee"
-
-
-@pytest.fixture
-def process_with_subscription(simple_workflow, generic_subscription_1):
-    """A CREATED process linked to a single existing subscription."""
-    process_id = uuid4()
-    p = ProcessTable(
-        process_id=process_id,
-        workflow_id=simple_workflow.workflow_id,
-        last_status=ProcessStatus.CREATED,
-        created_by=SYSTEM_USER,
-    )
-    db.session.add(p)
-    db.session.add(ProcessSubscriptionTable(process_id=process_id, subscription_id=generic_subscription_1))
-    db.session.commit()
-    return process_id, generic_subscription_1
-
-
-@pytest.mark.parametrize(
-    "state, expected_status",
-    [
-        pytest.param(Failed(error_state_to_dict(Exception("boom"))), ProcessStatus.FAILED, id="failed"),
-        pytest.param(Abort({"foo": "bar"}), ProcessStatus.ABORTED, id="aborted"),
-        pytest.param(Complete({"foo": "bar"}), ProcessStatus.COMPLETED, id="completed"),
-    ],
-)
-@mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
-def test_db_log_step_invalidates_subscription_cache_on_terminal_end_state(
-    mock_invalidate, process_with_subscription, state, expected_status
-):
-    """Invalidate subscription caches when a process reaches a terminal status.
-
-    Every in-step cache invalidation (`unsync`/`resync`) runs while the process is still
-    RUNNING, so the cache never reflects the terminal status — `done` (COMPLETED) sets it
-    without invalidating, and failed/aborted processes skip `resync` entirely. `_db_log_step`
-    must invalidate the related subscription caches itself, otherwise the UI keeps the stale
-    RUNNING status.
-    """
-    process_id, subscription_id = process_with_subscription
-    pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, Assignee.SYSTEM)
-
-    result = _db_log_step(pstat, step, state)
-
-    assert result.overall_status == expected_status
-    mock_invalidate.assert_called_once()
-    (called_subscription_id,) = mock_invalidate.call_args.args
-    assert str(called_subscription_id) == str(subscription_id)
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        pytest.param(Success({"foo": "bar"}), id="success-running"),
-        pytest.param(Suspend({"foo": "bar"}), id="suspended"),
-    ],
-)
-@mock.patch("orchestrator.core.services.processes.sync_invalidate_subscription_cache_by_id")
-def test_db_log_step_does_not_invalidate_subscription_cache_on_non_terminal_state(
-    mock_invalidate, process_with_subscription, state
-):
-    """Do not invalidate subscription caches for non-terminal states.
-
-    A running (`Success`) or suspended process has not reached its final status yet, so there
-    is nothing terminal to reflect — invalidating here would only add cache churn mid-workflow.
-    """
-    process_id, _ = process_with_subscription
-    pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, Assignee.SYSTEM)
-
-    _db_log_step(pstat, step, state)
-
-    mock_invalidate.assert_not_called()
 
 
 def test_process_log_db_step_no_process_id(simple_workflow):

--- a/test/unit_tests/websocket/test_websocket_init.py
+++ b/test/unit_tests/websocket/test_websocket_init.py
@@ -223,18 +223,22 @@ def test_broadcast_invalidate_status_counts_sync(mock_sync, enabled: bool, sync_
 
 
 @pytest.mark.parametrize(
-    "enabled,expected_call_count",
+    "enabled",
     [
-        pytest.param(True, 2, id="enabled"),
-        pytest.param(False, 0, id="disabled"),
+        pytest.param(True, id="enabled"),
+        pytest.param(False, id="disabled"),
     ],
 )
-@patch("orchestrator.core.websocket.sync_broadcast_invalidate_cache")
-def test_broadcast_process_update_sync(mock_sync, enabled: bool, expected_call_count: int):
+@patch("orchestrator.core.websocket.anyio")
+def test_broadcast_process_update_sync(mock_anyio, enabled: bool):
+    process_id = uuid4()
     with patch("orchestrator.core.websocket.websocket_manager") as mock_wsm:
         mock_wsm.enabled = enabled
-        broadcast_process_update_to_websocket(uuid4())
-        assert mock_sync.call_count == expected_call_count
+        broadcast_process_update_to_websocket(process_id)
+        if enabled:
+            mock_anyio.run.assert_called_once_with(broadcast_process_update_to_websocket_async, process_id)
+        else:
+            mock_anyio.run.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -246,9 +250,14 @@ def test_broadcast_process_update_sync(mock_sync, enabled: bool, expected_call_c
 )
 @pytest.mark.asyncio
 async def test_broadcast_process_update_async(enabled: bool, expected_call_count: int):
-    with patch("orchestrator.core.websocket.websocket_manager") as mock_wsm:
+    with patch("orchestrator.core.websocket.websocket_manager") as mock_wsm, patch(
+        "orchestrator.core.websocket.db"
+    ) as mock_db:
         mock_wsm.enabled = enabled
         mock_wsm.broadcast_data = AsyncMock()
+        mock_db.database_scope.return_value.__enter__ = MagicMock(return_value=None)
+        mock_db.database_scope.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.session.get.return_value = None
         await broadcast_process_update_to_websocket_async(uuid4())
         assert mock_wsm.broadcast_data.await_count == expected_call_count
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
After a workflow finishes with a terminal status (FAILED, COMPLETED, etc.) the UI keeps showing the process as RUNNING. The websocket broadcast opened a fresh DB scope to read the process, but by the time it ran, the session had not yet committed — so it always read RUNNING.                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                              
Additionally, subscription caches were never invalidated on terminal statuses when a workflow ended outside of a normal `_db_log_step` call, causing stale subscription state in the UI.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                              
### Root cause                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  In `_run_process_async`, `broadcast_func` was called inside the `db.session.commit()` try-block, before the commit completed. The broadcast function opened a new database scope, but the status update was not yet visible.                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                              
 ### Fix                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                              
  - Move the `broadcast_func` call to after `db.session.commit()` in `_run_process_async`, so the broadcast always observes the committed terminal status.                                                                                                                                                                                                                                                          
  - Move subscription cache invalidation for terminal statuses from `_db_log_step` (PR #1694) into `broadcast_process_update_to_websocket_async`, where it runs with the correct committed state.                                                                                                                                                                                                                 
  - Have the sync `broadcast_process_update_to_websocket` delegate entirely to the async variant via `anyio.run(...)` to avoid duplicating logic.

### Related Issues
Fixes #1624


