### PR TITLE
Increase limit from 30 to 100 for search subscription results

### DIFF
--- a/orchestrator/core/search/query/queries.py
+++ b/orchestrator/core/search/query/queries.py
@@ -34,7 +34,7 @@ class BaseQuery(BaseModel):
 
     MIN_LIMIT: ClassVar[int] = 1
     DEFAULT_LIMIT: ClassVar[int] = 10
-    MAX_LIMIT: ClassVar[int] = 30
+    MAX_LIMIT: ClassVar[int] = 100
     DEFAULT_EXPORT_LIMIT: ClassVar[int] = 1000
     MAX_EXPORT_LIMIT: ClassVar[int] = 10000
 


### PR DESCRIPTION
## Summary
Fix: search returns at most 30 results                                                                                                                                                                                 
                                                                                                                                                                                                                         
MAX_LIMIT was set to 30, capping all search queries to 30 results regardless of the requested limit. Raised it to 100 to match the internal retriever's `field_candidates_limit`, which was already fetching up to 100 candidates.

Issue: https://git.ia.surf.nl/netdev/automation/projects/orchestrator/-/work_items/2783