### PR TITLE
Import litellm lazily; pre-warm at app startup when EMBEDDING_API_ENABLED

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.1
+current_version = 5.1.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<build>\d+))?

--- a/orchestrator/core/app.py
+++ b/orchestrator/core/app.py
@@ -58,6 +58,7 @@ from orchestrator.core.graphql.schemas.subscription import SubscriptionInterface
 from orchestrator.core.graphql.types import ScalarOverrideType, StrawberryModelType
 from orchestrator.core.log_config import LOGGER_OVERRIDES
 from orchestrator.core.metrics import ORCHESTRATOR_METRICS_REGISTRY, initialize_default_metrics
+from orchestrator.core.search.core.embedding import prewarm_embedding_dependencies
 from orchestrator.core.search.query.exceptions import QueryValidationError
 from orchestrator.core.services.process_broadcast_thread import ProcessDataBroadcastThread
 from orchestrator.core.services.worker_status_monitor import get_worker_status_monitor
@@ -220,6 +221,10 @@ class OrchestratorCore(FastAPI):
             from orchestrator.core.mcp.server import mount_mcp
 
             self._mcp_app = mount_mcp(self)
+
+        # Pre-warm the lazily imported litellm so the first embedding call at runtime
+        # does not pay the import cost (no-op unless EMBEDDING_API_ENABLED is set).
+        prewarm_embedding_dependencies()
 
         @self.router.get("/", response_model=str, response_class=JSONResponse, include_in_schema=False)
         def _index() -> str:

--- a/orchestrator/core/search/core/embedding.py
+++ b/orchestrator/core/search/core/embedding.py
@@ -22,6 +22,19 @@ from orchestrator.core.settings import llm_settings
 logger = structlog.get_logger(__name__)
 
 
+def prewarm_embedding_dependencies() -> None:
+    """Eagerly import litellm if the embedding API is enabled.
+
+    litellm is imported lazily in this package to keep process startup fast when
+    embeddings are unused. Applications that do use embeddings can call this at
+    startup so the first embedding call does not pay the (multi-second) import cost.
+    """
+    if not llm_settings.EMBEDDING_API_ENABLED:
+        return
+
+    import litellm  # noqa: F401
+
+
 class EmbeddingIndexer:
     @classmethod
     def _empty_embeddings(cls, texts: list[str]) -> list[list[Any]]:

--- a/orchestrator/core/search/core/embedding.py
+++ b/orchestrator/core/search/core/embedding.py
@@ -13,11 +13,11 @@
 from typing import Any
 
 import structlog
-from litellm import aembedding as llm_aembedding
-from litellm import embedding as llm_embedding
-from litellm import exceptions as llm_exc
 
 from orchestrator.core.settings import llm_settings
+
+# Note: litellm is imported lazily inside the methods below because importing it is
+# expensive (multiple seconds) and it is only needed when embeddings are generated.
 
 logger = structlog.get_logger(__name__)
 
@@ -38,6 +38,9 @@ class EmbeddingIndexer:
         if not llm_settings.EMBEDDING_API_ENABLED:
             logger.info("Embedding API not enabled, not generating embeddings")
             return EmbeddingIndexer._empty_embeddings(texts)
