### PR TITLE
Fix schedule creation redirect

### DIFF
--- a/orchestrator/core/api/api_v1/endpoints/schedules.py
+++ b/orchestrator/core/api/api_v1/endpoints/schedules.py
@@ -40,7 +40,8 @@ async def validate_schedule_authorization(task: Workflow | None, user_model: OID
         raise_status(HTTPStatus.FORBIDDEN, f"User is not authorized to manage schedule with '{task.name}' task")
 
 
-@router.post("/", status_code=HTTPStatus.CREATED)
+@router.post("/", status_code=HTTPStatus.CREATED, include_in_schema=False)
+@router.post("", status_code=HTTPStatus.CREATED)
 async def create_scheduled_task(
     payload: APSchedulerJobCreate, user_model: OIDCUserModel | None = Depends(authenticate)
 ) -> dict[str, str]:

--- a/test/unit_tests/api/test_schedules.py
+++ b/test/unit_tests/api/test_schedules.py
@@ -1,0 +1,25 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fastapi.routing import APIRoute
+
+from orchestrator.core.api.api_v1.endpoints.schedules import router
+
+
+def test_create_schedule_accepts_documented_url_without_redirect():
+    post_routes = [
+        route for route in router.routes if isinstance(route, APIRoute) and "POST" in (route.methods or set())
+    ]
+
+    assert any(route.path == "" and route.include_in_schema for route in post_routes)
+    assert any(route.path == "/" and not route.include_in_schema for route in post_routes)


### PR DESCRIPTION
## Summary
Register the documented `POST /api/schedules` URL directly so schedule creation returns 201 instead of a 307 redirect. The trailing-slash route remains available for compatibility.

## Related Issues
Fixes #1794

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
