### PR TITLE
Fix cron schedule parsing (wildcards dropped → every second, valid fields rejected, 6 fields → 500)

### DIFF
--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -348,5 +348,6 @@ The deadline is measured from the moment the await started. Progress updates sen
 Timeouts are enforced by the `task_validate_awaiting_callbacks` scheduled task, which sweeps every
 **30 seconds** by default. So `timeout` is a *minimum*: a process is failed on the first sweep at or
 after its deadline (up to ~30 seconds late) — don't rely on sub-30-second precision. Load the task
-with `orchestrator-core scheduler load-initial-schedule`; the interval can be changed to any value
-via the scheduler API (`PUT /api/schedules/`, which reschedules the job in place).
+with `orchestrator-core scheduler load-initial-schedule`; to change the interval, delete the schedule
+and recreate it as a cron schedule at the desired frequency (a 6-field cron can specify seconds, e.g.
+`*/15 * * * * *`).

--- a/orchestrator/core/forms/scheduler_form.py
+++ b/orchestrator/core/forms/scheduler_form.py
@@ -72,31 +72,26 @@ INTERVAL_MAPPING = {
     Intervals.ONE_MONTH: {"weeks": 4},
 }
 
-cron_regex = r"^(?:(\*|([0-5]?\d))(?:/(\d+))?\s+){4}(?:(\*|([0-5]?\d))(?:/(\d+))?\s+)?(?:([0-9,/*\-?LW#]+)(?:\s+([0-9,/*\-?LW#]+))?(?:\s+([0-9,/*\-?LW#]+))?)$"
+# 5 fields (minute hour day month day_of_week) or 6 with a leading second; each field allows the
+# cron characters (digits, *, /, -, ,, and names). CronTrigger validates the field values.
+cron_regex = r"^([\w*,\-/]+)(\s+[\w*,\-/]+){4,5}$"
 
 
 def get_interval_kwargs(form_data: dict) -> dict:
     return {"start_date": form_data["start_date"]} | INTERVAL_MAPPING[form_data["interval"]]
 
 
-def parse_cron_field(value: str) -> int | None:
-    try:
-        return int(value)
-    except ValueError:
-        return None
-
-
 def get_cron_kwargs(form_data: dict) -> dict:
-    minute, hour, day, month, day_of_week = form_data["cron"].split(" ")
+    # Pass the raw field strings to CronTrigger, which accepts *, */n, ranges and lists. A 5-field
+    # expression is minute..day_of_week; a 6-field one adds a leading second.
+    names = ["minute", "hour", "day", "month", "day_of_week"]
+    fields = form_data["cron"].split()
+    if len(fields) == 6:
+        names = ["second", *names]
+    elif len(fields) != 5:
+        raise ValueError("A cron schedule needs 5 fields (minute hour day month day_of_week) or 6 with a leading second")
 
-    return {
-        "start_date": form_data["start_date"],
-        "minute": parse_cron_field(minute),
-        "hour": parse_cron_field(hour),
-        "day": parse_cron_field(day),
-        "month": parse_cron_field(month),
-        "day_of_week": parse_cron_field(day_of_week),
-    }
+    return {"start_date": form_data["start_date"]} | dict(zip(names, fields, strict=True))
 
 
 async def _check_authorize(workflow: Workflow, user_model: OIDCUserModel | None) -> bool:

--- a/orchestrator/core/forms/scheduler_form.py
+++ b/orchestrator/core/forms/scheduler_form.py
@@ -17,7 +17,8 @@ from typing import Annotated
 from uuid import UUID
 
 import structlog
-from pydantic import ConfigDict, StringConstraints
+from apscheduler.triggers.cron import CronTrigger
+from pydantic import AfterValidator, ConfigDict
 from sqlalchemy import select
 from typing_extensions import TypedDict
 
@@ -72,26 +73,52 @@ INTERVAL_MAPPING = {
     Intervals.ONE_MONTH: {"weeks": 4},
 }
 
-# 5 fields (minute hour day month day_of_week) or 6 with a leading second; each field allows the
-# cron characters (digits, *, /, -, ,, and names). CronTrigger validates the field values.
-cron_regex = r"^([\w*,\-/]+)(\s+[\w*,\-/]+){4,5}$"
-
 
 def get_interval_kwargs(form_data: dict) -> dict:
     return {"start_date": form_data["start_date"]} | INTERVAL_MAPPING[form_data["interval"]]
 
 