+
+        from litellm import embedding as llm_embedding
+        from litellm import exceptions as llm_exc
 
         try:
             resp = llm_embedding(
@@ -82,6 +85,8 @@ class QueryEmbedder:
         if not llm_settings.EMBEDDING_API_ENABLED:
             logger.debug("Embedding API not enabled, search functionality restricted to fuzzy/structured search")
             return None
+
+        from litellm import aembedding as llm_aembedding
 
         try:
             resp = await llm_aembedding(

--- a/orchestrator/core/search/indexing/indexer.py
+++ b/orchestrator/core/search/indexing/indexer.py
@@ -18,7 +18,6 @@ from functools import lru_cache
 from typing import Any
 
 import structlog
-from litellm.utils import encode, get_max_tokens
 from sqlalchemy import delete, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.dialects.postgresql.dml import Insert
@@ -261,6 +260,9 @@ class Indexer:
         self, fields_to_upsert: Iterable[tuple[str, ExtractedField]]
     ) -> Generator[list[IndexableRecord], None, None]:
         """Streams through fields, buffers them by token count, and yields batches."""
+        # Imported lazily because importing litellm is expensive (multiple seconds).
+        from litellm.utils import encode
+
         embeddable_buffer: list[tuple[str, ExtractedField]] = []
         non_embeddable_records: list[IndexableRecord] = []
         current_tokens = 0
@@ -325,6 +327,9 @@ class Indexer:
 
     def _get_max_tokens(self) -> int:
         """Gets max tokens, using a fallback from settings if necessary."""
+        # Imported lazily because importing litellm is expensive (multiple seconds).
+        from litellm.utils import get_max_tokens
+
         try:
             max_ctx = get_max_tokens(self.embedding_model)
             if isinstance(max_ctx, int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "orchestrator-core"
 description = "This is the orchestrator workflow engine."
-version = "5.1.1"
+version = "5.1.2"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/test/acceptance_tests/search/llm/conftest.py
+++ b/test/acceptance_tests/search/llm/conftest.py
@@ -173,7 +173,7 @@ def mock_embeddings(embedding_fixtures: dict[str, list[float]]):
 
         return mock_response
 
-    with patch("orchestrator.core.search.core.embedding.llm_aembedding", side_effect=mock_embedding_async):
+    with patch("litellm.aembedding", side_effect=mock_embedding_async):
         yield
 
 

--- a/test/integration_tests/search/test_indexer.py
+++ b/test/integration_tests/search/test_indexer.py
@@ -207,14 +207,14 @@ def test_force_index_ignores_existing_hashes(mock_config, mock_entity):
 
 def test_get_max_tokens_from_model(indexer):
     """Test retrieving max tokens from model."""
-    with patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=8191):
+    with patch("litellm.utils.get_max_tokens", return_value=8191):
         assert indexer._get_max_tokens() == 8191
 
 
 def test_get_max_tokens_fallback(indexer):
     """Test fallback when model is not recognized."""
     with (
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", side_effect=Exception("Unknown model")),
+        patch("litellm.utils.get_max_tokens", side_effect=Exception("Unknown model")),
         patch("orchestrator.core.search.indexing.indexer.llm_settings.EMBEDDING_FALLBACK_MAX_TOKENS", 8000),
     ):
         assert indexer._get_max_tokens() == 8000
@@ -266,7 +266,7 @@ def test_generate_upsert_batches(indexer, field_path, field_value, field_type):
 
     if should_have_embedding:
         with (
-            patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1, 2, 3, 4, 5]),
+            patch("litellm.utils.encode", return_value=[1, 2, 3, 4, 5]),
             patch(
                 "orchestrator.core.search.core.embedding.EmbeddingIndexer.get_embeddings_from_api_batch",
                 return_value=[[0.1, 0.2]],
@@ -292,7 +292,7 @@ def test_tokenization_failure_skips_field(indexer):
         (ENTITY_ID, ExtractedField(path="description", value="Text", value_type=FieldType.STRING)),
     ]
 
-    with patch("orchestrator.core.search.indexing.indexer.encode", side_effect=Exception("Tokenization error")):
+    with patch("litellm.utils.encode", side_effect=Exception("Tokenization error")):
         batches = list(indexer._generate_upsert_batches(fields_to_upsert))
 
     assert batches == []
@@ -305,7 +305,7 @@ def test_field_exceeds_context_window(indexer):
     ]
 
     with (
-        patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1] * 10000),
+        patch("litellm.utils.encode", return_value=[1] * 10000),
         patch.object(indexer, "_get_max_tokens", return_value=8191),
     ):
         batches = list(indexer._generate_upsert_batches(fields_to_upsert))

