### PR TITLE
Allow reconcile workflow to be run on out-of-sync subscriptions

### DIFF
--- a/orchestrator/core/workflows/steps.py
+++ b/orchestrator/core/workflows/steps.py
@@ -102,7 +102,7 @@ def unsync(subscription_id: UUIDstr, __old_subscriptions__: dict | None = None) 
 
 @step("Lock subscription")
 def unsync_unchecked(subscription_id: UUIDstr) -> State:
-    """Use for validation workflows that need to run if the subscription is out of sync."""
+    """Use for validation and reconcile workflows that need to run if the subscription is out of sync."""
     subscription = SubscriptionModel.from_subscription(subscription_id)
     subscription.insync = False
     sync_invalidate_subscription_cache(subscription.subscription_id)

--- a/orchestrator/core/workflows/utils.py
+++ b/orchestrator/core/workflows/utils.py
@@ -516,7 +516,7 @@ def reconcile_workflow(
         steplist = (
             init
             >> store_process_subscription()
-            >> unsync
+            >> unsync_unchecked
             >> f()
             >> (additional_steps or StepList())
             >> resync


### PR DESCRIPTION
## Summary
Allow reconcile workflow to be run on out-of-sync subscriptions
- apply same mechanism as used for validate workflow
- the workflow will not fail on the lock subscription step anymore

## Related Issues
Fixes # (issue number)

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
