### PR TITLE
1284 persist name of user triggering task create/resume

### DIFF
--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -18,6 +18,7 @@ import structlog
 from sqlalchemy import select
 
 from oauth2_lib.fastapi import OIDCUserModel
+from orchestrator.core import app_settings
 from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.services.executors.types import ExecutorFunction
@@ -32,6 +33,7 @@ from orchestrator.core.services.processes import (
     load_process,
     safe_logstep,
 )
+from orchestrator.core.settings import ExecutorType
 from orchestrator.core.types import BroadcastFunc
 from orchestrator.core.workflow import (
     ProcessStat,
@@ -95,6 +97,14 @@ def thread_start_process(
 
     # Trigger the task in the current thread or threadpool (depends on executor mode).
     pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
+
+    # When using celery, the current_user prop is set to SYSTEM, because there is no actual user involved.
+    # The `user` property is supplied via the task and is the name of the user that triggered this task.
+    # When using the WORKER type, override `current_user` with this value so we have it available in the
+    # `created_by` property of a step.
+    if app_settings.EXECUTOR == ExecutorType.WORKER and user != SYSTEM_USER:
+        pstat.current_user = user
+
     _safe_logstep_with_func = partial(safe_logstep, broadcast_func=broadcast_func)
     return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func), broadcast_func=broadcast_func)
 

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -18,7 +18,6 @@ import structlog
 from sqlalchemy import select
 
 from oauth2_lib.fastapi import OIDCUserModel
-from orchestrator.core import app_settings
 from orchestrator.core.db import ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.services.executors.types import ExecutorFunction
@@ -33,7 +32,6 @@ from orchestrator.core.services.processes import (
     load_process,
     safe_logstep,
 )
