### PR TITLE
Add optional timeout to callback_step

### DIFF
--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -303,3 +303,58 @@ For long-running jobs, such as executing Terraform or Ansible playbooks, the Orc
 Progress updates should be delivered to `{callback_route}/progress`, where `"/progress"` is a fixed endpoint appended to the callback URL.
 
 The remote service should send a JSON or plain string payload with each progress callback, this replaces the previous progress update and refreshes the UI. Once the final callback is triggered and the job completes, progress updates are removed, leaving only the callback result. Therefore, all troubleshooting or diagnostic information must be included in the final callback payload, as progress updates are not retained for debugging.
+
+## Timeouts
+
+By default a callback step waits **indefinitely** for the remote service to call back. If that
+service never responds (for example after a network failure), the process stays in
+`AWAITING_CALLBACK` forever and the only recovery is manual database intervention.
+
+To guard against this, pass an optional `timeout` (in **seconds**) to `callback_step`:
+
+```python
+from orchestrator.core.workflow import callback_step
+
+
+callback_step(
+    name="Call ext system",
+    action_step=call_ansible_playbook,
+    validate_step=_evaluate_callback_results,
+    timeout=300,  # fail if no callback arrives within 5 minutes
+)
+```
+
+`timeout=None` (the default) keeps the original behaviour of waiting forever, so existing
+callbacks are unaffected.
+
+### What happens when the timeout is exceeded
+
+When the deadline passes, the process is moved to `FAILED` with `failed_reason = "Callback timed
+out"`. This unblocks the standard recovery actions, so you no longer have to edit the database:
+
+- **Retry** re-runs the *entire callback step group*: it executes the action step again (re-issuing
+  the external request and generating a fresh callback URL) and waits anew. Design the action step
+  so it is safe to repeat (idempotent, or otherwise tolerant of being run more than once).
+- **Abort** marks the process `ABORTED` and stops it. Note that abort does **not** run the
+  workflow's remaining steps (the callback cleanup step is skipped) and does **not** itself change
+  the subscription's lifecycle state — any follow-up on the subscription is left to the operator or
+  a separate workflow.
+
+The deadline is measured from the moment the await started. Progress updates sent to
+`{callback_route}/progress` do **not** extend it.
+
+### Enforcement resolution
+
+Timeouts are enforced by the `task_validate_awaiting_callbacks` scheduled task, which runs every
+**30 seconds** by default. As a result `timeout` is a *minimum*: a process is failed on the first
+sweep at or after its deadline (so up to ~30 seconds late), and a `timeout` smaller than the sweep
+interval is effectively rounded up to the next sweep. Do not rely on sub-30-second precision.
+
+The task is registered like the other core tasks and is loaded with:
+
+```bash
+orchestrator-core scheduler load-initial-schedule
+```
+
+The interval is tunable through the scheduler API. The sweep does not start a run (and therefore
+creates no process record) when no process is awaiting a callback.

--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -345,16 +345,8 @@ The deadline is measured from the moment the await started. Progress updates sen
 
 ### Enforcement resolution
 
-Timeouts are enforced by the `task_validate_awaiting_callbacks` scheduled task, which runs every
-**30 seconds** by default. As a result `timeout` is a *minimum*: a process is failed on the first
-sweep at or after its deadline (so up to ~30 seconds late), and a `timeout` smaller than the sweep
-interval is effectively rounded up to the next sweep. Do not rely on sub-30-second precision.
-
-The task is registered like the other core tasks and is loaded with:
-
-```bash
-orchestrator-core scheduler load-initial-schedule
-```
-
-The interval is tunable through the scheduler API. The sweep does not start a run (and therefore
-creates no process record) when no process is awaiting a callback.
+Timeouts are enforced by the `task_validate_awaiting_callbacks` scheduled task, which sweeps every
+**30 seconds** by default. So `timeout` is a *minimum*: a process is failed on the first sweep at or
+after its deadline (up to ~30 seconds late) — don't rely on sub-30-second precision. Load the task
+with `orchestrator-core scheduler load-initial-schedule`; the interval can be changed to any value
+via the scheduler API (`PUT /api/schedules/`, which reschedules the job in place).

--- a/orchestrator/core/cli/scheduler.py
+++ b/orchestrator/core/cli/scheduler.py
@@ -160,6 +160,8 @@ def load_initial_schedule(
       - Task Resume Workflows
       - Task Clean Up Tasks
       - Task Validate Subscriptions
+      - Task Validate Products
+      - Task Validate Awaiting Callbacks
 
     By default, this command is idempotent since v4.7.1 when the scheduler is running.
     The schedules are only created when they do not already exist in the database.
@@ -193,6 +195,13 @@ def load_initial_schedule(
             "workflow_id": "",
             "trigger": "cron",
             "trigger_kwargs": {"hour": 2, "minute": 30},
+        },
+        {
+            "name": "Task Validate Awaiting Callbacks",
+            "workflow_name": "task_validate_awaiting_callbacks",
+            "workflow_id": "",
+            "trigger": "interval",
+            "trigger_kwargs": {"seconds": 30},
         },
     ]
 

--- a/orchestrator/core/cli/scheduler.py
+++ b/orchestrator/core/cli/scheduler.py
@@ -77,16 +77,15 @@ def _to_schedule_row(task: Job, *, api_managed_ids: set[str], verbose: bool) -> 
     run_time = str(task.next_run_time.replace(microsecond=0))
 
     def values() -> Iterator[str]:
-        yield task.id # id
-        yield task.name # name
-        yield source # source
-        yield str(run_time) # next run time
-        yield str(task.trigger) # trigger
+        yield task.id  # id
+        yield task.name  # name
+        yield source  # source
+        yield str(run_time)  # next run time
+        yield str(task.trigger)  # trigger
         if verbose:
-            yield json.dumps(task.kwargs, indent=2) # kwargs
+            yield json.dumps(task.kwargs, indent=2)  # kwargs
 
     return list(values())
-
 
 
 @app.command()

