### PR TITLE
Fix indentation in plugin section of mkdocs.yaml

### DIFF
--- a/docs/getting-started/base.md
+++ b/docs/getting-started/base.md
@@ -149,6 +149,6 @@ Visit the [ReDoc](http://127.0.0.1:8080/api/redoc) or [OpenAPI](http://127.0.0.1
 
 ### Next:
 
-- [Create a product.](../../workshops/example-orchestrator/domain-models.md)
+- [Create a product.](../../../workshops/example-orchestrator/domain-models/)
 - [Create a workflow for a product.](./workflows.md)
 - [Generate products and workflows](../reference-docs/cli.md#generate)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,25 +52,25 @@ plugins:
   - privacy
   - social
   - mkdocstrings:
-    default_handler: python
-    enable_inventory: true
-    handlers:
-      python:
-        options:
-          show_source: true
-          show_root_heading: true
-          show_root_toc_entry: true
-          show_symbol_type_heading: true
-          show_symbol_type_toc: true
-          docstring_style: null
-          docstring_section_style: list
-          annotations_path: full
-          separate_signature: true
-          line_length: 80
-          show_signature_annotations: true
-          unwrap_annotated: true
-          docstring_options:
-            trim_doctest_flags: true
+      default_handler: python
+      enable_inventory: true
+      handlers:
+        python:
+          options:
+            show_source: true
+            show_root_heading: true
+            show_root_toc_entry: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            docstring_style: null
+            docstring_section_style: list
+            annotations_path: full
+            separate_signature: true
+            line_length: 80
+            show_signature_annotations: true
+            unwrap_annotated: true
+            docstring_options:
+              trim_doctest_flags: true
   - redirects:
       redirect_maps:
         "architecture/product_modelling/imports.md": "guides/product-modeling/imports.md"


### PR DESCRIPTION
## Summary
Fix a YAML indentation error that caused the CI pipeline for docs build to fail

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