--- a/test/unit_tests/search/core/test_embedding.py
+++ b/test/unit_tests/search/core/test_embedding.py
@@ -96,7 +96,7 @@ def test_embedding_indexer_successful_batch_returns_truncated():
     resp_mock = _make_embedding_response(raw_embeddings)
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_embedding", return_value=resp_mock),
+        patch("litellm.embedding", return_value=resp_mock),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = EmbeddingIndexer.get_embeddings_from_api_batch(["hello", "world"], dry_run=False)
@@ -126,7 +126,7 @@ def test_embedding_indexer_sorts_by_index(resp_data, expected):
     resp.data = resp_data
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_embedding", return_value=resp),
+        patch("litellm.embedding", return_value=resp),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = EmbeddingIndexer.get_embeddings_from_api_batch(["first", "second"], dry_run=False)
@@ -139,7 +139,7 @@ def test_embedding_indexer_inputs_are_lowercased():
     resp_mock = _make_embedding_response([[0.1, 0.2, 0.3]])
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_embedding", return_value=resp_mock) as mock_embed,
+        patch("litellm.embedding", return_value=resp_mock) as mock_embed,
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         EmbeddingIndexer.get_embeddings_from_api_batch(["HELLO"], dry_run=False)
@@ -179,7 +179,7 @@ def test_embedding_indexer_known_api_errors_return_empty(exception):
     texts = ["hello", "world"]
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_embedding", side_effect=exception),
+        patch("litellm.embedding", side_effect=exception),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = EmbeddingIndexer.get_embeddings_from_api_batch(texts, dry_run=False)
@@ -192,7 +192,7 @@ def test_embedding_indexer_unexpected_error_returns_empty():
     texts = ["a", "b", "c"]
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_embedding", side_effect=RuntimeError("boom")),
+        patch("litellm.embedding", side_effect=RuntimeError("boom")),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = EmbeddingIndexer.get_embeddings_from_api_batch(texts, dry_run=False)
@@ -231,7 +231,7 @@ async def test_query_embedder_returns_truncated_embedding():
     resp_mock.data = [{"embedding": raw_embedding}]
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_aembedding", new=AsyncMock(return_value=resp_mock)),
+        patch("litellm.aembedding", new=AsyncMock(return_value=resp_mock)),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = await QueryEmbedder.generate_for_text_async("hello world")
@@ -247,7 +247,7 @@ async def test_query_embedder_input_is_lowercased():
     mock_aembed = AsyncMock(return_value=resp_mock)
 
     with (
-        patch("orchestrator.core.search.core.embedding.llm_aembedding", new=mock_aembed),
+        patch("litellm.aembedding", new=mock_aembed),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         await QueryEmbedder.generate_for_text_async("UPPERCASE TEXT")
@@ -267,7 +267,7 @@ async def test_query_embedder_exception_returns_none():
 
     with (
         patch(
-            "orchestrator.core.search.core.embedding.llm_aembedding", new=AsyncMock(side_effect=RuntimeError("fail"))
+            "litellm.aembedding", new=AsyncMock(side_effect=RuntimeError("fail"))
         ),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):

--- a/test/unit_tests/search/core/test_embedding.py
+++ b/test/unit_tests/search/core/test_embedding.py
@@ -17,13 +17,14 @@ Covers batch embedding, dry-run mode, truncation, sorting, error handling,
 and async query embedding.
 """
 
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import litellm.exceptions as llm_exc
 import pytest
 
-from orchestrator.core.search.core.embedding import EmbeddingIndexer, QueryEmbedder
+from orchestrator.core.search.core.embedding import EmbeddingIndexer, QueryEmbedder, prewarm_embedding_dependencies
 
 pytestmark = pytest.mark.search
 
@@ -266,11 +267,37 @@ async def test_query_embedder_exception_returns_none():
     settings_mock = _make_settings_mock()
 
     with (
-        patch(
-            "litellm.aembedding", new=AsyncMock(side_effect=RuntimeError("fail"))
-        ),
+        patch("litellm.aembedding", new=AsyncMock(side_effect=RuntimeError("fail"))),
         patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
     ):
         result = await QueryEmbedder.generate_for_text_async("some text")
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# prewarm_embedding_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_prewarm_does_not_import_litellm_when_disabled():
+    settings_mock = _make_settings_mock()
+    settings_mock.EMBEDDING_API_ENABLED = False
+
+    with (
+        patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock),
+        patch.dict(sys.modules),
+    ):
+        sys.modules.pop("litellm", None)
+        prewarm_embedding_dependencies()
+        assert "litellm" not in sys.modules
+
+
+def test_prewarm_imports_litellm_when_enabled():
+    settings_mock = _make_settings_mock()
+    settings_mock.EMBEDDING_API_ENABLED = True
+
+    with patch("orchestrator.core.search.core.embedding.llm_settings", settings_mock):
+        prewarm_embedding_dependencies()
+
+    assert "litellm" in sys.modules

--- a/test/unit_tests/search/indexing/test_indexer.py
+++ b/test/unit_tests/search/indexing/test_indexer.py
@@ -477,7 +477,7 @@ def test_upsert_non_embeddable_field_accumulated_directly(indexer: Indexer) -> N
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
+        patch("litellm.utils.get_max_tokens", return_value=100),
     ):
         mock_llm.EMBEDDING_SAFE_MARGIN_PERCENT = 0.1
         mock_llm.EMBEDDING_MAX_BATCH_SIZE = None
@@ -494,8 +494,8 @@ def test_upsert_embeddable_field_with_embedding(indexer: Indexer) -> None:
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
-        patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1, 2, 3]),
+        patch("litellm.utils.get_max_tokens", return_value=100),
+        patch("litellm.utils.encode", return_value=[1, 2, 3]),
         patch(
             "orchestrator.core.search.core.embedding.EmbeddingIndexer.get_embeddings_from_api_batch",
             return_value=[[0.1, 0.2]],
@@ -524,8 +524,8 @@ def test_upsert_token_budget_exceeded_flushes_before_adding(indexer: Indexer) ->
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
-        patch("orchestrator.core.search.indexing.indexer.encode", side_effect=mock_encode),
+        patch("litellm.utils.get_max_tokens", return_value=100),
+        patch("litellm.utils.encode", side_effect=mock_encode),
         patch(
             "orchestrator.core.search.core.embedding.EmbeddingIndexer.get_embeddings_from_api_batch",
             side_effect=[[[0.1]], [[0.2]]],
@@ -544,8 +544,8 @@ def test_upsert_max_batch_size_triggers_flush(indexer: Indexer) -> None:
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=10000),
-        patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1]),  # 1 token each
+        patch("litellm.utils.get_max_tokens", return_value=10000),
+        patch("litellm.utils.encode", return_value=[1]),  # 1 token each
         patch(
             "orchestrator.core.search.core.embedding.EmbeddingIndexer.get_embeddings_from_api_batch",
             side_effect=[[[0.1], [0.2]], [[0.3]]],
@@ -564,8 +564,8 @@ def test_upsert_field_exceeds_max_context_is_skipped(indexer: Indexer) -> None:
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
-        patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1] * 200),  # > max_ctx=100
+        patch("litellm.utils.get_max_tokens", return_value=100),
+        patch("litellm.utils.encode", return_value=[1] * 200),  # > max_ctx=100
     ):
         mock_llm.EMBEDDING_SAFE_MARGIN_PERCENT = 0.0
         mock_llm.EMBEDDING_MAX_BATCH_SIZE = None
@@ -580,8 +580,8 @@ def test_upsert_tokenization_failure_skips_field(indexer: Indexer) -> None:
 
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
-        patch("orchestrator.core.search.indexing.indexer.encode", side_effect=Exception("tokenizer broken")),
+        patch("litellm.utils.get_max_tokens", return_value=100),
+        patch("litellm.utils.encode", side_effect=Exception("tokenizer broken")),
     ):
         mock_llm.EMBEDDING_SAFE_MARGIN_PERCENT = 0.0
         mock_llm.EMBEDDING_MAX_BATCH_SIZE = None
@@ -599,8 +599,8 @@ _MIXED_FIELDS = [
 def test_upsert_mixed_embeddable_and_non_embeddable(indexer: Indexer) -> None:
     with (
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=100),
-        patch("orchestrator.core.search.indexing.indexer.encode", return_value=[1, 2]),
+        patch("litellm.utils.get_max_tokens", return_value=100),
+        patch("litellm.utils.encode", return_value=[1, 2]),
         patch(
             "orchestrator.core.search.core.embedding.EmbeddingIndexer.get_embeddings_from_api_batch",
             return_value=[[0.5]],
@@ -721,7 +721,7 @@ def test_flush_buffer_dry_run_embeddings_are_empty(mock_config: MagicMock) -> No
 
 
 def test_get_max_tokens_returns_int_from_litellm(indexer: Indexer) -> None:
-    with patch("orchestrator.core.search.indexing.indexer.get_max_tokens", return_value=8191):
+    with patch("litellm.utils.get_max_tokens", return_value=8191):
         assert indexer._get_max_tokens() == 8191
 
 
@@ -738,7 +738,7 @@ def test_get_max_tokens_litellm_invalid_falls_back(
 ) -> None:
     kwargs = {"side_effect": get_max_tokens_se} if get_max_tokens_se else {"return_value": get_max_tokens_rv}
     with (
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", **kwargs),
+        patch("litellm.utils.get_max_tokens", **kwargs),
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
     ):
         mock_llm.EMBEDDING_FALLBACK_MAX_TOKENS = fallback
@@ -750,7 +750,7 @@ def test_get_max_tokens_litellm_invalid_falls_back(
 
 def test_get_max_tokens_fallback_not_set_raises(indexer: Indexer) -> None:
     with (
-        patch("orchestrator.core.search.indexing.indexer.get_max_tokens", side_effect=Exception("unknown")),
+        patch("litellm.utils.get_max_tokens", side_effect=Exception("unknown")),
         patch("orchestrator.core.search.indexing.indexer.llm_settings") as mock_llm,
     ):
         mock_llm.EMBEDDING_FALLBACK_MAX_TOKENS = None

--- a/uv.lock
+++ b/uv.lock
@@ -2762,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-core"
-version = "5.1.1"
+version = "5.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Fixes #1786

### What

Importing `orchestrator.core.app` unconditionally imported `litellm` (plus `openai` — ~1500 modules, **~2.7 s**) via `api_v1.endpoints.processes → search.indexing.indexer`, even when the LLM search / embedding features are unused. This cost was paid at every app boot, every CLI invocation, and by every pytest(-xdist) worker of downstream applications.

This PR:

1. **Imports litellm lazily** — moves the module-scope imports in `search/indexing/indexer.py` and `search/core/embedding.py` into the functions that use them (same pattern as the existing lazy `import typer` in `indexer.py`). After the first use, a function-level `from litellm import ...` is a cached `sys.modules` lookup, so steady-state performance is unchanged.
2. **Pre-warms litellm at app startup when `EMBEDDING_API_ENABLED` is true** — new `prewarm_embedding_dependencies()` in `search/core/embedding.py`, called from `OrchestratorCore.__init__`, so deployments that do use embeddings pay the import cost at boot (as before) rather than on the first search query or indexing run. It is a no-op when the embedding API is disabled.
3. **Updates tests** that monkeypatched the re-exported names (`indexer.encode`, `embedding.llm_embedding`, ...) to patch `litellm.utils.encode` / `litellm.embedding` etc. directly, and adds tests for the pre-warm helper.

### Measurements

`python -X importtime` on 5.1.0, Python 3.13, warm FS cache (`EMBEDDING_API_ENABLED` unset):

| Metric | Before | After |
|---|---|---|
| litellm/openai modules imported by `import orchestrator.core.app` | 1513 | 0 |
| `import orchestrator.core.app` cumulative importtime | 6.28 s | 3.35 s |
| `import orchestrator.core.app` wall time | ~6.7–7.7 s | ~3.7–3.9 s |

In a downstream application (SURF orchestrator) this halves the app import: ~7.2 s → ~3.6 s per process.

### Behaviour

- `EMBEDDING_API_ENABLED=false` (default): litellm is never imported. Runtime-verified that the disabled/dry-run embedding paths complete without loading litellm, and error handling on the enabled path is unchanged.
- `EMBEDDING_API_ENABLED=true`: litellm is imported once during `OrchestratorCore.__init__` (pre-warm), so no first-request latency. Non-app processes (CLI, tests) still skip it unless they actually embed.

### Tests

`test/unit_tests/search`: 735 passed (733 existing + 2 new for the pre-warm helper). ruff, ruff format, mypy and the full pre-commit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