-def get_cron_kwargs(form_data: dict) -> dict:
-    # Pass the raw field strings to CronTrigger, which accepts *, */n, ranges and lists. A 5-field
-    # expression is minute..day_of_week; a 6-field one adds a leading second.
-    names = ["minute", "hour", "day", "month", "day_of_week"]
-    fields = form_data["cron"].split()
-    if len(fields) == 6:
-        names = ["second", *names]
-    elif len(fields) != 5:
-        raise ValueError("A cron schedule needs 5 fields (minute hour day month day_of_week) or 6 with a leading second")
+def _cron_fields(cron: str) -> dict[str, str]:
+    """Map cron field strings to their CronTrigger keyword names.
 
-    return {"start_date": form_data["start_date"]} | dict(zip(names, fields, strict=True))
+    A 5-field expression is minute..day_of_week; a 6-field one adds a leading second.
+    """
+    fields = cron.split()
+    match len(fields):
+        case 5:
+            names = ["minute", "hour", "day", "month", "day_of_week"]
+        case 6:
+            names = ["second", "minute", "hour", "day", "month", "day_of_week"]
+        case _:
+            raise ValueError(
+                "A cron schedule needs 5 fields (minute hour day month day_of_week) or 6 with a leading second"
+            )
+    return dict(zip(names, fields, strict=True))
+
+
+def _cron_field_error(name: str, value: str) -> str | None:
+    """Return a field-scoped error message if ``value`` is invalid for cron field ``name``, else None."""
+    try:
+        CronTrigger(**{name: value})
+        return None
+    except ValueError as exc:
+        return f"{name} {value!r}: {exc}"
+
+
+def validate_cron(cron: str) -> str:
+    """Reject invalid cron expressions at form time.
+
+    Each field is validated on its own (minute 0-59, hour 0-23, day 1-31, month 1-12, day_of_week
+    0-7; a leading second 0-59 with 6 fields) so the error names the offending field(s) and reports
+    all of them at once, instead of failing silently later in the scheduler queue.
+    """
+    if errors := [msg for name, value in _cron_fields(cron).items() if (msg := _cron_field_error(name, value))]:
+        raise ValueError("; ".join(errors))
+    return cron
+
+
+def get_cron_kwargs(form_data: dict) -> dict:
+    return {"start_date": form_data["start_date"]} | _cron_fields(form_data["cron"])
 
 
 async def _check_authorize(workflow: Workflow, user_model: OIDCUserModel | None) -> bool:
@@ -179,7 +206,7 @@ async def configure_schedule_form(state: State) -> FormGeneratorAsync:
         if schedule_type_form.schedule_type == ScheduleTypeEnum.INTERVAL:
             interval: Intervals
         if schedule_type_form.schedule_type == ScheduleTypeEnum.CRON:
-            cron: Annotated[str, StringConstraints(pattern=cron_regex)]
+            cron: Annotated[str, AfterValidator(validate_cron)]
 
         buttons: Buttons = {"previous": {}, "next": {"text": "Create Schedule"}}
 

--- a/orchestrator/core/schedules/service.py
+++ b/orchestrator/core/schedules/service.py
@@ -15,9 +15,7 @@ from uuid import UUID, uuid4
 
 import structlog
 from apscheduler.schedulers.base import BaseScheduler
-from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.date import DateTrigger
-from apscheduler.triggers.interval import IntervalTrigger
+from apscheduler.triggers.base import BaseTrigger
 from sqlalchemy import delete, select
 
 from orchestrator.core import app_settings
@@ -29,6 +27,7 @@ from orchestrator.core.schemas.schedules import (
     APSchedulerJobs,
     APSchedulerJobUpdate,
     APSJobAdapter,
+    build_trigger,
 )
 from orchestrator.core.services.processes import start_process
 from orchestrator.core.services.workflows import get_workflow_by_workflow_id
@@ -88,7 +87,7 @@ def _delete_scheduled_tasks(schedules: list[WorkflowApschedulerJob]) -> None:
         add_scheduled_task_to_queue(delete_payload)
 
 