-from orchestrator.core.settings import ExecutorType
 from orchestrator.core.types import BroadcastFunc
 from orchestrator.core.workflow import (
     ProcessStat,
@@ -102,8 +100,7 @@ def thread_start_process(
     # The `user` property is supplied via the task and is the name of the user that triggered this task.
     # When using the WORKER type, override `current_user` with this value so we have it available in the
     # `created_by` property of a step.
-    if app_settings.EXECUTOR == ExecutorType.WORKER and user != SYSTEM_USER:
-        pstat.current_user = user
+    pstat.current_user = user
 
     _safe_logstep_with_func = partial(safe_logstep, broadcast_func=broadcast_func)
     return _run_process_async(pstat.process_id, lambda: runwf(pstat, _safe_logstep_with_func), broadcast_func=broadcast_func)
@@ -112,7 +109,7 @@ def thread_start_process(
 def thread_resume_process(
     process: ProcessTable,
     *,
-    user: str | None = None,
+    user: str = SYSTEM_USER,
     user_model: OIDCUserModel | None = None,
     broadcast_func: BroadcastFunc | None = None,
 ) -> UUID:

--- a/orchestrator/core/services/executors/threadpool.py
+++ b/orchestrator/core/services/executors/threadpool.py
@@ -133,7 +133,9 @@ def thread_resume_process(
     input_data = retrieve_input_state(process.process_id, retrieve_input_str, False)
 
     if user:
-        pstat.update(current_user=user)
+        # restore the `current_user` prop to provide an answer to the question:
+        # "who retried this workflow step?"
+        pstat.current_user = user
     pstat.update(state=pstat.state.map(lambda state: StateMerger.merge(state, input_data.input_state)))
 
     # Final write action to the process: ensure the SessionTransaction is committed.

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -290,6 +290,7 @@ def _get_current_step_to_update(
             last_db_step is not None
             and last_db_step.status == process_state.status
             and last_db_step.name == step.name
+            and last_db_step.created_by == stat.current_user
             and last_db_step.state.get("error") == step_state.get("error")
             and last_db_step.state.get("details") == step_state.get("details")
         ):

--- a/test/integration_tests/services/executors/test_threadpool.py
+++ b/test/integration_tests/services/executors/test_threadpool.py
@@ -164,7 +164,7 @@ def test_thread_resume_process_resumed(
     pstat.user = expected_user
     mock_set_process_status_running.assert_called_once()
     mock_retrieve_input_state.assert_called_once_with(pstat.process_id, "user_input", False)
-    assert pstat.update.call_args_list == [call(current_user="other user"), call(state={"state": "test"})]
+    assert pstat.update.call_args_list == [call(state={"state": "test"})]
     mock_run_process_async.assert_called_once()
     assert result == process_id
 

--- a/test/integration_tests/services/executors/test_threadpool.py
+++ b/test/integration_tests/services/executors/test_threadpool.py
@@ -23,7 +23,11 @@ from orchestrator.core.services.executors.threadpool import (
     thread_resume_process,
     thread_start_process,
 )
-from orchestrator.core.services.processes import RESUME_WORKFLOW_REMOVED_ERROR_MSG, START_WORKFLOW_REMOVED_ERROR_MSG
+from orchestrator.core.services.processes import (
+    RESUME_WORKFLOW_REMOVED_ERROR_MSG,
+    START_WORKFLOW_REMOVED_ERROR_MSG,
+    SYSTEM_USER,
+)
 from orchestrator.core.targets import Target
 from orchestrator.core.workflow import (
     ProcessStat,
@@ -109,6 +113,36 @@ def test_thread_start_process(
     mock_set_process_status_running,
 ):
     process_id = uuid4()
+    username = "some user"
+
+    pstat = MagicMock()
+    pstat.process_id = process_id
+    pstat.state.map.return_value = {"state": "test"}
+
+    mock_input_data = MagicMock()
+    mock_input_data.input_state = {"key": "val"}
+    mock_retrieve_input_state.return_value = mock_input_data
+    mock_run_process_async.return_value = process_id
+
+    result = thread_start_process(pstat, username)
+
+    mock_set_process_status_running.assert_called_once_with(process_id)
+    mock_retrieve_input_state.assert_called_once_with(process_id, "initial_state", False)
+    assert pstat.update.call_args_list == [call(state={"state": "test"})]
+    mock_run_process_async.assert_called_once()
+    assert result == process_id
+    assert pstat.current_user == username
+
+
+@mock.patch("orchestrator.core.services.executors.threadpool._set_process_status_running")
+@mock.patch("orchestrator.core.services.executors.threadpool.retrieve_input_state")
+@mock.patch("orchestrator.core.services.executors.threadpool._run_process_async")
+def test_thread_start_process_without_user(
+    mock_run_process_async,
+    mock_retrieve_input_state,
+    mock_set_process_status_running,
+):
+    process_id = uuid4()
 
     pstat = MagicMock()
     pstat.process_id = process_id
@@ -126,6 +160,8 @@ def test_thread_start_process(
     assert pstat.update.call_args_list == [call(state={"state": "test"})]
     mock_run_process_async.assert_called_once()
     assert result == process_id
+    # No user supplied, so it should default to "SYSTEM"
+    assert pstat.current_user == SYSTEM_USER
 
 
 def test_thread_start_process_errors_with_removed_workflow():
@@ -159,14 +195,47 @@ def test_thread_resume_process_resumed(
 
     expected_user = "other user"
 
-    result = thread_resume_process(process, user="other user")
+    result = thread_resume_process(process, user=expected_user)
 
-    pstat.user = expected_user
     mock_set_process_status_running.assert_called_once()
     mock_retrieve_input_state.assert_called_once_with(pstat.process_id, "user_input", False)
     assert pstat.update.call_args_list == [call(state={"state": "test"})]
     mock_run_process_async.assert_called_once()
     assert result == process_id
+    assert pstat.current_user == expected_user
+
+
+@mock.patch("orchestrator.core.services.executors.threadpool._set_process_status_running")
+@mock.patch("orchestrator.core.services.executors.threadpool.retrieve_input_state")
+@mock.patch("orchestrator.core.services.executors.threadpool._run_process_async")
+@mock.patch("orchestrator.core.services.executors.threadpool.load_process")
+def test_thread_resume_process_resumed_without_user(
+    mock_load_process,
+    mock_run_process_async,
+    mock_retrieve_input_state,
+    mock_set_process_status_running,
+):
+    process_id = uuid4()
+    process = MagicMock()
+    process.process_id = process_id
+    process.last_status = ProcessStatus.SUSPENDED
+
+    pstat = MagicMock()
+    pstat.process_id = process_id
+    pstat.state.map.return_value = {"state": "test"}
+
+    mock_load_process.return_value = pstat
+
+    result = thread_resume_process(process)
+
+    mock_set_process_status_running.assert_called_once()
+    mock_retrieve_input_state.assert_called_once_with(pstat.process_id, "user_input", False)
+    assert pstat.update.call_args_list == [call(state={"state": "test"})]
+    mock_run_process_async.assert_called_once()
+    assert result == process_id
+    # Resumed without supplied username.
+    # Should default to "SYSTEM"
+    assert pstat.current_user == SYSTEM_USER
 
 
 @mock.patch("orchestrator.core.services.executors.threadpool._set_process_status_running")


### PR DESCRIPTION
## Summary
When using the worker as task executor (versus threadpool), there is no actual user triggering the task since Celery doesn't know about it. This information is provided with the task however, just not persisted.

In `start_process` and `resume_process` we update the `current_user` in ProcessState with the `user` parameter. This `user` is the actual user that created the task/ran the workflow/retried the workflow.
The `created_by` column in `process_steps` is now filled with this user instead of the default `SYSTEM`.

The method `_get_current_step_to_update` now also takes this `created_by` value into account in the decision to update the last step (same user) or record a new step (another user retried the step).

## Related Issues
Fixes #1284

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