--- a/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
+++ b/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
@@ -19,10 +19,10 @@ Create Date: 2026-06-29 09:00:00.000000
 
 """
 
-from uuid import uuid4
-
 import sqlalchemy as sa
 from alembic import op
+
+from orchestrator.core.migrations.helpers import create_task
 
 # revision identifiers, used by Alembic.
 revision = "f4a7c9e21b08"
@@ -31,26 +31,17 @@ branch_labels = None
 depends_on = None
 
 
-workflow = {
+task = {
     "name": "task_validate_awaiting_callbacks",
-    "target": "SYSTEM",
     "description": "Fail callback steps that exceeded their timeout",
-    "workflow_id": uuid4(),
 }
 
 
 def upgrade() -> None:
     conn = op.get_bind()
-    # Named columns (not positional) so is_task is set explicitly; this is a task, not a process.
-    conn.execute(
-        sa.text(
-            "INSERT INTO workflows (workflow_id, name, target, description, is_task, created_at) "
-            "VALUES (:workflow_id, :name, :target, :description, true, now()) ON CONFLICT DO NOTHING"
-        ),
-        workflow,
-    )
+    create_task(conn, task)
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": workflow["name"]})
+    conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": task["name"]})

--- a/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
+++ b/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
@@ -44,4 +44,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     conn = op.get_bind()
-    conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": task["name"]})
+    delete_task(conn, task["name"])

--- a/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
+++ b/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
@@ -1,0 +1,56 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add Validate Awaiting Callbacks task.
+
+Revision ID: f4a7c9e21b08
+Revises: cab8b6a0ac92
+Create Date: 2026-06-29 09:00:00.000000
+
+"""
+
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f4a7c9e21b08"
+down_revision = "cab8b6a0ac92"
+branch_labels = None
+depends_on = None
+
+
+workflow = {
+    "name": "task_validate_awaiting_callbacks",
+    "target": "SYSTEM",
+    "description": "Fail callback steps that exceeded their timeout",
+    "workflow_id": uuid4(),
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # Named columns (not positional) so is_task is set explicitly; this is a task, not a process.
+    conn.execute(
+        sa.text(
+            "INSERT INTO workflows (workflow_id, name, target, description, is_task, created_at) "
+            "VALUES (:workflow_id, :name, :target, :description, true, now()) ON CONFLICT DO NOTHING"
+        ),
+        workflow,
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("DELETE FROM workflows WHERE name = :name"), {"name": workflow["name"]})

--- a/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
+++ b/orchestrator/core/migrations/versions/schema/2026-06-29_f4a7c9e21b08_add_validate_awaiting_callbacks_task.py
@@ -19,10 +19,9 @@ Create Date: 2026-06-29 09:00:00.000000
 
 """
 
-import sqlalchemy as sa
 from alembic import op
 
-from orchestrator.core.migrations.helpers import create_task
+from orchestrator.core.migrations.helpers import create_task, delete_workflow
 
 # revision identifiers, used by Alembic.
 revision = "f4a7c9e21b08"
@@ -44,4 +43,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     conn = op.get_bind()
-    delete_task(conn, task["name"])
+    delete_workflow(conn, task["name"])

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -62,6 +62,7 @@ from orchestrator.core.workflow import (
     Workflow,
     abort_wf,
     default_user_inputs,
+    fail_awaiting_wf,
 )
 from orchestrator.core.workflow import Process as WFProcess
 from orchestrator.core.workflows import get_workflow
@@ -794,6 +795,12 @@ def abort_process(process: ProcessTable, user: str, broadcast_func: Callable | N
 
     pstat.update(current_user=user)
     return abort_wf(pstat, partial(safe_logstep, broadcast_func=broadcast_func))
+
+
+def fail_awaiting_process(process: ProcessTable, broadcast_func: Callable | None = None) -> WFProcess:
+    """Fail a process that has been stuck awaiting a callback past its timeout."""
+    pstat = load_process(process)
+    return fail_awaiting_wf(pstat, partial(safe_logstep, broadcast_func=broadcast_func))
 
 
 def _recoverwf(wf: Workflow, log: list[WFProcess]) -> tuple[WFProcess, StepList]:

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -75,6 +75,7 @@ step_log_fn_var: contextvars.ContextVar[StepLogFuncInternal] = contextvars.Conte
 DEFAULT_CALLBACK_ROUTE_KEY = "callback_route"
 CALLBACK_TOKEN_KEY = "__callback_token"  # noqa: S105
 DEFAULT_CALLBACK_PROGRESS_KEY = "callback_progress"  # noqa: S105
+CALLBACK_TIMEOUT_KEY = "__callback_timeout"  # seconds; stored in the await step state when a timeout is set
 
 
 @runtime_checkable
@@ -463,11 +464,14 @@ def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
     return stepfunc
 
 
-def _awaitstep(name: str, result_key: str | None = None) -> Step:
+def _awaitstep(name: str, result_key: str | None = None, timeout: int | None = None) -> Step:
+    extra_state = {
+        **({"__callback_result_key": result_key} if result_key else {}),
+        **({CALLBACK_TIMEOUT_KEY: timeout} if timeout is not None else {}),
+    }
+
     def await_(state: State) -> Process:
-        if result_key:
-            state = {**state, "__callback_result_key": result_key}
-        return AwaitingCallback(state)
+        return AwaitingCallback({**state, **extra_state})
 
     return make_step_function(await_, name)
 
@@ -478,6 +482,7 @@ def callback_step(
     validate_step: Step,
     result_key: str | None = None,
     callback_route_key: str = DEFAULT_CALLBACK_ROUTE_KEY,
+    timeout: int | None = None,
 ) -> Step:
     """Creates an asynchronous callback step.
 
@@ -489,9 +494,14 @@ def callback_step(
 
     The data returned in the callback will be merged in the state. An optional result_key parameter can be supplied
     to specify under which key the data will be merged.
+
+    By default the process waits indefinitely for the callback. When ``timeout`` (in seconds) is supplied, a process
+    still in AWAITING_CALLBACK after that many seconds (measured from when the await started) is transitioned to FAILED
+    by the ``task_validate_awaiting_callbacks`` scheduled task, so it can be retried or aborted through the normal
+    flows. The timeout is a minimum: enforcement resolution equals that task's run interval (30 seconds by default).
     """
     create_endpoint_step = step(f"{name} - Create endpoint")(_create_endpoint_step(key=callback_route_key))
-    await_step = _awaitstep(f"{name} - Await callback", result_key=result_key)
+    await_step = _awaitstep(f"{name} - Await callback", result_key=result_key, timeout=timeout)
     cleanup_step = step(f"{name} - Cleanup callback step")(lambda: {"__remove_keys": [CALLBACK_TOKEN_KEY]})
     return step_group(
         name=name, steps=begin >> create_endpoint_step >> action_step >> await_step >> validate_step >> cleanup_step
@@ -1632,6 +1642,23 @@ def abort_wf(pstat: ProcessStat, logstep: StepLogFunc) -> Process:
         with transactional(db, logger):
             return logstep(pstat, abort_func, state)
     return pstat.state
+
+
+def fail_awaiting_wf(pstat: ProcessStat, logstep: StepLogFunc, reason: str = "Callback timed out") -> Process:
+    """Fail a workflow that is stuck awaiting a callback.
+
+    Overwrites the existing AWAITING_CALLBACK step in place (via ``__replace_last_state``) and turns it into FAILED, so
+    the process can be retried or aborted through the normal flows. The ``isawaitingcallback`` guard makes this a no-op
+    when the callback has arrived in the meantime, which also protects against the callback-arrives-during-sweep race.
+    """
+    if not pstat.state.isawaitingcallback():
+        return pstat.state
+
+    fail_func = make_step_function(Failed, reason)
+    state = Failed({**pstat.state.unwrap(), "error": reason, "__replace_last_state": True})
+
+    with transactional(db, logger):
+        return logstep(pstat, fail_func, state)
 
 
 @_purestep("Start")

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -1527,6 +1527,7 @@ def log_workflow_failure(error: ErrorDict) -> None:
     """Log the error state from a failed workflow."""
     logger.info("Workflow returned an error.", **error)
 
+
 def invalidate_status_counts() -> None:
     """Broadcast invalidate status counts to the websocket."""
     from orchestrator.core.websocket import broadcast_invalidate_status_counts
@@ -1546,6 +1547,7 @@ def capture_workflow_failure(err: Any) -> None:
     match err:
         case Exception() if app_settings.TRACING_ENABLED:
             import sentry_sdk
+
             sentry_sdk.capture_exception(err)
         case _:
             pass

--- a/orchestrator/core/workflow.py
+++ b/orchestrator/core/workflow.py
@@ -75,7 +75,7 @@ step_log_fn_var: contextvars.ContextVar[StepLogFuncInternal] = contextvars.Conte
 DEFAULT_CALLBACK_ROUTE_KEY = "callback_route"
 CALLBACK_TOKEN_KEY = "__callback_token"  # noqa: S105
 DEFAULT_CALLBACK_PROGRESS_KEY = "callback_progress"  # noqa: S105
-CALLBACK_TIMEOUT_KEY = "__callback_timeout"  # seconds; stored in the await step state when a timeout is set
+CALLBACK_TIMEOUT_KEY = "__callback_timeout"
 
 
 @runtime_checkable
@@ -465,13 +465,14 @@ def _create_endpoint_step(key: str = DEFAULT_CALLBACK_ROUTE_KEY) -> StepFunc:
 
 
 def _awaitstep(name: str, result_key: str | None = None, timeout: int | None = None) -> Step:
-    extra_state = {
-        **({"__callback_result_key": result_key} if result_key else {}),
-        **({CALLBACK_TIMEOUT_KEY: timeout} if timeout is not None else {}),
-    }
+    extra_state: State = {}
+    if result_key:
+        extra_state["__callback_result_key"] = result_key
+    if timeout is not None:
+        extra_state[CALLBACK_TIMEOUT_KEY] = timeout
 
     def await_(state: State) -> Process:
-        return AwaitingCallback({**state, **extra_state})
+        return AwaitingCallback(state | extra_state)
 
     return make_step_function(await_, name)
 

--- a/orchestrator/core/workflows/__init__.py
+++ b/orchestrator/core/workflows/__init__.py
@@ -114,6 +114,7 @@ LazyWorkflowInstance(".modify_note", "modify_note")
 # Tasks
 LazyWorkflowInstance(".tasks.cleanup_tasks_log", "task_clean_up_tasks")
 LazyWorkflowInstance(".tasks.resume_workflows", "task_resume_workflows")
+LazyWorkflowInstance(".tasks.validate_awaiting_callbacks", "task_validate_awaiting_callbacks")
 LazyWorkflowInstance(".tasks.validate_products", "task_validate_products")
 LazyWorkflowInstance(".tasks.validate_product_type", "task_validate_product_type")
 LazyWorkflowInstance(".tasks.validate_subscriptions", "task_validate_subscriptions")

--- a/orchestrator/core/workflows/predicates.py
+++ b/orchestrator/core/workflows/predicates.py
@@ -15,13 +15,15 @@ from __future__ import annotations
 
 from sqlalchemy import func, select
 
-from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.db import ProcessStepTable, ProcessTable, db
 from orchestrator.core.workflow import (
+    CALLBACK_TIMEOUT_KEY,
     PredicateContext,
     ProcessStatus,
     RunPredicateFail,
     RunPredicatePass,
     RunPredicateResult,
+    StepStatus,
 )
 
 
@@ -46,3 +48,37 @@ def no_uncompleted_instance(context: PredicateContext) -> RunPredicateResult:
     if uncompleted_count == 0:
         return RunPredicatePass()
     return RunPredicateFail(f"Workflow '{workflow_name}' already has {uncompleted_count} uncompleted instance(s)")
+
+
+def awaiting_callbacks_exist(context: PredicateContext) -> RunPredicateResult:
+    """Predicate that only runs the workflow when a process is awaiting a callback that has a timeout set.
+
+    Composes with :func:`no_uncompleted_instance` so the timeout sweep neither overlaps a previous run nor starts a run
+    (and thus creates a process row) when there is nothing to check. The timeout lives in the awaiting step's JSONB
+    state, so we join to the awaiting step and require the ``__callback_timeout`` key; callbacks without a timeout (the
+    default) never need the sweep. Joining on ``last_status`` excludes the lingering awaiting-callback step rows of
+    aborted/failed processes.
+
+    Args:
+        context: PredicateContext containing the workflow information.
+
+    Returns:
+        RunPredicatePass when work exists and no instance is running, RunPredicateFail otherwise.
+    """
+    match no_uncompleted_instance(context):
+        case RunPredicateFail() as fail:
+            return fail
+        case _:
+            awaiting_count = db.session.scalar(
+                select(func.count())
+                .select_from(ProcessTable)
+                .join(ProcessStepTable, ProcessStepTable.process_id == ProcessTable.process_id)
+                .filter(
+                    ProcessTable.last_status == ProcessStatus.AWAITING_CALLBACK,
+                    ProcessStepTable.status == StepStatus.AWAITING_CALLBACK,
+                    ProcessStepTable.state.has_key(CALLBACK_TIMEOUT_KEY),
+                )
+            )
+            if awaiting_count:
+                return RunPredicatePass()
+            return RunPredicateFail("No processes are awaiting a callback with a timeout")

--- a/orchestrator/core/workflows/tasks/validate_awaiting_callbacks.py
+++ b/orchestrator/core/workflows/tasks/validate_awaiting_callbacks.py
@@ -1,0 +1,99 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+
+from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.services import processes
+from orchestrator.core.settings import get_authorizers
+from orchestrator.core.targets import Target
+from orchestrator.core.utils.datetime import nowtz
+from orchestrator.core.workflow import CALLBACK_TIMEOUT_KEY, ProcessStatus, StepList, done, init, step, workflow
+from orchestrator.core.workflows.predicates import awaiting_callbacks_exist
+from pydantic_forms.types import State, UUIDstr
+
+authorizers = get_authorizers()
+logger = structlog.get_logger(__name__)
+
+
+def _is_timed_out(process: ProcessTable, now: datetime) -> bool:
+    """Return True when the process's awaiting callback step has a timeout that has elapsed.
+
+    The deadline is anchored on the awaiting step's ``started_at`` column (the time the await began) and the timeout
+    (seconds) is read from that step's state. A step without a ``__callback_timeout`` never times out.
+    """
+    last_step = process.steps[-1] if process.steps else None
+    if last_step is None or last_step.started_at is None:
+        return False
+    timeout = last_step.state.get(CALLBACK_TIMEOUT_KEY)
+    if timeout is None:
+        return False
+    return (now - last_step.started_at).total_seconds() > timeout
+
+
+def _fail_if_still_awaiting(process_id: UUIDstr) -> UUIDstr | None:
+    """Fail a single timed-out process, re-checking its status first to avoid racing an arriving callback."""
+    process = db.session.get(ProcessTable, process_id)
+    if process is None or process.last_status != ProcessStatus.AWAITING_CALLBACK:
+        return None
+    try:
+        # Enable commit to be able to fail the process as normal
+        db.session.enable_commit()
+        processes.fail_awaiting_process(process)
+        return process_id
+    except Exception as exc:
+        logger.warning("Could not fail timed-out awaiting process", process_id=process_id, error=str(exc))
+        return None
+    finally:
+        # Make sure to disable commit again
+        db.session.disable_commit()
+
+
+@step("Find timed-out awaiting-callback processes")
+def find_timed_out_callbacks(process_id: UUID) -> State:
+    now = nowtz()
+    awaiting_processes = db.session.scalars(
+        select(ProcessTable).filter(
+            ProcessTable.last_status == ProcessStatus.AWAITING_CALLBACK,
+            ProcessTable.process_id != process_id,
+        )
+    )
+    timed_out_process_ids = [str(p.process_id) for p in awaiting_processes if _is_timed_out(p, now)]
+
+    return {
+        "number_of_timed_out_processes": len(timed_out_process_ids),
+        "timed_out_process_ids": timed_out_process_ids,
+    }
+
+
+@step("Fail timed-out callbacks")
+def fail_timed_out_callbacks(timed_out_process_ids: list[UUIDstr]) -> State:
+    failed_process_ids = list(filter(None, map(_fail_if_still_awaiting, timed_out_process_ids)))
+
+    return {
+        "number_of_failed_process_ids": len(failed_process_ids),
+        "failed_process_ids": failed_process_ids,
+    }
+
+
+@workflow(
+    target=Target.SYSTEM,
+    authorize_callback=authorizers.authorize_callback,
+    retry_auth_callback=authorizers.retry_auth_callback,
+    run_predicate=awaiting_callbacks_exist,
+)
+def task_validate_awaiting_callbacks() -> StepList:
+    return init >> find_timed_out_callbacks >> fail_timed_out_callbacks >> done

--- a/orchestrator/core/workflows/tasks/validate_awaiting_callbacks.py
+++ b/orchestrator/core/workflows/tasks/validate_awaiting_callbacks.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.services import processes
@@ -66,7 +67,9 @@ def _fail_if_still_awaiting(process_id: UUIDstr) -> UUIDstr | None:
 def find_timed_out_callbacks(process_id: UUID) -> State:
     now = nowtz()
     awaiting_processes = db.session.scalars(
-        select(ProcessTable).filter(
+        select(ProcessTable)
+        .options(selectinload(ProcessTable.steps))
+        .filter(
             ProcessTable.last_status == ProcessStatus.AWAITING_CALLBACK,
             ProcessTable.process_id != process_id,
         )

--- a/orchestrator/core/workflows/translations/en-GB.json
+++ b/orchestrator/core/workflows/translations/en-GB.json
@@ -25,6 +25,7 @@
         "task_validate_products": "Validate Products and Subscriptions",
         "task_validate_product_type": "Validate all subscriptions of Product Type",
         "reset_subscription_description": "Reset description of a subscription to default",
-        "task_validate_subscriptions": "Validate subscriptions"
+        "task_validate_subscriptions": "Validate subscriptions",
+        "task_validate_awaiting_callbacks": "Fail callback steps that exceeded their timeout"
     }
 }

--- a/test/integration_tests/graphql/test_workflows.py
+++ b/test/integration_tests/graphql/test_workflows.py
@@ -108,7 +108,7 @@ def test_workflows_query(test_client_graphql):
         "hasNextPage": True,
         "startCursor": 0,
         "endCursor": 1,
-        "totalItems": 6,
+        "totalItems": 7,
     }
 
 
@@ -127,14 +127,15 @@ def test_workflows_has_previous_page(test_client_graphql):
         "hasNextPage": False,
         "hasPreviousPage": True,
         "startCursor": 1,
-        "endCursor": 5,
-        "totalItems": 6,
+        "endCursor": 6,
+        "totalItems": 7,
     }
 
-    assert len(workflows) == 5
+    assert len(workflows) == 6
     assert [workflow["name"] for workflow in workflows] == [
         "task_clean_up_tasks",
         "task_resume_workflows",
+        "task_validate_awaiting_callbacks",
         "task_validate_product_type",
         "task_validate_products",
         "task_validate_subscriptions",
@@ -163,15 +164,16 @@ def test_workflows_filter_by_name(test_client_graphql, query_args):
 
     assert "errors" not in result
     assert pageinfo == {
-        "endCursor": 4,
+        "endCursor": 5,
         "hasNextPage": False,
         "hasPreviousPage": False,
         "startCursor": 0,
-        "totalItems": 5,
+        "totalItems": 6,
     }
     expected_workflows = [
         "task_clean_up_tasks",
         "task_resume_workflows",
+        "task_validate_awaiting_callbacks",
         "task_validate_product_type",
         "task_validate_products",
         "task_validate_subscriptions",
@@ -247,13 +249,14 @@ def test_workflows_sort_by_resource_type_desc(test_client_graphql):
         "hasNextPage": False,
         "hasPreviousPage": False,
         "startCursor": 0,
-        "endCursor": 5,
-        "totalItems": 6,
+        "endCursor": 6,
+        "totalItems": 7,
     }
     expected_workflows = [
         "task_validate_subscriptions",
         "task_validate_products",
         "task_validate_product_type",
+        "task_validate_awaiting_callbacks",
         "task_resume_workflows",
         "task_clean_up_tasks",
         "modify_note",

--- a/test/integration_tests/workflows/tasks/test_validate_awaiting_callbacks.py
+++ b/test/integration_tests/workflows/tasks/test_validate_awaiting_callbacks.py
@@ -1,0 +1,88 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import timedelta
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+from orchestrator.core.config.assignee import Assignee
+from orchestrator.core.db import ProcessStepTable, ProcessTable, WorkflowTable, db
+from orchestrator.core.targets import Target
+from orchestrator.core.utils.datetime import nowtz
+from orchestrator.core.workflow import CALLBACK_TIMEOUT_KEY, ProcessStatus
+from test.integration_tests.workflows import assert_complete, extract_state, run_workflow
+
+
+@pytest.fixture
+def awaiting_workflow():
+    wf = WorkflowTable(workflow_id=uuid4(), name="Awaiting workflow", target=Target.CREATE, description="Description")
+    db.session.add(wf)
+    db.session.commit()
+    return wf
+
+
+def _make_awaiting_process(awaiting_workflow, *, timeout: int | None, started_seconds_ago: int) -> ProcessTable:
+    pid = uuid4()
+    process = ProcessTable(
+        process_id=pid,
+        workflow_id=awaiting_workflow.workflow_id,
+        last_status=ProcessStatus.AWAITING_CALLBACK,
+        assignee=Assignee.SYSTEM,
+        last_step="Await callback",
+        created_by="tester",
+    )
+    state = {"__sub_step": "Await callback"} | ({CALLBACK_TIMEOUT_KEY: timeout} if timeout is not None else {})
+    await_step = ProcessStepTable(
+        process_id=pid,
+        name="Await callback",
+        status=ProcessStatus.AWAITING_CALLBACK,
+        state=state,
+        created_by="tester",
+        started_at=nowtz() - timedelta(seconds=started_seconds_ago),
+    )
+    db.session.add_all([process, await_step])
+    db.session.commit()
+    return process
+
+
+def test_task_fails_only_timed_out_callbacks(awaiting_workflow):
+    expired = _make_awaiting_process(awaiting_workflow, timeout=300, started_seconds_ago=600)
+    not_expired = _make_awaiting_process(awaiting_workflow, timeout=300, started_seconds_ago=60)
+    no_timeout = _make_awaiting_process(awaiting_workflow, timeout=None, started_seconds_ago=600)
+
+    result, _, _ = run_workflow("task_validate_awaiting_callbacks", {})
+    assert_complete(result)
+
+    res = extract_state(result)
+    assert res["number_of_timed_out_processes"] == 1
+    assert res["failed_process_ids"] == [str(expired.process_id)]
+
+    assert db.session.get(ProcessTable, expired.process_id).last_status == ProcessStatus.FAILED
+    assert db.session.get(ProcessTable, not_expired.process_id).last_status == ProcessStatus.AWAITING_CALLBACK
+    assert db.session.get(ProcessTable, no_timeout.process_id).last_status == ProcessStatus.AWAITING_CALLBACK
+
+
+@mock.patch("orchestrator.core.workflows.tasks.validate_awaiting_callbacks.processes.fail_awaiting_process")
+def test_task_skips_process_when_failing_raises(mock_fail, awaiting_workflow):
+    # Exercises the per-process error handling: a failure to fail one process is logged and skipped.
+    mock_fail.side_effect = Exception("boom")
+    _make_awaiting_process(awaiting_workflow, timeout=300, started_seconds_ago=600)
+
+    result, _, _ = run_workflow("task_validate_awaiting_callbacks", {})
+    assert_complete(result)
+
+    res = extract_state(result)
+    assert res["number_of_timed_out_processes"] == 1
+    assert res["failed_process_ids"] == []

--- a/test/integration_tests/workflows/test_async_workflow.py
+++ b/test/integration_tests/workflows/test_async_workflow.py
@@ -43,8 +43,10 @@ from test.integration_tests.workflows import (
 def _backdate_await_step(process_id: str, seconds: int) -> None:
     """Move the awaiting step's started_at into the past so its timeout is considered elapsed."""
     process = db.session.get(ProcessTable, process_id)
-    process.steps[-1].started_at = nowtz() - timedelta(seconds=seconds)
-    db.session.add(process.steps[-1])
+    assert process is not None
+    await_step = process.steps[-1]
+    await_step.started_at = nowtz() - timedelta(seconds=seconds)
+    db.session.add(await_step)
     db.session.commit()
 
 

--- a/test/integration_tests/workflows/test_async_workflow.py
+++ b/test/integration_tests/workflows/test_async_workflow.py
@@ -18,7 +18,6 @@ from orchestrator.core.services import processes
 from orchestrator.core.targets import Target
 from orchestrator.core.utils.datetime import nowtz
 from orchestrator.core.workflow import (
-    CALLBACK_TIMEOUT_KEY,
     DEFAULT_CALLBACK_PROGRESS_KEY,
     DEFAULT_CALLBACK_ROUTE_KEY,
     AwaitingCallback,
@@ -375,24 +374,6 @@ def _start_timeout_wf(test_client, timeout):
     process_id = response.json()["id"]
     assert test_client.get(f"api/processes/{process_id}").json()["last_status"] == "awaiting_callback"
     return instance, process_id
-
-
-def test_callback_step_timeout_stored_in_state(test_client):
-    instance, process_id = _start_timeout_wf(test_client, timeout=300)
-    try:
-        process = db.session.get(ProcessTable, process_id)
-        assert process.steps[-1].state[CALLBACK_TIMEOUT_KEY] == 300
-    finally:
-        instance.__exit__(None, None, None)
-
-
-def test_callback_step_without_timeout_has_no_timeout_key(test_client):
-    instance, process_id = _start_timeout_wf(test_client, timeout=None)
-    try:
-        process = db.session.get(ProcessTable, process_id)
-        assert CALLBACK_TIMEOUT_KEY not in process.steps[-1].state
-    finally:
-        instance.__exit__(None, None, None)
 
 
 def test_timed_out_callback_fails_in_place_and_can_be_retried(test_client):

--- a/test/integration_tests/workflows/test_async_workflow.py
+++ b/test/integration_tests/workflows/test_async_workflow.py
@@ -11,11 +11,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import timedelta
+
+from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.services import processes
 from orchestrator.core.targets import Target
+from orchestrator.core.utils.datetime import nowtz
 from orchestrator.core.workflow import (
+    CALLBACK_TIMEOUT_KEY,
     DEFAULT_CALLBACK_PROGRESS_KEY,
     DEFAULT_CALLBACK_ROUTE_KEY,
     AwaitingCallback,
+    ProcessStatus,
     begin,
     callback_step,
     done,
@@ -31,6 +38,14 @@ from test.integration_tests.workflows import (
     assert_state,
     run_workflow,
 )
+
+
+def _backdate_await_step(process_id: str, seconds: int) -> None:
+    """Move the awaiting step's started_at into the past so its timeout is considered elapsed."""
+    process = db.session.get(ProcessTable, process_id)
+    process.steps[-1].started_at = nowtz() - timedelta(seconds=seconds)
+    db.session.add(process.steps[-1])
+    db.session.commit()
 
 
 @step("Step 1")
@@ -342,3 +357,106 @@ def test_wf_callback_progress_with_multiple_callback_steps(test_client):
         state = response_data["current_state"]
         assert state["ext_data"] == "56789"
         assert DEFAULT_CALLBACK_PROGRESS_KEY not in state
+
+
+def _start_timeout_wf(test_client, timeout):
+    call_ext = callback_step(name="Call ext", action_step=action, validate_step=step1, timeout=timeout)
+
+    @workflow(target=Target.CREATE)
+    def timeout_wf():
+        return begin >> step1 >> call_ext >> done
+
+    instance = WorkflowInstanceForTests(timeout_wf, "timeout_wf")
+    instance.__enter__()
+    response = test_client.post("/api/processes/timeout_wf", json=[{}])
+    assert response.status_code == 201
+    process_id = response.json()["id"]
+    assert test_client.get(f"api/processes/{process_id}").json()["last_status"] == "awaiting_callback"
+    return instance, process_id
+
+
+def test_callback_step_timeout_stored_in_state(test_client):
+    instance, process_id = _start_timeout_wf(test_client, timeout=300)
+    try:
+        process = db.session.get(ProcessTable, process_id)
+        assert process.steps[-1].state[CALLBACK_TIMEOUT_KEY] == 300
+    finally:
+        instance.__exit__(None, None, None)
+
+
+def test_callback_step_without_timeout_has_no_timeout_key(test_client):
+    instance, process_id = _start_timeout_wf(test_client, timeout=None)
+    try:
+        process = db.session.get(ProcessTable, process_id)
+        assert CALLBACK_TIMEOUT_KEY not in process.steps[-1].state
+    finally:
+        instance.__exit__(None, None, None)
+
+
+def test_timed_out_callback_fails_in_place_and_can_be_retried(test_client):
+    instance, process_id = _start_timeout_wf(test_client, timeout=300)
+    try:
+        steps_before = len(db.session.get(ProcessTable, process_id).steps)
+        _backdate_await_step(process_id, seconds=600)
+
+        processes.fail_awaiting_process(db.session.get(ProcessTable, process_id))
+
+        process = db.session.get(ProcessTable, process_id)
+        assert process.last_status == ProcessStatus.FAILED
+        assert process.failed_reason == "Callback timed out"
+        # In-place: the awaiting row turned FAILED, no orphan extra row was appended.
+        assert len(process.steps) == steps_before
+        assert process.steps[-1].name == "Call ext"
+
+        # Retry re-runs the callback group (re-issues the action) and waits again.
+        response = test_client.put(f"/api/processes/{process_id}/resume", json=[{}])
+        assert response.status_code == 204
+        assert test_client.get(f"api/processes/{process_id}").json()["last_status"] == "awaiting_callback"
+    finally:
+        instance.__exit__(None, None, None)
+
+
+def test_timed_out_callback_can_be_aborted(test_client):
+    instance, process_id = _start_timeout_wf(test_client, timeout=300)
+    try:
+        _backdate_await_step(process_id, seconds=600)
+        processes.fail_awaiting_process(db.session.get(ProcessTable, process_id))
+
+        response = test_client.put(f"/api/processes/{process_id}/abort")
+        assert response.status_code == 204
+        assert test_client.get(f"api/processes/{process_id}").json()["last_status"] == "aborted"
+    finally:
+        instance.__exit__(None, None, None)
+
+
+def test_sweep_selection_respects_the_deadline(test_client):
+    # The sweep only fails processes _is_timed_out selects; a process still within its window is not picked.
+    from orchestrator.core.workflows.tasks.validate_awaiting_callbacks import _is_timed_out
+
+    instance, process_id = _start_timeout_wf(test_client, timeout=300)
+    try:
+        _backdate_await_step(process_id, seconds=60)  # within the 300s window
+        assert _is_timed_out(db.session.get(ProcessTable, process_id), nowtz()) is False
+
+        _backdate_await_step(process_id, seconds=600)  # past the 300s window
+        assert _is_timed_out(db.session.get(ProcessTable, process_id), nowtz()) is True
+    finally:
+        instance.__exit__(None, None, None)
+
+
+def test_fail_awaiting_process_is_noop_when_not_awaiting(test_client):
+    # Concurrency guard: if the callback already arrived (process no longer awaiting), failing is a no-op.
+    @workflow(target=Target.CREATE)
+    def plain_wf():
+        return begin >> step1 >> done
+
+    with WorkflowInstanceForTests(plain_wf, "plain_wf"):
+        response = test_client.post("/api/processes/plain_wf", json=[{}])
+        process_id = response.json()["id"]
+        process = db.session.get(ProcessTable, process_id)
+        assert process.last_status == ProcessStatus.COMPLETED
+
+        result = processes.fail_awaiting_process(process)
+
+        assert result.iscomplete()
+        assert db.session.get(ProcessTable, process_id).last_status == ProcessStatus.COMPLETED

--- a/test/integration_tests/workflows/test_predicates.py
+++ b/test/integration_tests/workflows/test_predicates.py
@@ -13,7 +13,7 @@
 
 """Tests for no_uncompleted_instance predicate: pass on zero count, fail with message on nonzero."""
 
-from unittest.mock import MagicMock
+from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -26,8 +26,14 @@ from orchestrator.core.workflow import (
     RunPredicateFail,
     RunPredicatePass,
     StepStatus,
+    Workflow,
 )
 from orchestrator.core.workflows.predicates import awaiting_callbacks_exist, no_uncompleted_instance
+
+
+def _context(workflow_key: str) -> PredicateContext:
+    # The predicates only read workflow_key; workflow is irrelevant here.
+    return PredicateContext(workflow=cast(Workflow, None), workflow_key=workflow_key)
 
 
 @pytest.fixture
@@ -53,8 +59,7 @@ def test_no_uncompleted_by_process_last_status(test_process, test_workflow, proc
     db.session.add(test_process)
     db.session.commit()
 
-    context = MagicMock(spec=PredicateContext)
-    context.workflow_key = test_workflow.name
+    context = _context(test_workflow.name)
 
     result = no_uncompleted_instance(context)
 
@@ -82,8 +87,7 @@ def test_awaiting_callbacks_exist_pass(test_workflow, generic_subscription_1) ->
     _awaiting_process(test_workflow, with_timeout=True)
 
     # workflow_key with no uncompleted instances of itself, so only the awaiting-existence check matters
-    context = MagicMock(spec=PredicateContext)
-    context.workflow_key = "task_validate_awaiting_callbacks"
+    context = _context("task_validate_awaiting_callbacks")
 
     assert isinstance(awaiting_callbacks_exist(context), RunPredicatePass)
 
@@ -99,8 +103,7 @@ def test_awaiting_callbacks_exist_fail(test_workflow, generic_subscription_1, cr
     if create_awaiting_without_timeout:
         _awaiting_process(test_workflow, with_timeout=False)
 
-    context = MagicMock(spec=PredicateContext)
-    context.workflow_key = "task_validate_awaiting_callbacks"
+    context = _context("task_validate_awaiting_callbacks")
 
     result = awaiting_callbacks_exist(context)
 
@@ -113,8 +116,7 @@ def test_awaiting_callbacks_exist_short_circuits_on_uncompleted_instance(test_pr
     # even though there is an awaiting-callback process with a timeout to check.
     _awaiting_process(test_workflow, with_timeout=True)
 
-    context = MagicMock(spec=PredicateContext)
-    context.workflow_key = test_workflow.name
+    context = _context(test_workflow.name)
 
     result = awaiting_callbacks_exist(context)
 

--- a/test/integration_tests/workflows/test_predicates.py
+++ b/test/integration_tests/workflows/test_predicates.py
@@ -18,14 +18,16 @@ from uuid import uuid4
 
 import pytest
 
-from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.db import ProcessStepTable, ProcessTable, db
 from orchestrator.core.workflow import (
+    CALLBACK_TIMEOUT_KEY,
     PredicateContext,
     ProcessStatus,
     RunPredicateFail,
     RunPredicatePass,
+    StepStatus,
 )
-from orchestrator.core.workflows.predicates import no_uncompleted_instance
+from orchestrator.core.workflows.predicates import awaiting_callbacks_exist, no_uncompleted_instance
 
 
 @pytest.fixture
@@ -57,3 +59,64 @@ def test_no_uncompleted_by_process_last_status(test_process, test_workflow, proc
     result = no_uncompleted_instance(context)
 
     assert isinstance(result, expected_type)
+
+
+def _awaiting_process(test_workflow, *, with_timeout: bool) -> ProcessTable:
+    process = ProcessTable(
+        process_id=uuid4(), workflow_id=test_workflow.workflow_id, last_status=ProcessStatus.AWAITING_CALLBACK
+    )
+    db.session.add(process)
+    db.session.add(
+        ProcessStepTable(
+            process_id=process.process_id,
+            name="Await callback",
+            status=StepStatus.AWAITING_CALLBACK,
+            state={CALLBACK_TIMEOUT_KEY: 300} if with_timeout else {},
+        )
+    )
+    db.session.commit()
+    return process
+
+
+def test_awaiting_callbacks_exist_pass(test_workflow, generic_subscription_1) -> None:
+    _awaiting_process(test_workflow, with_timeout=True)
+
+    # workflow_key with no uncompleted instances of itself, so only the awaiting-existence check matters
+    context = MagicMock(spec=PredicateContext)
+    context.workflow_key = "task_validate_awaiting_callbacks"
+
+    assert isinstance(awaiting_callbacks_exist(context), RunPredicatePass)
+
+
+@pytest.mark.parametrize(
+    "create_awaiting_without_timeout",
+    [
+        pytest.param(False, id="no-awaiting-processes"),
+        pytest.param(True, id="awaiting-without-timeout"),
+    ],
+)
+def test_awaiting_callbacks_exist_fail(test_workflow, generic_subscription_1, create_awaiting_without_timeout) -> None:
+    if create_awaiting_without_timeout:
+        _awaiting_process(test_workflow, with_timeout=False)
+
+    context = MagicMock(spec=PredicateContext)
+    context.workflow_key = "task_validate_awaiting_callbacks"
+
+    result = awaiting_callbacks_exist(context)
+
+    assert isinstance(result, RunPredicateFail)
+    assert result.message == "No processes are awaiting a callback with a timeout"
+
+
+def test_awaiting_callbacks_exist_short_circuits_on_uncompleted_instance(test_process, test_workflow) -> None:
+    # An uncompleted instance of the task itself exists (test_process is CREATED), so the sweep must not start
+    # even though there is an awaiting-callback process with a timeout to check.
+    _awaiting_process(test_workflow, with_timeout=True)
+
+    context = MagicMock(spec=PredicateContext)
+    context.workflow_key = test_workflow.name
+
+    result = awaiting_callbacks_exist(context)
+
+    assert isinstance(result, RunPredicateFail)
+    assert "uncompleted instance" in result.message

--- a/test/unit_tests/cli/test_scheduler.py
+++ b/test/unit_tests/cli/test_scheduler.py
@@ -117,6 +117,7 @@ def test_load_initial_schedule_all_workflows_found():
         "task_clean_up_tasks",
         "task_validate_subscriptions",
         "task_validate_products",
+        "task_validate_awaiting_callbacks",
     ]
     workflow_map = {name: _make_workflow(name) for name in wf_names}
     with (
@@ -125,7 +126,7 @@ def test_load_initial_schedule_all_workflows_found():
     ):
         result = runner.invoke(app, ["load-initial-schedule"])
     assert result.exit_code == 0
-    assert mock_add.call_count == 4
+    assert mock_add.call_count == 5
     assert "Skipping" not in result.output
 
 
@@ -154,7 +155,7 @@ def test_load_initial_schedule_all_missing():
         result = runner.invoke(app, ["load-initial-schedule"])
     assert result.exit_code == 0
     assert mock_add.call_count == 0
-    assert result.output.count("Skipping") == 4
+    assert result.output.count("Skipping") == 5
 
 
 # --- show_schedule ---

--- a/test/unit_tests/workflows/tasks/test_validate_awaiting_callbacks.py
+++ b/test/unit_tests/workflows/tasks/test_validate_awaiting_callbacks.py
@@ -1,0 +1,58 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the pure timeout helper of the awaiting-callback sweep task."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from orchestrator.core.utils.datetime import nowtz
+from orchestrator.core.workflow import CALLBACK_TIMEOUT_KEY
+from orchestrator.core.workflows.tasks.validate_awaiting_callbacks import _is_timed_out
+
+NOW = nowtz()
+
+
+def _process(*, state: dict | None = None, started_offset: timedelta | None = None, no_steps: bool = False):
+    if no_steps:
+        return SimpleNamespace(steps=[])
+    started_at = None if started_offset is None else NOW - started_offset
+    return SimpleNamespace(steps=[SimpleNamespace(state=state or {}, started_at=started_at)])
+
+
+@pytest.mark.parametrize(
+    "process,expected",
+    [
+        pytest.param(_process(no_steps=True), False, id="no-steps"),
+        pytest.param(_process(state={}, started_offset=timedelta(hours=1)), False, id="no-timeout-key"),
+        pytest.param(
+            _process(state={CALLBACK_TIMEOUT_KEY: 300}, started_offset=None),
+            False,
+            id="no-started-at",
+        ),
+        pytest.param(
+            _process(state={CALLBACK_TIMEOUT_KEY: 300}, started_offset=timedelta(seconds=120)),
+            False,
+            id="not-yet-expired",
+        ),
+        pytest.param(
+            _process(state={CALLBACK_TIMEOUT_KEY: 300}, started_offset=timedelta(seconds=600)),
+            True,
+            id="expired",
+        ),
+    ],
+)
+def test_is_timed_out(process, expected) -> None:
+    assert _is_timed_out(process, NOW) is expected


### PR DESCRIPTION
Closes #1736.

A `callback_step` waits **indefinitely** in `AWAITING_CALLBACK`; if the external system never calls back, the process hangs forever and can only be recovered via the database.

This adds an optional `timeout` (seconds) to `callback_step`, default `None` = wait indefinitely (backward compatible). When set, a process past its deadline is moved to `FAILED` so it can be retried or aborted normally.

- Fail timed-out processes in place via `fail_awaiting_wf` / `fail_awaiting_process`, guarded against racing an arriving callback.
- New `task_validate_awaiting_callbacks` sweep (30s interval), gated by `awaiting_callbacks_exist` so it only runs when an awaiting callback has a timeout set.
- Register the task (LazyWorkflowInstance, migration, initial-schedule entry); document in `callbacks.md`.

Notes: `timeout` is a minimum (resolution ~30s); retry re-runs the whole callback group (re-issues the action step), so design it to be safe to repeat. Unit + integration tests added; `mypy`/`ruff` clean.