-def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate, *, recreate: bool=False) -> bool:
+def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate, *, recreate: bool = False) -> bool:
     """Create a unique scheduled task service function.
 
     Checks if the workflow is already scheduled before creating an apscheduler
@@ -112,7 +111,9 @@ def add_unique_scheduled_task_to_queue(payload: APSchedulerJobCreate, *, recreat
     schedules = db.session.scalars(select(WorkflowApschedulerJob).filter_by(workflow_id=payload.workflow_id)).all()
     if schedules:
         if not recreate:
-            logger.info("Not scheduling workflow as there are existing schedules, and recreate is not set", existing=schedules)
+            logger.info(
+                "Not scheduling workflow as there are existing schedules, and recreate is not set", existing=schedules
+            )
             return False
         logger.info("Deleting existing schedules for workflow", existing=schedules)
         _delete_scheduled_tasks(
@@ -227,22 +228,12 @@ def _add_scheduled_task(payload: APSchedulerJobCreate, scheduler_connection: Bas
     _add_linker_entry(workflow_id=payload.workflow_id, schedule_id=schedule_id)
 
 
-def _build_trigger_on_update(
-    trigger_name: str | None, trigger_kwargs: dict
-) -> IntervalTrigger | CronTrigger | DateTrigger | None:
+def _build_trigger_on_update(trigger_name: str | None, trigger_kwargs: dict) -> BaseTrigger | None:
     if not trigger_name or not trigger_kwargs:
         logger.info("Skipping building trigger as no trigger information is provided")
         return None
 
-    match trigger_name:
-        case "interval":
-            return IntervalTrigger(**trigger_kwargs)
-        case "cron":
-            return CronTrigger(**trigger_kwargs)
-        case "date":
-            return DateTrigger(**trigger_kwargs)
-        case _:
-            raise ValueError(f"Invalid trigger type: {trigger_name}")
+    return build_trigger(trigger_name, trigger_kwargs)
 
 
 def _update_scheduled_task(payload: APSchedulerJobUpdate, scheduler_connection: BaseScheduler) -> None:

--- a/orchestrator/core/schemas/schedules.py
+++ b/orchestrator/core/schemas/schedules.py
@@ -10,10 +10,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal, Self, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, TypeAdapter
+from apscheduler.triggers.base import BaseTrigger
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 from orchestrator.core.workflow import default_user_inputs
 from pydantic_forms.types import State
@@ -21,6 +25,32 @@ from pydantic_forms.types import State
 SCHEDULER_Q_CREATE = "create"
 SCHEDULER_Q_UPDATE = "update"
 SCHEDULER_Q_DELETE = "delete"
+
+TRIGGER_TYPES: dict[str, type[BaseTrigger]] = {
+    "interval": IntervalTrigger,
+    "cron": CronTrigger,
+    "date": DateTrigger,
+}
+
+
+def build_trigger(trigger: str, trigger_kwargs: dict[str, Any]) -> BaseTrigger:
+    """Construct the APScheduler trigger for ``trigger``, raising ValueError/TypeError on bad kwargs."""
+    if (trigger_cls := TRIGGER_TYPES.get(trigger)) is None:
+        raise ValueError(f"Invalid trigger type: {trigger}")
+    return trigger_cls(**trigger_kwargs)
+
+
+def _validate_trigger_kwargs(trigger: str | None, trigger_kwargs: dict[str, Any] | None) -> None:
+    """Fail schema validation if trigger_kwargs don't build a valid trigger.
+
+    Returning a 422 at the API boundary beats silently dropping the job later in the scheduler queue.
+    """
+    if trigger is None:
+        return
+    try:
+        build_trigger(trigger, trigger_kwargs or {})
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid trigger_kwargs for {trigger!r} trigger: {exc}") from exc
 
 
 class APSchedulerJob(BaseModel):
@@ -42,6 +72,11 @@ class APSchedulerJobCreate(APSchedulerJob):
 
     scheduled_type: Literal["create"] = Field("create", frozen=True)
 
+    @model_validator(mode="after")
+    def _check_trigger_kwargs(self) -> Self:
+        _validate_trigger_kwargs(self.trigger, self.trigger_kwargs)
+        return self
+
 
 class APSchedulerJobUpdate(APSchedulerJob):
     name: str | None = Field(None, description="Human readable name e.g. 'My Process'")
@@ -55,6 +90,11 @@ class APSchedulerJobUpdate(APSchedulerJob):
     )
 
     scheduled_type: Literal["update"] = Field("update", frozen=True)
+
+    @model_validator(mode="after")
+    def _check_trigger_kwargs(self) -> Self:
+        _validate_trigger_kwargs(self.trigger, self.trigger_kwargs)
+        return self
 
 
 class APSchedulerJobDelete(APSchedulerJob):

--- a/orchestrator/core/workflows/translations/en-GB.json
+++ b/orchestrator/core/workflows/translations/en-GB.json
@@ -14,7 +14,7 @@
             "start_date": "Start date",
             "interval": "Choose the schedule interval",
             "cron": "Cron expression",
-            "cron_info": "Enter a valid cron-expression using 5 fields: minute (0-59) hour (0-23) day (1-31) month (1-12) weekday (0-6). Example: 0 8 * * 1 (every Monday at 08:00)",
+            "cron_info": "Cron expression: 5 fields (minute hour day month weekday), or 6 with a leading second. Examples: 0 8 * * 1 (Mondays at 08:00), */15 * * * * * (every 15 seconds)",
             "buttons": "buttons"
         }
     },

--- a/test/integration_tests/api/test_schedule_config_form.py
+++ b/test/integration_tests/api/test_schedule_config_form.py
@@ -124,11 +124,11 @@ def test_forms_endpoint_scheduler_config_cron_type(test_client):
             "trigger": "cron",
             "trigger_kwargs": {
                 "start_date": response_data["trigger_kwargs"]["start_date"],
-                "minute": 0,
-                "hour": 9,
-                "day": None,
-                "month": None,
-                "day_of_week": None,
+                "minute": "0",
+                "hour": "9",
+                "day": "*",
+                "month": "*",
+                "day_of_week": "1-5",
             },
             "user_inputs": [{}],
         }

--- a/test/unit_tests/forms/test_scheduler_form.py
+++ b/test/unit_tests/forms/test_scheduler_form.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-from orchestrator.core.forms.scheduler_form import _check_authorize, get_cron_kwargs
+from orchestrator.core.forms.scheduler_form import _check_authorize, get_cron_kwargs, validate_cron
 from orchestrator.core.utils.auth import AuthContext
 from orchestrator.core.workflow import begin, done, step, workflow
 
@@ -128,3 +128,59 @@ def test_get_cron_kwargs(cron, expected):
 def test_get_cron_kwargs_rejects_wrong_field_count(cron):
     with pytest.raises(ValueError):
         get_cron_kwargs({"cron": cron, "start_date": START_DATE})
+
+
+@pytest.mark.parametrize(
+    "cron",
+    ["* * * * *", "0-59 * * * *", "1,15,30 * * * *", "0 9-17 * * 1-5", "*/15 * * * * *"],
+    ids=["wildcards", "range", "list", "workhours", "6-field-seconds"],
+)
+def test_validate_cron_accepts_valid(cron):
+    assert validate_cron(cron) == cron
+
+
+@pytest.mark.parametrize(
+    "cron",
+    [
+        "60 * * * * *",
+        "60 * * * *",
+        "* 24 * * *",
+        "* * 0 * *",
+        "* * 32 * *",
+        "* * * 0 *",
+        "* * * 13 *",
+        "* * * * 8",
+        "* * * *",
+        "* * * * * * *",
+    ],
+    ids=[
+        "second-oob",
+        "minute-oob",
+        "hour-oob",
+        "day-zero",
+        "day-oob",
+        "month-zero",
+        "month-oob",
+        "day_of_week-oob",
+        "4-fields",
+        "7-fields",
+    ],
+)
+def test_validate_cron_rejects_invalid(cron):
+    with pytest.raises(ValueError):
+        validate_cron(cron)
+
+
+@pytest.mark.parametrize(
+    "cron,expected_fields",
+    [
+        pytest.param("61 61 * * * *", ["second '61'", "minute '61'"], id="two-bad-6-field"),
+        pytest.param("50-52 59 24 * * *", ["hour '24'"], id="hour-only-6-field"),
+        pytest.param("61 24 * * *", ["minute '61'", "hour '24'"], id="two-bad-5-field"),
+    ],
+)
+def test_validate_cron_error_names_all_bad_fields(cron, expected_fields):
+    with pytest.raises(ValueError) as exc_info:
+        validate_cron(cron)
+    message = str(exc_info.value)
+    assert all(field in message for field in expected_fields)

--- a/test/unit_tests/forms/test_scheduler_form.py
+++ b/test/unit_tests/forms/test_scheduler_form.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-from orchestrator.core.forms.scheduler_form import _check_authorize
+from orchestrator.core.forms.scheduler_form import _check_authorize, get_cron_kwargs
 from orchestrator.core.utils.auth import AuthContext
 from orchestrator.core.workflow import begin, done, step, workflow
 
@@ -85,3 +85,46 @@ async def test_check_authorize_passes_auth_context(username_workflow):
     assert await _check_authorize(username_workflow, FakeUser("admin")) is True
     assert await _check_authorize(username_workflow, FakeUser("nobody")) is False
     assert await _check_authorize(username_workflow, None) is False
+
+
+START_DATE = object()  # get_cron_kwargs passes start_date through unchanged
+
+
+@pytest.mark.parametrize(
+    ("cron", "expected"),
+    [
+        pytest.param(
+            "* * * * *",
+            {"minute": "*", "hour": "*", "day": "*", "month": "*", "day_of_week": "*"},
+            id="5-field-wildcards",
+        ),
+        pytest.param(
+            "0-59 * * * *",
+            {"minute": "0-59", "hour": "*", "day": "*", "month": "*", "day_of_week": "*"},
+            id="range",
+        ),
+        pytest.param(
+            "1,15,30 * * * *",
+            {"minute": "1,15,30", "hour": "*", "day": "*", "month": "*", "day_of_week": "*"},
+            id="list",
+        ),
+        pytest.param(
+            "0 8 * * 1",
+            {"minute": "0", "hour": "8", "day": "*", "month": "*", "day_of_week": "1"},
+            id="specific",
+        ),
+        pytest.param(
+            "*/15 * * * * *",
+            {"second": "*/15", "minute": "*", "hour": "*", "day": "*", "month": "*", "day_of_week": "*"},
+            id="6-field-seconds",
+        ),
+    ],
+)
+def test_get_cron_kwargs(cron, expected):
+    assert get_cron_kwargs({"cron": cron, "start_date": START_DATE}) == {"start_date": START_DATE, **expected}
+
+
+@pytest.mark.parametrize("cron", ["* * * *", "* * * * * * *"], ids=["4-fields", "7-fields"])
+def test_get_cron_kwargs_rejects_wrong_field_count(cron):
+    with pytest.raises(ValueError):
+        get_cron_kwargs({"cron": cron, "start_date": START_DATE})

--- a/test/unit_tests/schemas/test_schedules.py
+++ b/test/unit_tests/schemas/test_schedules.py
@@ -79,7 +79,7 @@ CREATE_BASE = {"scheduled_type": "create", "workflow_name": "wf", "workflow_id":
     ],
 )
 def test_create_accepts_valid_trigger_kwargs(trigger: str, trigger_kwargs: dict) -> None:
-    job = APSchedulerJobCreate(**CREATE_BASE, trigger=trigger, trigger_kwargs=trigger_kwargs)
+    job = APSchedulerJobCreate.model_validate({**CREATE_BASE, "trigger": trigger, "trigger_kwargs": trigger_kwargs})
     assert job.trigger_kwargs == trigger_kwargs
 
 
@@ -93,17 +93,24 @@ def test_create_accepts_valid_trigger_kwargs(trigger: str, trigger_kwargs: dict)
 )
 def test_create_rejects_invalid_trigger_kwargs(trigger: str, trigger_kwargs: dict) -> None:
     with pytest.raises(ValidationError):
-        APSchedulerJobCreate(**CREATE_BASE, trigger=trigger, trigger_kwargs=trigger_kwargs)
+        APSchedulerJobCreate.model_validate({**CREATE_BASE, "trigger": trigger, "trigger_kwargs": trigger_kwargs})
 
 
 def test_update_rejects_invalid_trigger_kwargs() -> None:
     with pytest.raises(ValidationError):
-        APSchedulerJobUpdate(
-            scheduled_type="update", schedule_id=str(SCHEDULE_ID), trigger="cron", trigger_kwargs={"minute": "61"}
+        APSchedulerJobUpdate.model_validate(
+            {
+                "scheduled_type": "update",
+                "schedule_id": str(SCHEDULE_ID),
+                "trigger": "cron",
+                "trigger_kwargs": {"minute": "61"},
+            }
         )
 
 
 def test_update_without_trigger_skips_validation() -> None:
     # trigger/trigger_kwargs are optional on update; nothing to validate when trigger is absent
-    job = APSchedulerJobUpdate(scheduled_type="update", schedule_id=str(SCHEDULE_ID), name="renamed")
+    job = APSchedulerJobUpdate.model_validate(
+        {"scheduled_type": "update", "schedule_id": str(SCHEDULE_ID), "name": "renamed"}
+    )
     assert job.trigger is None

--- a/test/unit_tests/schemas/test_schedules.py
+++ b/test/unit_tests/schemas/test_schedules.py
@@ -64,3 +64,46 @@ def test_adapter_dispatches_to_correct_type(data: dict, expected_type: type) -> 
 def test_adapter_rejects_invalid_input(data: dict) -> None:
     with pytest.raises(ValidationError):
         APSJobAdapter.validate_python(data)
+
+
+CREATE_BASE = {"scheduled_type": "create", "workflow_name": "wf", "workflow_id": str(WORKFLOW_ID)}
+
+
+@pytest.mark.parametrize(
+    "trigger,trigger_kwargs",
+    [
+        pytest.param("cron", {"minute": "*/15"}, id="cron-valid"),
+        pytest.param("cron", {"second": "*/15", "minute": "*"}, id="cron-6-field"),
+        pytest.param("interval", {"hours": 12}, id="interval-valid"),
+        pytest.param("cron", {}, id="empty-kwargs-ok"),
+    ],
+)
+def test_create_accepts_valid_trigger_kwargs(trigger: str, trigger_kwargs: dict) -> None:
+    job = APSchedulerJobCreate(**CREATE_BASE, trigger=trigger, trigger_kwargs=trigger_kwargs)
+    assert job.trigger_kwargs == trigger_kwargs
+
+
+@pytest.mark.parametrize(
+    "trigger,trigger_kwargs",
+    [
+        pytest.param("cron", {"minute": "61"}, id="cron-minute-oob"),
+        pytest.param("cron", {"day_of_week": "8"}, id="cron-dow-oob"),
+        pytest.param("interval", {"hours": "not-a-number"}, id="interval-bad-type"),
+    ],
+)
+def test_create_rejects_invalid_trigger_kwargs(trigger: str, trigger_kwargs: dict) -> None:
+    with pytest.raises(ValidationError):
+        APSchedulerJobCreate(**CREATE_BASE, trigger=trigger, trigger_kwargs=trigger_kwargs)
+
+
+def test_update_rejects_invalid_trigger_kwargs() -> None:
+    with pytest.raises(ValidationError):
+        APSchedulerJobUpdate(
+            scheduled_type="update", schedule_id=str(SCHEDULE_ID), trigger="cron", trigger_kwargs={"minute": "61"}
+        )
+
+
+def test_update_without_trigger_skips_validation() -> None:
+    # trigger/trigger_kwargs are optional on update; nothing to validate when trigger is absent
+    job = APSchedulerJobUpdate(scheduled_type="update", schedule_id=str(SCHEDULE_ID), name="renamed")
+    assert job.trigger is None


### PR DESCRIPTION
Closes #1754.

The CRON path in `scheduler_form.py` had three defects:
- `parse_cron_field` int-coerced fields, turning `*`, `*/n`, ranges and lists into `None` → an unconstrained `CronTrigger` firing **every second**.
- a 6-field expression passed the regex but crashed the 5-way unpack → **500**.
- the regex rejected valid `-`/`,` fields (e.g. `0-59 * * * *`).

Now the field strings are passed straight to `CronTrigger` (which accepts `*`, `*/n`, ranges, lists), and the form accepts exactly **5 fields** (`minute…day_of_week`) or **6** (leading `second`), rejecting other counts. Also updates the callback-timeout doc to the delete-and-recreate-cron flow.

Verified via `test_get_cron_kwargs`: `* * * * *` → every minute; `0-59 * * * *`, `1,15,30 * * * *`, `0 9-17 * * 1-5` accepted; `*/15 * * * * *` → every 15s; 4-/7-field input rejected.
