### PR TITLE
search: Add schema-aware type inference for ambiguous ES DSL terms (i.e. digits)

### DIFF
--- a/orchestrator/core/app.py
+++ b/orchestrator/core/app.py
@@ -59,6 +59,7 @@ from orchestrator.core.graphql.types import ScalarOverrideType, StrawberryModelT
 from orchestrator.core.log_config import LOGGER_OVERRIDES
 from orchestrator.core.metrics import ORCHESTRATOR_METRICS_REGISTRY, initialize_default_metrics
 from orchestrator.core.search.core.embedding import prewarm_embedding_dependencies
+from orchestrator.core.search.indexing.field_types import clear_field_type_cache
 from orchestrator.core.search.query.exceptions import QueryValidationError
 from orchestrator.core.services.process_broadcast_thread import ProcessDataBroadcastThread
 from orchestrator.core.services.worker_status_monitor import get_worker_status_monitor
@@ -297,6 +298,7 @@ class OrchestratorCore(FastAPI):
 
         """
         SUBSCRIPTION_MODEL_REGISTRY.update(product_to_subscription_model_mapping)
+        clear_field_type_cache()
 
     @staticmethod
     def register_table(base_class: type[BaseModel], custom_class: type[BaseModel]) -> None:

--- a/orchestrator/core/schemas/search_requests.py
+++ b/orchestrator/core/schemas/search_requests.py
@@ -14,10 +14,11 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter, model_validator
 
-from orchestrator.core.search.core.types import EntityType, RetrieverType
+from orchestrator.core.search.core.types import EntityType, FieldType, RetrieverType, UIType
 from orchestrator.core.search.filters import ElasticQuery, FilterTree, elastic_to_filter_tree
+from orchestrator.core.search.indexing.field_types import resolve_field_types
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 from orchestrator.core.search.query.queries import SelectQuery
 
@@ -26,27 +27,46 @@ _ES_DSL_KEYS = frozenset({"term", "range", "wildcard", "regexp", "exists", "bool
 _ES_QUERY_ADAPTER: TypeAdapter[ElasticQuery] = TypeAdapter(ElasticQuery)
 
 
+def _resolve_digit_only_string_kind(entity_type: EntityType, path: str) -> UIType | None:
+    field_types = resolve_field_types(entity_type, path)
+    if field_types == {FieldType.STRING}:
+        return UIType.STRING
+    if field_types and field_types <= {FieldType.INTEGER, FieldType.FLOAT}:
+        return UIType.NUMBER
+    return None
+
+
 class SearchRequest(BaseModel):
     """API request model for search operations.
 
     Only supports SELECT action, used by search endpoints.
     Accepts filters in either FilterTree format or Elasticsearch DSL format.
-    ES DSL filters are auto-converted to FilterTree before processing.
+    ES DSL filters are validated on receipt and converted after the entity type is known.
     """
 
     filters: FilterTree | None = Field(
         default=None,
         description="Structured filters to apply to the search. Accepts FilterTree or Elasticsearch DSL format.",
     )
+    _elastic_filters: ElasticQuery | None = PrivateAttr(default=None)
 
-    @field_validator("filters", mode="wrap")
+    @model_validator(mode="wrap")
     @classmethod
-    def _convert_elastic_dsl_filters(cls, value: Any, handler: Any) -> FilterTree | None:
-        """Detect and convert ES DSL filters to FilterTree, bypassing re-parse."""
-        if isinstance(value, dict) and _ES_DSL_KEYS & value.keys():
-            es_query = _ES_QUERY_ADAPTER.validate_python(value)
-            return elastic_to_filter_tree(es_query)
-        return handler(value)
+    def _parse_elastic_dsl_filters(cls, value: Any, handler: Any) -> "SearchRequest":
+        """Validate ES DSL while retaining it for entity-aware conversion in to_query."""
+        if not isinstance(value, dict):
+            return handler(value)
+
+        raw_filters = value.get("filters")
+        if not (isinstance(raw_filters, dict) and _ES_DSL_KEYS & raw_filters.keys()):
+            return handler(value)
+
+        parsed_filters = _ES_QUERY_ADAPTER.validate_python(raw_filters)
+        input_data = dict(value)
+        input_data["filters"] = None
+        request = handler(input_data)
+        request._elastic_filters = parsed_filters
+        return request
 
     query: str | None = Field(
         default=None,
@@ -82,9 +102,16 @@ class SearchRequest(BaseModel):
         Returns:
             SelectQuery for search operation
         """
+        filters = self.filters
+        if self._elastic_filters is not None:
+            filters = elastic_to_filter_tree(
+                self._elastic_filters,
+                value_kind_resolver=lambda path, _value: _resolve_digit_only_string_kind(entity_type, path),
+            )
+
         return SelectQuery(
             entity_type=entity_type,
-            filters=self.filters,
+            filters=filters,
             query_text=self.query,
             limit=self.limit,
             retriever=self.retriever,

--- a/orchestrator/core/schemas/search_requests.py
+++ b/orchestrator/core/schemas/search_requests.py
@@ -14,20 +14,11 @@
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from orchestrator.core.search.core.types import EntityType, FieldType, RetrieverType, UIType
+from orchestrator.core.search.core.types import EntityType, RetrieverType
 from orchestrator.core.search.filters import ElasticQuery, FilterTree, elastic_to_filter_tree
-from orchestrator.core.search.indexing.field_types import resolve_field_types
+from orchestrator.core.search.indexing.field_types import resolve_field_value_kind
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 from orchestrator.core.search.query.queries import SelectQuery
-
-
-def _resolve_digit_only_string_kind(entity_type: EntityType, path: str) -> UIType | None:
-    field_types = resolve_field_types(entity_type, path)
-    if field_types == {FieldType.STRING}:
-        return UIType.STRING
-    if field_types and field_types <= {FieldType.INTEGER, FieldType.FLOAT}:
-        return UIType.NUMBER
-    return None
 
 
 class SearchRequest(BaseModel):
@@ -81,7 +72,7 @@ class SearchRequest(BaseModel):
         if filters is not None and not isinstance(filters, FilterTree):
             filters = elastic_to_filter_tree(
                 filters,
-                value_kind_resolver=lambda path, _value: _resolve_digit_only_string_kind(entity_type, path),
+                value_kind_resolver=lambda path, _value: resolve_field_value_kind(entity_type, path),
             )
 
         return SelectQuery(

--- a/orchestrator/core/schemas/search_requests.py
+++ b/orchestrator/core/schemas/search_requests.py
@@ -12,19 +12,13 @@
 # limitations under the License.
 
 
-from typing import Any
-
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from orchestrator.core.search.core.types import EntityType, FieldType, RetrieverType, UIType
 from orchestrator.core.search.filters import ElasticQuery, FilterTree, elastic_to_filter_tree
 from orchestrator.core.search.indexing.field_types import resolve_field_types
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 from orchestrator.core.search.query.queries import SelectQuery
-
-# Keys that identify an ES DSL query at the top level
-_ES_DSL_KEYS = frozenset({"term", "range", "wildcard", "regexp", "exists", "bool"})
-_ES_QUERY_ADAPTER: TypeAdapter[ElasticQuery] = TypeAdapter(ElasticQuery)
 
 
 def _resolve_digit_only_string_kind(entity_type: EntityType, path: str) -> UIType | None:
@@ -41,32 +35,13 @@ class SearchRequest(BaseModel):
 
     Only supports SELECT action, used by search endpoints.
     Accepts filters in either FilterTree format or Elasticsearch DSL format.
-    ES DSL filters are validated on receipt and converted after the entity type is known.
+    ES DSL filters are converted to FilterTree in to_query, once the entity type is known.
     """
 
-    filters: FilterTree | None = Field(
+    filters: FilterTree | ElasticQuery | None = Field(
         default=None,
         description="Structured filters to apply to the search. Accepts FilterTree or Elasticsearch DSL format.",
     )
-    _elastic_filters: ElasticQuery | None = PrivateAttr(default=None)
-
-    @model_validator(mode="wrap")
-    @classmethod
-    def _parse_elastic_dsl_filters(cls, value: Any, handler: Any) -> "SearchRequest":
-        """Validate ES DSL while retaining it for entity-aware conversion in to_query."""
-        if not isinstance(value, dict):
-            return handler(value)
-
-        raw_filters = value.get("filters")
-        if not (isinstance(raw_filters, dict) and _ES_DSL_KEYS & raw_filters.keys()):
-            return handler(value)
-
-        parsed_filters = _ES_QUERY_ADAPTER.validate_python(raw_filters)
-        input_data = dict(value)
-        input_data["filters"] = None
-        request = handler(input_data)
-        request._elastic_filters = parsed_filters
-        return request
 
     query: str | None = Field(
         default=None,
@@ -103,9 +78,9 @@ class SearchRequest(BaseModel):
             SelectQuery for search operation
         """
         filters = self.filters
-        if self._elastic_filters is not None:
+        if filters is not None and not isinstance(filters, FilterTree):
             filters = elastic_to_filter_tree(
-                self._elastic_filters,
+                filters,
                 value_kind_resolver=lambda path, _value: _resolve_digit_only_string_kind(entity_type, path),
             )
 

--- a/orchestrator/core/schemas/search_requests.py
+++ b/orchestrator/core/schemas/search_requests.py
@@ -69,7 +69,7 @@ class SearchRequest(BaseModel):
             SelectQuery for search operation
         """
         filters = self.filters
-        if filters is not None and not isinstance(filters, FilterTree):
+        if isinstance(filters, ElasticQuery):
             filters = elastic_to_filter_tree(
                 filters,
                 value_kind_resolver=lambda path, _value: resolve_field_value_kind(entity_type, path),

--- a/orchestrator/core/search/core/types.py
+++ b/orchestrator/core/search/core/types.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum, IntEnum
@@ -216,7 +217,7 @@ class FieldType(str, Enum):
 
         origin, args = get_origin_and_args(type_hint)
 
-        if origin is list:
+        if origin is list or origin is Sequence:
             return cls._handle_list_type(args)
 
         if origin is Literal:

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -55,8 +55,8 @@ _INVERT_OP: dict[FilterOp, FilterOp] = {
 }
 
 
+# Given a field path and its raw term value, return the UIType to use, or None to fall back to inference.
 ValueKindResolver = Callable[[str, Any], UIType | None]
-"""Given a field path and its raw term value, return the UIType to use, or None to fall back to inference."""
 
 
 def _infer_value_kind(value: Any) -> UIType:

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -364,8 +364,9 @@ def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKin
     Args:
         es_query: A parsed ElasticQuery (TermQuery, RangeQuery, WildcardQuery,
             ExistsQuery, or BoolQuery).
-        value_kind_resolver: Optional resolver for term values, used to override
-            the default value-kind inference for digit-only strings.
+        value_kind_resolver: Optional schema-aware override for ambiguous term
+            values. It is consulted for digit-only strings; all other values use
+            normal inference.
 
     Returns:
         A FilterTree suitable for compilation to SQL.

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -21,7 +21,7 @@ FilterTree representation used by the search engine.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Annotated, Any, Literal
+from typing import Any, Literal, TypeAlias
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -136,10 +136,7 @@ class BoolClause(BaseModel):
         return self
 
 
-ElasticQuery = Annotated[
-    TermQuery | RangeQuery | WildcardQuery | RegexpQuery | ExistsQuery | BoolQuery,
-    Field(discriminator=None),
-]
+ElasticQuery: TypeAlias = TermQuery | RangeQuery | WildcardQuery | RegexpQuery | ExistsQuery | BoolQuery
 
 # Rebuild models that reference the forward ref
 BoolClause.model_rebuild()
@@ -365,8 +362,7 @@ def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKin
         es_query: A parsed ElasticQuery (TermQuery, RangeQuery, WildcardQuery,
             ExistsQuery, or BoolQuery).
         value_kind_resolver: Optional schema-aware override for ambiguous term
-            values. It is consulted for digit-only strings; all other values use
-            normal inference.
+            values.
 
     Returns:
         A FilterTree suitable for compilation to SQL.

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -64,14 +64,6 @@ def _infer_value_kind(value: Any) -> UIType:
     return UIType.from_field_type(FieldType.infer(value))
 
 
-def _resolve_value_kind(field: str, value: Any, value_kind_resolver: ValueKindResolver | None) -> UIType:
-    """Resolve digit-only strings from the indexed model schema when available."""
-    if value_kind_resolver and isinstance(value, str) and value.isdigit():
-        if value_kind := value_kind_resolver(field, value):
-            return value_kind
-    return _infer_value_kind(value)
-
-
 # ---------------------------------------------------------------------------
 # Wildcard pattern conversion
 # ---------------------------------------------------------------------------
@@ -158,16 +150,6 @@ BoolQuery.model_rebuild()
 # ---------------------------------------------------------------------------
 
 _RANGE_KEYS = frozenset({"gt", "gte", "lt", "lte"})
-
-
-def _translate_term(query: TermQuery, value_kind_resolver: ValueKindResolver | None = None) -> PathFilter:
-    """Convert a term query to a PathFilter with EqualityFilter."""
-    field, value = next(iter(query.term.items()))
-    return PathFilter(
-        path=field,
-        condition=EqualityFilter(op=FilterOp.EQ, value=value),
-        value_kind=_resolve_value_kind(field, value, value_kind_resolver),
-    )
 
 
 def _translate_range(query: RangeQuery) -> PathFilter:
@@ -296,76 +278,16 @@ def _negate_node(node: FilterTree | PathFilter) -> FilterTree | PathFilter:
             return node
 
 
-def _translate_must_not(
-    queries: list[ElasticQuery], value_kind_resolver: ValueKindResolver | None = None
-) -> list[FilterTree | PathFilter]:
-    """Translate must_not clauses by inverting operators where possible."""
-    return [_negate_node(_translate_node(q, value_kind_resolver)) for q in queries]
-
-
-def _translate_node(
-    query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None
-) -> FilterTree | PathFilter:
-    """Recursively translate a single ES DSL node."""
-    match query:
-        case TermQuery():
-            return _translate_term(query, value_kind_resolver)
-        case RangeQuery():
-            return _translate_range(query)
-        case WildcardQuery():
-            return _translate_wildcard(query)
-        case RegexpQuery():
-            return _translate_regexp(query)
-        case ExistsQuery():
-            return _translate_exists(query)
-        case BoolQuery():
-            return _translate_bool(query, value_kind_resolver)
-        case _:
-            raise ValueError(f"Unsupported ES DSL query type: {type(query)}")
-
-
-def _translate_bool(query: BoolQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree | PathFilter:
-    """Translate a bool query into a FilterTree."""
-    clause = query.bool
-    children: list[FilterTree | PathFilter] = []
-
-    must_children = [_translate_node(q, value_kind_resolver) for q in clause.must]
-    should_children = [_translate_node(q, value_kind_resolver) for q in clause.should]
-    must_not_children = _translate_must_not(clause.must_not, value_kind_resolver)
-
-    # Build sub-trees for each clause type
-    if clause.must and clause.should:
-        # Both must and should: must is AND, should is OR, combine with AND
-        children.extend(must_children)
-        children.append(FilterTree(op=BooleanOperator.OR, children=should_children))
-    elif clause.must:
-        children.extend(must_children)
-    elif clause.should:
-        return (
-            FilterTree(op=BooleanOperator.OR, children=should_children)
-            if len(should_children) > 1
-            else should_children[0]
-        )
-
-    children.extend(must_not_children)
-
-    if not children:
-        raise ValueError("bool query produced no children after translation")
-
-    if len(children) == 1:
-        return children[0]
-
-    return FilterTree(op=BooleanOperator.AND, children=children)
-
-
-def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree:
+def elastic_to_filter_tree(  # noqa: C901
+    es_query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None
+) -> FilterTree:
     """Convert an Elasticsearch DSL query to a FilterTree.
 
     Args:
         es_query: A parsed ElasticQuery (TermQuery, RangeQuery, WildcardQuery,
             ExistsQuery, or BoolQuery).
         value_kind_resolver: Optional resolver for term values, used to override
-            the default value-kind inference (see ``_resolve_value_kind``).
+            the default value-kind inference for digit-only strings.
 
     Returns:
         A FilterTree suitable for compilation to SQL.
@@ -373,7 +295,79 @@ def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKin
     Raises:
         ValueError: If the query structure is invalid or exceeds MAX_DEPTH.
     """
-    result = _translate_node(es_query, value_kind_resolver)
+
+    def resolve_value_kind(field: str, value: Any) -> UIType:
+        """Resolve digit-only strings from the indexed model schema when available."""
+        if value_kind_resolver and isinstance(value, str) and value.isdigit():
+            if value_kind := value_kind_resolver(field, value):
+                return value_kind
+        return _infer_value_kind(value)
+
+    def translate_term(query: TermQuery) -> PathFilter:
+        """Convert a term query to a PathFilter with EqualityFilter."""
+        field, value = next(iter(query.term.items()))
+        return PathFilter(
+            path=field,
+            condition=EqualityFilter(op=FilterOp.EQ, value=value),
+            value_kind=resolve_value_kind(field, value),
+        )
+
+    def translate_must_not(queries: list[ElasticQuery]) -> list[FilterTree | PathFilter]:
+        """Translate must_not clauses by inverting operators where possible."""
+        return [_negate_node(translate_node(q)) for q in queries]
+
+    def translate_node(query: ElasticQuery) -> FilterTree | PathFilter:
+        """Recursively translate a single ES DSL node."""
+        match query:
+            case TermQuery():
+                return translate_term(query)
+            case RangeQuery():
+                return _translate_range(query)
+            case WildcardQuery():
+                return _translate_wildcard(query)
+            case RegexpQuery():
+                return _translate_regexp(query)
+            case ExistsQuery():
+                return _translate_exists(query)
+            case BoolQuery():
+                return translate_bool(query)
+            case _:
+                raise ValueError(f"Unsupported ES DSL query type: {type(query)}")
+
+    def translate_bool(query: BoolQuery) -> FilterTree | PathFilter:
+        """Translate a bool query into a FilterTree."""
+        clause = query.bool
+        children: list[FilterTree | PathFilter] = []
+
+        must_children = [translate_node(q) for q in clause.must]
+        should_children = [translate_node(q) for q in clause.should]
+        must_not_children = translate_must_not(clause.must_not)
+
+        # Build sub-trees for each clause type
+        if clause.must and clause.should:
+            # Both must and should: must is AND, should is OR, combine with AND
+            children.extend(must_children)
+            children.append(FilterTree(op=BooleanOperator.OR, children=should_children))
+        elif clause.must:
+            children.extend(must_children)
+        elif clause.should:
+            return (
+                FilterTree(op=BooleanOperator.OR, children=should_children)
+                if len(should_children) > 1
+                else should_children[0]
+            )
+
+        children.extend(must_not_children)
+
+        if not children:
+            raise ValueError("bool query produced no children after translation")
+
+        if len(children) == 1:
+            return children[0]
+
+        return FilterTree(op=BooleanOperator.AND, children=children)
+
+    result = translate_node(es_query)
     if isinstance(result, PathFilter):
         return FilterTree(op=BooleanOperator.AND, children=[result])
     return result

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -152,6 +152,24 @@ BoolQuery.model_rebuild()
 _RANGE_KEYS = frozenset({"gt", "gte", "lt", "lte"})
 
 
+def _resolve_value_kind(field: str, value: Any, value_kind_resolver: ValueKindResolver | None) -> UIType:
+    """Resolve digit-only strings from the indexed model schema when available."""
+    if value_kind_resolver and isinstance(value, str) and value.isdigit():
+        if value_kind := value_kind_resolver(field, value):
+            return value_kind
+    return _infer_value_kind(value)
+
+
+def _translate_term(query: TermQuery, value_kind_resolver: ValueKindResolver | None = None) -> PathFilter:
+    """Convert a term query to a PathFilter with EqualityFilter."""
+    field, value = next(iter(query.term.items()))
+    return PathFilter(
+        path=field,
+        condition=EqualityFilter(op=FilterOp.EQ, value=value),
+        value_kind=_resolve_value_kind(field, value, value_kind_resolver),
+    )
+
+
 def _translate_range(query: RangeQuery) -> PathFilter:
     """Convert a range query to a PathFilter with date/numeric value or range filter."""
     field, bounds = next(iter(query.range.items()))
@@ -278,9 +296,69 @@ def _negate_node(node: FilterTree | PathFilter) -> FilterTree | PathFilter:
             return node
 
 
-def elastic_to_filter_tree(  # noqa: C901
-    es_query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None
-) -> FilterTree:
+def _translate_must_not(
+    queries: list[ElasticQuery], value_kind_resolver: ValueKindResolver | None = None
+) -> list[FilterTree | PathFilter]:
+    """Translate must_not clauses by inverting operators where possible."""
+    return [_negate_node(_translate_node(q, value_kind_resolver)) for q in queries]
+
+
+def _translate_node(
+    query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None
+) -> FilterTree | PathFilter:
+    """Recursively translate a single ES DSL node."""
+    match query:
+        case TermQuery():
+            return _translate_term(query, value_kind_resolver)
+        case RangeQuery():
+            return _translate_range(query)
+        case WildcardQuery():
+            return _translate_wildcard(query)
+        case RegexpQuery():
+            return _translate_regexp(query)
+        case ExistsQuery():
+            return _translate_exists(query)
+        case BoolQuery():
+            return _translate_bool(query, value_kind_resolver)
+        case _:
+            raise ValueError(f"Unsupported ES DSL query type: {type(query)}")
+
+
+def _translate_bool(query: BoolQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree | PathFilter:
+    """Translate a bool query into a FilterTree."""
+    clause = query.bool
+    children: list[FilterTree | PathFilter] = []
+
+    must_children = [_translate_node(q, value_kind_resolver) for q in clause.must]
+    should_children = [_translate_node(q, value_kind_resolver) for q in clause.should]
+    must_not_children = _translate_must_not(clause.must_not, value_kind_resolver)
+
+    # Build sub-trees for each clause type
+    if clause.must and clause.should:
+        # Both must and should: must is AND, should is OR, combine with AND
+        children.extend(must_children)
+        children.append(FilterTree(op=BooleanOperator.OR, children=should_children))
+    elif clause.must:
+        children.extend(must_children)
+    elif clause.should:
+        return (
+            FilterTree(op=BooleanOperator.OR, children=should_children)
+            if len(should_children) > 1
+            else should_children[0]
+        )
+
+    children.extend(must_not_children)
+
+    if not children:
+        raise ValueError("bool query produced no children after translation")
+
+    if len(children) == 1:
+        return children[0]
+
+    return FilterTree(op=BooleanOperator.AND, children=children)
+
+
+def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree:
     """Convert an Elasticsearch DSL query to a FilterTree.
 
     Args:
@@ -295,79 +373,7 @@ def elastic_to_filter_tree(  # noqa: C901
     Raises:
         ValueError: If the query structure is invalid or exceeds MAX_DEPTH.
     """
-
-    def resolve_value_kind(field: str, value: Any) -> UIType:
-        """Resolve digit-only strings from the indexed model schema when available."""
-        if value_kind_resolver and isinstance(value, str) and value.isdigit():
-            if value_kind := value_kind_resolver(field, value):
-                return value_kind
-        return _infer_value_kind(value)
-
-    def translate_term(query: TermQuery) -> PathFilter:
-        """Convert a term query to a PathFilter with EqualityFilter."""
-        field, value = next(iter(query.term.items()))
-        return PathFilter(
-            path=field,
-            condition=EqualityFilter(op=FilterOp.EQ, value=value),
-            value_kind=resolve_value_kind(field, value),
-        )
-
-    def translate_must_not(queries: list[ElasticQuery]) -> list[FilterTree | PathFilter]:
-        """Translate must_not clauses by inverting operators where possible."""
-        return [_negate_node(translate_node(q)) for q in queries]
-
-    def translate_node(query: ElasticQuery) -> FilterTree | PathFilter:
-        """Recursively translate a single ES DSL node."""
-        match query:
-            case TermQuery():
-                return translate_term(query)
-            case RangeQuery():
-                return _translate_range(query)
-            case WildcardQuery():
-                return _translate_wildcard(query)
-            case RegexpQuery():
-                return _translate_regexp(query)
-            case ExistsQuery():
-                return _translate_exists(query)
-            case BoolQuery():
-                return translate_bool(query)
-            case _:
-                raise ValueError(f"Unsupported ES DSL query type: {type(query)}")
-
-    def translate_bool(query: BoolQuery) -> FilterTree | PathFilter:
-        """Translate a bool query into a FilterTree."""
-        clause = query.bool
-        children: list[FilterTree | PathFilter] = []
-
-        must_children = [translate_node(q) for q in clause.must]
-        should_children = [translate_node(q) for q in clause.should]
-        must_not_children = translate_must_not(clause.must_not)
-
-        # Build sub-trees for each clause type
-        if clause.must and clause.should:
-            # Both must and should: must is AND, should is OR, combine with AND
-            children.extend(must_children)
-            children.append(FilterTree(op=BooleanOperator.OR, children=should_children))
-        elif clause.must:
-            children.extend(must_children)
-        elif clause.should:
-            return (
-                FilterTree(op=BooleanOperator.OR, children=should_children)
-                if len(should_children) > 1
-                else should_children[0]
-            )
-
-        children.extend(must_not_children)
-
-        if not children:
-            raise ValueError("bool query produced no children after translation")
-
-        if len(children) == 1:
-            return children[0]
-
-        return FilterTree(op=BooleanOperator.AND, children=children)
-
-    result = translate_node(es_query)
+    result = _translate_node(es_query, value_kind_resolver)
     if isinstance(result, PathFilter):
         return FilterTree(op=BooleanOperator.AND, children=[result])
     return result

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -56,6 +56,7 @@ _INVERT_OP: dict[FilterOp, FilterOp] = {
 
 
 ValueKindResolver = Callable[[str, Any], UIType | None]
+"""Given a field path and its raw term value, return the UIType to use, or None to fall back to inference."""
 
 
 def _infer_value_kind(value: Any) -> UIType:
@@ -363,7 +364,8 @@ def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKin
     Args:
         es_query: A parsed ElasticQuery (TermQuery, RangeQuery, WildcardQuery,
             ExistsQuery, or BoolQuery).
-        value_kind_resolver: Optional resolver for digit-only string term values.
+        value_kind_resolver: Optional resolver for term values, used to override
+            the default value-kind inference (see ``_resolve_value_kind``).
 
     Returns:
         A FilterTree suitable for compilation to SQL.

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -20,6 +20,7 @@ FilterTree representation used by the search engine.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -54,9 +55,20 @@ _INVERT_OP: dict[FilterOp, FilterOp] = {
 }
 
 
+ValueKindResolver = Callable[[str, Any], UIType | None]
+
+
 def _infer_value_kind(value: Any) -> UIType:
     """Infer a UIType from a raw filter value using FieldType heuristics."""
     return UIType.from_field_type(FieldType.infer(value))
+
+
+def _resolve_value_kind(field: str, value: Any, value_kind_resolver: ValueKindResolver | None) -> UIType:
+    """Resolve digit-only strings from the indexed model schema when available."""
+    if value_kind_resolver and isinstance(value, str) and value.isdigit():
+        if value_kind := value_kind_resolver(field, value):
+            return value_kind
+    return _infer_value_kind(value)
 
 
 # ---------------------------------------------------------------------------
@@ -147,13 +159,13 @@ BoolQuery.model_rebuild()
 _RANGE_KEYS = frozenset({"gt", "gte", "lt", "lte"})
 
 
-def _translate_term(query: TermQuery) -> PathFilter:
+def _translate_term(query: TermQuery, value_kind_resolver: ValueKindResolver | None = None) -> PathFilter:
     """Convert a term query to a PathFilter with EqualityFilter."""
     field, value = next(iter(query.term.items()))
     return PathFilter(
         path=field,
         condition=EqualityFilter(op=FilterOp.EQ, value=value),
-        value_kind=_infer_value_kind(value),
+        value_kind=_resolve_value_kind(field, value, value_kind_resolver),
     )
 
 
@@ -283,16 +295,20 @@ def _negate_node(node: FilterTree | PathFilter) -> FilterTree | PathFilter:
             return node
 
 
-def _translate_must_not(queries: list[ElasticQuery]) -> list[FilterTree | PathFilter]:
+def _translate_must_not(
+    queries: list[ElasticQuery], value_kind_resolver: ValueKindResolver | None = None
+) -> list[FilterTree | PathFilter]:
     """Translate must_not clauses by inverting operators where possible."""
-    return [_negate_node(_translate_node(q)) for q in queries]
+    return [_negate_node(_translate_node(q, value_kind_resolver)) for q in queries]
 
 
-def _translate_node(query: ElasticQuery) -> FilterTree | PathFilter:
+def _translate_node(
+    query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None
+) -> FilterTree | PathFilter:
     """Recursively translate a single ES DSL node."""
     match query:
         case TermQuery():
-            return _translate_term(query)
+            return _translate_term(query, value_kind_resolver)
         case RangeQuery():
             return _translate_range(query)
         case WildcardQuery():
@@ -302,19 +318,19 @@ def _translate_node(query: ElasticQuery) -> FilterTree | PathFilter:
         case ExistsQuery():
             return _translate_exists(query)
         case BoolQuery():
-            return _translate_bool(query)
+            return _translate_bool(query, value_kind_resolver)
         case _:
             raise ValueError(f"Unsupported ES DSL query type: {type(query)}")
 
 
-def _translate_bool(query: BoolQuery) -> FilterTree | PathFilter:
+def _translate_bool(query: BoolQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree | PathFilter:
     """Translate a bool query into a FilterTree."""
     clause = query.bool
     children: list[FilterTree | PathFilter] = []
 
-    must_children = [_translate_node(q) for q in clause.must]
-    should_children = [_translate_node(q) for q in clause.should]
-    must_not_children = _translate_must_not(clause.must_not)
+    must_children = [_translate_node(q, value_kind_resolver) for q in clause.must]
+    should_children = [_translate_node(q, value_kind_resolver) for q in clause.should]
+    must_not_children = _translate_must_not(clause.must_not, value_kind_resolver)
 
     # Build sub-trees for each clause type
     if clause.must and clause.should:
@@ -341,12 +357,13 @@ def _translate_bool(query: BoolQuery) -> FilterTree | PathFilter:
     return FilterTree(op=BooleanOperator.AND, children=children)
 
 
-def elastic_to_filter_tree(es_query: ElasticQuery) -> FilterTree:
+def elastic_to_filter_tree(es_query: ElasticQuery, value_kind_resolver: ValueKindResolver | None = None) -> FilterTree:
     """Convert an Elasticsearch DSL query to a FilterTree.
 
     Args:
         es_query: A parsed ElasticQuery (TermQuery, RangeQuery, WildcardQuery,
-                  ExistsQuery, or BoolQuery).
+            ExistsQuery, or BoolQuery).
+        value_kind_resolver: Optional resolver for digit-only string term values.
 
     Returns:
         A FilterTree suitable for compilation to SQL.
@@ -354,7 +371,7 @@ def elastic_to_filter_tree(es_query: ElasticQuery) -> FilterTree:
     Raises:
         ValueError: If the query structure is invalid or exceeds MAX_DEPTH.
     """
-    result = _translate_node(es_query)
+    result = _translate_node(es_query, value_kind_resolver)
     if isinstance(result, PathFilter):
         return FilterTree(op=BooleanOperator.AND, children=[result])
     return result

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -1,0 +1,85 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from functools import lru_cache
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+
+from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.core.search.core.types import EntityType, FieldType
+
+
+def _model_types(annotation: Any) -> set[type[BaseModel]]:
+    """Return Pydantic model types contained in an annotation."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return {annotation}
+    return {model_type for arg in get_args(annotation) for model_type in _model_types(arg)}
+
+
+def _collect_field_types(
+    model_type: type[BaseModel],
+    path: str,
+    field_types: dict[str, set[FieldType]],
+    ancestors: set[type[BaseModel]],
+) -> None:
+    if model_type in ancestors:
+        return
+
+    ancestors = ancestors | {model_type}
+    for name, field in model_type.model_fields.items():
+        field_path = f"{path}.{name}"
+        annotation = field.annotation
+        is_list = get_origin(annotation) is list
+        nested_model_types = _model_types(annotation)
+        if nested_model_types:
+            nested_path = f"{field_path}.*" if is_list else field_path
+            for nested_model_type in nested_model_types:
+                _collect_field_types(nested_model_type, nested_path, field_types, ancestors)
+        else:
+            indexed_path = f"{field_path}.*" if is_list else field_path
+            field_types[indexed_path].add(FieldType.from_type_hint(annotation))
+
+
+def _all_subclasses(model_type: type[BaseModel]) -> set[type[BaseModel]]:
+    subclasses = set(model_type.__subclasses__())
+    return subclasses | {subclass for child in subclasses for subclass in _all_subclasses(child)}
+
+
+@lru_cache(maxsize=1)
+def _subscription_field_types() -> dict[str, frozenset[FieldType]]:
+    """Build searchable subscription field types from registered Pydantic models."""
+    field_types: dict[str, set[FieldType]] = defaultdict(set)
+    model_types = {
+        model_type
+        for registered_model_type in SUBSCRIPTION_MODEL_REGISTRY.values()
+        for model_type in {registered_model_type, *_all_subclasses(registered_model_type)}
+    }
+    for model_type in model_types:
+        _collect_field_types(model_type, "subscription", field_types, set())
+    return {path: frozenset(types) for path, types in field_types.items()}
+
+
+def resolve_field_types(entity_type: EntityType, path: str) -> frozenset[FieldType]:
+    """Return the Pydantic-derived index types for an exact or global field path."""
+    if entity_type != EntityType.SUBSCRIPTION:
+        return frozenset()
+
+    field_types = _subscription_field_types()
+    if "." in path:
+        schema_path = ".".join("*" if segment.isdigit() else segment for segment in path.split("."))
+        return field_types.get(schema_path, frozenset())
+    return frozenset().union(
+        *(types for field_path, types in field_types.items() if field_path.rsplit(".", maxsplit=1)[-1] == path)
+    )

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.core.search.core.types import EntityType, FieldType
+from orchestrator.core.search.indexing.schema import iter_model_field_annotations
 
 
 def _model_types(annotation: Any) -> set[type[BaseModel]]:
@@ -38,9 +39,8 @@ def _collect_field_types(
         return
 
     ancestors = ancestors | {model_type}
-    for name, field in model_type.model_fields.items():
+    for name, annotation in iter_model_field_annotations(model_type):
         field_path = f"{path}.{name}"
-        annotation = field.annotation
         is_list = get_origin(annotation) is list
         nested_model_types = _model_types(annotation)
         if nested_model_types:

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -17,9 +17,11 @@ from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel
 
-from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
+from orchestrator.core.domain.lifecycle import lookup_specialized_type
 from orchestrator.core.search.core.types import EntityType, FieldType
 from orchestrator.core.search.indexing.schema import iter_model_field_annotations
+from orchestrator.core.types import SubscriptionLifecycle
 
 
 def _model_types(annotation: Any) -> set[type[BaseModel]]:
@@ -52,9 +54,13 @@ def _collect_field_types(
             field_types[indexed_path].add(FieldType.from_type_hint(annotation))
 
 
-def _all_subclasses(model_type: type[BaseModel]) -> set[type[BaseModel]]:
-    subclasses = set(model_type.__subclasses__())
-    return subclasses | {subclass for child in subclasses for subclass in _all_subclasses(child)}
+def _specialized_subscription_types(model_type: type[SubscriptionModel]) -> set[type[SubscriptionModel]]:
+    """Return a registered subscription model together with its lifecycle-specialized variants.
+
+    Uses the lifecycle registry maintained by ``register_specialized_type()`` instead of walking
+    ``__subclasses__()``, so only variants actually registered for this model are included.
+    """
+    return {lookup_specialized_type(model_type, lifecycle) for lifecycle in (None, *SubscriptionLifecycle)}
 
 
 @lru_cache(maxsize=1)
@@ -62,9 +68,9 @@ def _subscription_field_types() -> dict[str, frozenset[FieldType]]:
     """Build searchable subscription field types from registered Pydantic models."""
     field_types: dict[str, set[FieldType]] = defaultdict(set)
     model_types = {
-        model_type
+        specialized_type
         for registered_model_type in SUBSCRIPTION_MODEL_REGISTRY.values()
-        for model_type in {registered_model_type, *_all_subclasses(registered_model_type)}
+        for specialized_type in _specialized_subscription_types(registered_model_type)
     }
     for model_type in model_types:
         _collect_field_types(model_type, "subscription", field_types, set())

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
 from orchestrator.core.domain.base import DomainModel
 from orchestrator.core.domain.lifecycle import lookup_specialized_type
-from orchestrator.core.search.core.types import EntityType, FieldType
+from orchestrator.core.search.core.types import EntityType, FieldType, UIType
 from orchestrator.core.search.indexing.schema import iter_model_field_annotations
 from orchestrator.core.types import SubscriptionLifecycle
 
@@ -110,3 +110,13 @@ def resolve_field_types(entity_type: EntityType, path: str) -> frozenset[FieldTy
     return frozenset().union(
         *(types for field_path, types in field_types.items() if field_path.rsplit(".", maxsplit=1)[-1] == path)
     )
+
+
+def resolve_field_value_kind(entity_type: EntityType, path: str) -> UIType | None:
+    """Return the UI type for a schema-resolved field when it is unambiguous."""
+    field_types = resolve_field_types(entity_type, path)
+    if field_types == {FieldType.STRING}:
+        return UIType.STRING
+    if field_types and field_types <= {FieldType.INTEGER, FieldType.FLOAT}:
+        return UIType.NUMBER
+    return None

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -77,6 +77,11 @@ def _subscription_field_types() -> dict[str, frozenset[FieldType]]:
     return {path: frozenset(types) for path, types in field_types.items()}
 
 
+def clear_field_type_cache() -> None:
+    """Clear cached subscription field types after changing the model registry."""
+    _subscription_field_types.cache_clear()
+
+
 def resolve_field_types(entity_type: EntityType, path: str) -> frozenset[FieldType]:
     """Return the Pydantic-derived index types for an exact or global field path."""
     if entity_type != EntityType.SUBSCRIPTION:

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -14,7 +14,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 from functools import lru_cache
-from typing import Any, get_args, get_origin
+from typing import Any, get_args
 
 from pydantic import BaseModel
 
@@ -23,7 +23,7 @@ from orchestrator.core.domain.base import DomainModel
 from orchestrator.core.domain.lifecycle import lookup_specialized_type
 from orchestrator.core.search.core.types import EntityType, FieldType, UIType
 from orchestrator.core.search.indexing.schema import iter_model_field_annotations
-from orchestrator.core.types import SubscriptionLifecycle
+from orchestrator.core.types import SubscriptionLifecycle, is_list_type
 
 
 def _model_types(annotation: Any) -> set[type[BaseModel]]:
@@ -59,23 +59,18 @@ def _collect_field_types(
     ancestors = ancestors | {model_type}
     for name, annotation in _field_annotations(model_type):
         field_path = f"{path}.{name}"
-        is_list = get_origin(annotation) is list
+        is_list = is_list_type(annotation)
+        indexed_path = f"{field_path}.*" if is_list else field_path
         nested_model_types = _model_types(annotation)
         if nested_model_types:
-            nested_path = f"{field_path}.*" if is_list else field_path
             for nested_model_type in nested_model_types:
-                _collect_field_types(nested_model_type, nested_path, field_types, ancestors)
+                _collect_field_types(nested_model_type, indexed_path, field_types, ancestors)
         else:
-            indexed_path = f"{field_path}.*" if is_list else field_path
             field_types[indexed_path].add(FieldType.from_type_hint(annotation))
 
 
 def _specialized_subscription_types(model_type: type[SubscriptionModel]) -> set[type[SubscriptionModel]]:
-    """Return a registered subscription model together with its lifecycle-specialized variants.
-
-    Uses the lifecycle registry maintained by ``register_specialized_type()`` instead of walking
-    ``__subclasses__()``, so only variants actually registered for this model are included.
-    """
+    """Return a registered subscription model and its lifecycle-specialized variants."""
     return {lookup_specialized_type(model_type, lifecycle) for lifecycle in (None, *SubscriptionLifecycle)}
 
 
@@ -93,9 +88,20 @@ def _subscription_field_types() -> dict[str, frozenset[FieldType]]:
     return {path: frozenset(types) for path, types in field_types.items()}
 
 
+@lru_cache(maxsize=1)
+def _subscription_field_suffix_types() -> dict[str, frozenset[FieldType]]:
+    """Build field types indexed by their final path segment."""
+    suffix_types: dict[str, set[FieldType]] = defaultdict(set)
+    for field_path, field_types in _subscription_field_types().items():
+        suffix = field_path.rsplit(".", maxsplit=1)[-1]
+        suffix_types[suffix].update(field_types)
+    return {suffix: frozenset(types) for suffix, types in suffix_types.items()}
+
+
 def clear_field_type_cache() -> None:
     """Clear cached subscription field types after changing the model registry."""
     _subscription_field_types.cache_clear()
+    _subscription_field_suffix_types.cache_clear()
 
 
 def resolve_field_types(entity_type: EntityType, path: str) -> frozenset[FieldType]:
@@ -103,13 +109,10 @@ def resolve_field_types(entity_type: EntityType, path: str) -> frozenset[FieldTy
     if entity_type != EntityType.SUBSCRIPTION:
         return frozenset()
 
-    field_types = _subscription_field_types()
     if "." in path:
         schema_path = ".".join("*" if segment.isdigit() else segment for segment in path.split("."))
-        return field_types.get(schema_path, frozenset())
-    return frozenset().union(
-        *(types for field_path, types in field_types.items() if field_path.rsplit(".", maxsplit=1)[-1] == path)
-    )
+        return _subscription_field_types().get(schema_path, frozenset())
+    return _subscription_field_suffix_types().get(path, frozenset())
 
 
 def resolve_field_value_kind(entity_type: EntityType, path: str) -> UIType | None:

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -12,12 +12,14 @@
 # limitations under the License.
 
 from collections import defaultdict
+from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel
 
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY, SubscriptionModel
+from orchestrator.core.domain.base import DomainModel
 from orchestrator.core.domain.lifecycle import lookup_specialized_type
 from orchestrator.core.search.core.types import EntityType, FieldType
 from orchestrator.core.search.indexing.schema import iter_model_field_annotations
@@ -31,6 +33,20 @@ def _model_types(annotation: Any) -> set[type[BaseModel]]:
     return {model_type for arg in get_args(annotation) for model_type in _model_types(arg)}
 
 
+def _field_annotations(model_type: type[BaseModel]) -> Iterable[tuple[str, Any]]:
+    """Yield fields using domain-model classification when available."""
+    if issubclass(model_type, DomainModel):
+        yield from model_type._non_product_block_fields_.items()
+        yield from model_type._product_block_fields_.items()
+        yield from (
+            (name, computed_field.return_type)
+            for name, computed_field in getattr(model_type, "__pydantic_computed_fields__", {}).items()
+        )
+        return
+
+    yield from iter_model_field_annotations(model_type)
+
+
 def _collect_field_types(
     model_type: type[BaseModel],
     path: str,
@@ -41,7 +57,7 @@ def _collect_field_types(
         return
 
     ancestors = ancestors | {model_type}
-    for name, annotation in iter_model_field_annotations(model_type):
+    for name, annotation in _field_annotations(model_type):
         field_path = f"{path}.{name}"
         is_list = get_origin(annotation) is list
         nested_model_types = _model_types(annotation)

--- a/orchestrator/core/search/indexing/schema.py
+++ b/orchestrator/core/search/indexing/schema.py
@@ -17,12 +17,11 @@ from collections.abc import Iterable
 from typing import Any
 
 from pydantic import BaseModel
-from pydantic.fields import ComputedFieldInfo, FieldInfo
 
 
 def iter_model_field_annotations(model_type: type[BaseModel]) -> Iterable[tuple[str, Any]]:
     """Yield declared and computed field names with their annotations."""
-    fields: dict[str, FieldInfo | ComputedFieldInfo] = dict(model_type.model_fields)
-    fields.update(getattr(model_type, "__pydantic_computed_fields__", {}))
-    for name, field in fields.items():
-        yield name, field.return_type if isinstance(field, ComputedFieldInfo) else field.annotation
+    for name, field in model_type.model_fields.items():
+        yield name, field.annotation
+    for name, computed_field in getattr(model_type, "__pydantic_computed_fields__", {}).items():
+        yield name, computed_field.return_type

--- a/orchestrator/core/search/indexing/schema.py
+++ b/orchestrator/core/search/indexing/schema.py
@@ -1,0 +1,28 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for traversing Pydantic model field annotations."""
+
+from collections.abc import Iterable
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic.fields import ComputedFieldInfo, FieldInfo
+
+
+def iter_model_field_annotations(model_type: type[BaseModel]) -> Iterable[tuple[str, Any]]:
+    """Yield declared and computed field names with their annotations."""
+    fields: dict[str, FieldInfo | ComputedFieldInfo] = dict(model_type.model_fields)
+    fields.update(getattr(model_type, "__pydantic_computed_fields__", {}))
+    for name, field in fields.items():
+        yield name, field.return_type if isinstance(field, ComputedFieldInfo) else field.annotation

--- a/orchestrator/core/search/indexing/traverse.py
+++ b/orchestrator/core/search/indexing/traverse.py
@@ -33,6 +33,7 @@ from orchestrator.core.schemas.process import ProcessBaseSchema
 from orchestrator.core.schemas.workflow import WorkflowSchema
 from orchestrator.core.search.core.exceptions import ModelLoadError, ProductNotInRegistryError
 from orchestrator.core.search.core.types import LTREE_SEPARATOR, ExtractedField, FieldType
+from orchestrator.core.search.indexing.schema import iter_model_field_annotations
 from orchestrator.core.types import SubscriptionLifecycle
 
 logger = structlog.get_logger(__name__)
@@ -62,18 +63,13 @@ class BaseTraverser(ABC):
         """Walks the fields of a Pydantic model, dispatching each to a field handler."""
         model_class = type(instance)
 
-        # Handle both standard and computed fields from the Pydantic model
-        all_fields = model_class.model_fields.copy()
-        all_fields.update(getattr(model_class, "__pydantic_computed_fields__", {}))
-
-        for name, field in all_fields.items():
+        for name, annotation in iter_model_field_annotations(model_class):
             try:
                 value = getattr(instance, name, None)
             except Exception as e:
                 logger.error(f"Failed to access field '{name}' on {model_class.__name__}", error=str(e))
                 continue
             new_path = f"{path}{LTREE_SEPARATOR}{name}" if path else name
-            annotation = field.annotation if hasattr(field, "annotation") else field.return_type
             yield from cls._yield_fields_for_value(value, new_path, annotation)
 
     @classmethod

--- a/orchestrator/core/search/indexing/traverse.py
+++ b/orchestrator/core/search/indexing/traverse.py
@@ -208,12 +208,9 @@ class ProductTraverser(BaseTraverser):
 
         # Extract all field names from the block as RESOURCE_TYPE
         if hasattr(type(block_instance), "model_fields"):
-            all_fields = type(block_instance).model_fields
-            computed_fields = getattr(block_instance, "__pydantic_computed_fields__", None)
-            if computed_fields:
-                all_fields.update(computed_fields)
+            all_field_names = [name for name, _ in iter_model_field_annotations(type(block_instance))]
 
-            for field_name in all_fields:
+            for field_name in all_field_names:
                 field_value = getattr(block_instance, field_name, None)
                 field_path = f"{block_path}.{field_name}"
 

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -13,11 +13,16 @@
 
 """Tests for SearchRequest validation: limit bounds, order_by/query exclusivity, filter conversion, and to_query."""
 
-import pytest
-from pydantic import ValidationError
+from unittest.mock import patch
 
+import pytest
+from pydantic import ConfigDict, ValidationError
+
+from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.schemas.search_requests import SearchRequest
-from orchestrator.core.search.core.types import EntityType, RetrieverType
+from orchestrator.core.search.core.types import EntityType, RetrieverType, UIType
+from orchestrator.core.search.indexing.field_types import _subscription_field_types
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 
 
@@ -66,7 +71,7 @@ def test_order_by_without_query_succeeds() -> None:
 )
 def test_elastic_dsl_filter_converted(elastic_filter: dict) -> None:
     schema = SearchRequest(filters=elastic_filter)  # type: ignore[arg-type]
-    assert schema.filters is not None
+    assert schema.to_query(EntityType.SUBSCRIPTION).filters is not None
 
 
 @pytest.mark.parametrize(
@@ -84,6 +89,44 @@ def test_to_query_propagates_fields() -> None:
     assert query.query_text == "search text"
     assert query.limit == 15
     assert query.response_columns == ["name", "status"]
+
+
+def test_to_query_resolves_digit_only_string_term_from_subscription_schema() -> None:
+    class VlanRange(str):
+        pass
+
+    class VlanRangeSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        vlanrange: VlanRange | None = None
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanRangeSubscription}, clear=True):
+        request = SearchRequest(filters={"term": {"vlanrange": "26"}})  # type: ignore[arg-type]
+        query = request.to_query(EntityType.SUBSCRIPTION)
+
+    _subscription_field_types.cache_clear()
+    assert query.filters is not None
+    leaf = query.filters.children[0]
+    assert leaf.value_kind == UIType.STRING
+
+
+def test_to_query_preserves_native_filter_tree() -> None:
+    request = SearchRequest(
+        filters={  # type: ignore[arg-type]
+            "op": "AND",
+            "children": [
+                {
+                    "path": "subscription.status",
+                    "condition": {"op": "eq", "value": "active"},
+                    "value_kind": "string",
+                }
+            ],
+        }
+    )
+
+    query = request.to_query(EntityType.SUBSCRIPTION)
+    assert query.filters == request.filters
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -113,6 +113,49 @@ def test_to_query_resolves_digit_only_string_term_from_subscription_schema() -> 
     assert leaf.value_kind == UIType.STRING
 
 
+def test_to_query_resolves_digit_only_numeric_term_from_subscription_schema() -> None:
+    class VlanIdSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        vlan_id: int | None = None
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanIdSubscription}, clear=True):
+        request = SearchRequest(filters={"term": {"vlan_id": "26"}})  # type: ignore[arg-type]
+        query = request.to_query(EntityType.SUBSCRIPTION)
+
+    _subscription_field_types.cache_clear()
+    assert query.filters is not None
+    leaf = query.filters.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.NUMBER
+
+
+def test_to_query_falls_back_to_inference_for_unknown_field() -> None:
+    """When the resolver can't identify the field, value inference is used instead."""
+
+    class PlainSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        name: str
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"PLAIN": PlainSubscription}, clear=True):
+        request = SearchRequest(filters={"term": {"unknown_field": "26"}})  # type: ignore[arg-type]
+        query = request.to_query(EntityType.SUBSCRIPTION)
+
+    _subscription_field_types.cache_clear()
+    assert query.filters is not None
+    leaf = query.filters.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.NUMBER
+
+
+def test_model_validate_rejects_non_dict_non_model_input() -> None:
+    with pytest.raises(ValidationError):
+        SearchRequest.model_validate(42)
+
+
 def test_to_query_preserves_native_filter_tree() -> None:
     request = SearchRequest(
         filters={  # type: ignore[arg-type]

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -22,6 +22,7 @@ from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.schemas.search_requests import SearchRequest
 from orchestrator.core.search.core.types import EntityType, RetrieverType, UIType
+from orchestrator.core.search.filters.base import PathFilter
 from orchestrator.core.search.indexing.field_types import _subscription_field_types
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 
@@ -108,6 +109,7 @@ def test_to_query_resolves_digit_only_string_term_from_subscription_schema() -> 
     _subscription_field_types.cache_clear()
     assert query.filters is not None
     leaf = query.filters.children[0]
+    assert isinstance(leaf, PathFilter)
     assert leaf.value_kind == UIType.STRING
 
 

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -23,7 +23,7 @@ from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.schemas.search_requests import SearchRequest
 from orchestrator.core.search.core.types import EntityType, RetrieverType, UIType
 from orchestrator.core.search.filters.base import PathFilter
-from orchestrator.core.search.indexing.field_types import _subscription_field_types
+from orchestrator.core.search.indexing.field_types import clear_field_type_cache
 from orchestrator.core.search.query.mixins import StructuredOrderBy
 
 
@@ -101,12 +101,12 @@ def test_to_query_resolves_digit_only_string_term_from_subscription_schema() -> 
 
         vlanrange: VlanRange | None = None
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanRangeSubscription}, clear=True):
         request = SearchRequest(filters={"term": {"vlanrange": "26"}})  # type: ignore[arg-type]
         query = request.to_query(EntityType.SUBSCRIPTION)
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     assert query.filters is not None
     leaf = query.filters.children[0]
     assert isinstance(leaf, PathFilter)
@@ -119,12 +119,12 @@ def test_to_query_resolves_digit_only_numeric_term_from_subscription_schema() ->
 
         vlan_id: int | None = None
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanIdSubscription}, clear=True):
         request = SearchRequest(filters={"term": {"vlan_id": "26"}})  # type: ignore[arg-type]
         query = request.to_query(EntityType.SUBSCRIPTION)
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     assert query.filters is not None
     leaf = query.filters.children[0]
     assert isinstance(leaf, PathFilter)
@@ -139,12 +139,12 @@ def test_to_query_falls_back_to_inference_for_unknown_field() -> None:
 
         name: str
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"PLAIN": PlainSubscription}, clear=True):
         request = SearchRequest(filters={"term": {"unknown_field": "26"}})  # type: ignore[arg-type]
         query = request.to_query(EntityType.SUBSCRIPTION)
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     assert query.filters is not None
     leaf = query.filters.children[0]
     assert isinstance(leaf, PathFilter)

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -92,63 +92,34 @@ def test_to_query_propagates_fields() -> None:
     assert query.response_columns == ["name", "status"]
 
 
-def test_to_query_resolves_digit_only_string_term_from_subscription_schema() -> None:
+@pytest.mark.parametrize(
+    "field, expected_kind",
+    [
+        pytest.param("vlanrange", UIType.STRING, id="string-field"),
+        pytest.param("vlan_id", UIType.NUMBER, id="numeric-field"),
+        pytest.param("unknown_field", UIType.NUMBER, id="unknown-field-falls-back"),
+    ],
+)
+def test_to_query_resolves_digit_only_term_from_subscription_schema(field: str, expected_kind: UIType) -> None:
     class VlanRange(str):
         pass
 
-    class VlanRangeSubscription(SubscriptionModel, is_base=True):
+    class VlanSubscription(SubscriptionModel, is_base=True):
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
         vlanrange: VlanRange | None = None
-
-    clear_field_type_cache()
-    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanRangeSubscription}, clear=True):
-        request = SearchRequest(filters={"term": {"vlanrange": "26"}})  # type: ignore[arg-type]
-        query = request.to_query(EntityType.SUBSCRIPTION)
-
-    clear_field_type_cache()
-    assert query.filters is not None
-    leaf = query.filters.children[0]
-    assert isinstance(leaf, PathFilter)
-    assert leaf.value_kind == UIType.STRING
-
-
-def test_to_query_resolves_digit_only_numeric_term_from_subscription_schema() -> None:
-    class VlanIdSubscription(SubscriptionModel, is_base=True):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
-
         vlan_id: int | None = None
 
     clear_field_type_cache()
-    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanIdSubscription}, clear=True):
-        request = SearchRequest(filters={"term": {"vlan_id": "26"}})  # type: ignore[arg-type]
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanSubscription}, clear=True):
+        request = SearchRequest(filters={"term": {field: "26"}})  # type: ignore[arg-type]
         query = request.to_query(EntityType.SUBSCRIPTION)
 
     clear_field_type_cache()
     assert query.filters is not None
     leaf = query.filters.children[0]
     assert isinstance(leaf, PathFilter)
-    assert leaf.value_kind == UIType.NUMBER
-
-
-def test_to_query_falls_back_to_inference_for_unknown_field() -> None:
-    """When the resolver can't identify the field, value inference is used instead."""
-
-    class PlainSubscription(SubscriptionModel, is_base=True):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
-
-        name: str
-
-    clear_field_type_cache()
-    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"PLAIN": PlainSubscription}, clear=True):
-        request = SearchRequest(filters={"term": {"unknown_field": "26"}})  # type: ignore[arg-type]
-        query = request.to_query(EntityType.SUBSCRIPTION)
-
-    clear_field_type_cache()
-    assert query.filters is not None
-    leaf = query.filters.children[0]
-    assert isinstance(leaf, PathFilter)
-    assert leaf.value_kind == UIType.NUMBER
+    assert leaf.value_kind == expected_kind
 
 
 def test_model_validate_rejects_non_dict_non_model_input() -> None:

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -368,6 +368,33 @@ def test_value_kind_inference(value: Any, expected_kind: UIType) -> None:
     assert leaf.value_kind == expected_kind
 
 
+def test_resolve_value_kind_falls_back_when_resolver_returns_none() -> None:
+    """When the resolver can't resolve a digit-only string, inference is used instead."""
+    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
+
+    assert _resolve_value_kind("field", "26", lambda _field, _value: None) == UIType.NUMBER
+
+
+def test_resolve_value_kind_uses_resolver_for_digit_only_string() -> None:
+    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
+
+    assert _resolve_value_kind("field", "26", lambda _field, _value: UIType.STRING) == UIType.STRING
+
+
+def test_resolve_value_kind_ignores_resolver_for_non_digit_string() -> None:
+    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
+
+    resolver_called = False
+
+    def resolver(_field: str, _value: Any) -> UIType | None:
+        nonlocal resolver_called
+        resolver_called = True
+        return UIType.STRING
+
+    assert _resolve_value_kind("field", "not-digits", resolver) == UIType.STRING
+    assert resolver_called is False
+
+
 # ---------------------------------------------------------------------------
 # validation / edge cases
 # ---------------------------------------------------------------------------
@@ -376,6 +403,28 @@ def test_value_kind_inference(value: Any, expected_kind: UIType) -> None:
 def test_empty_bool_raises() -> None:
     with pytest.raises(ValidationError, match="at least one clause"):
         ElasticQueryAdapter.validate_python({"bool": {}})
+
+
+def test_translate_node_unsupported_query_type_raises() -> None:
+    """_translate_node raises for a query type outside the known ElasticQuery union."""
+    from orchestrator.core.search.filters.elastic_dsl import _translate_node
+
+    class UnsupportedQuery:
+        pass
+
+    with pytest.raises(ValueError, match="Unsupported ES DSL query type"):
+        _translate_node(UnsupportedQuery())  # type: ignore[arg-type]
+
+
+def test_translate_bool_no_children_raises() -> None:
+    """_translate_bool raises if must/should/must_not clauses translate to no children."""
+    from orchestrator.core.search.filters.elastic_dsl import BoolClause, BoolQuery, _translate_bool
+
+    clause = BoolClause.model_construct(must=[], should=[], must_not=[])
+    query = BoolQuery.model_construct(bool=clause)
+
+    with pytest.raises(ValueError, match="bool query produced no children"):
+        _translate_bool(query)
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -411,27 +411,6 @@ def test_empty_bool_raises() -> None:
         ElasticQueryAdapter.validate_python({"bool": {}})
 
 
-def test_translate_node_unsupported_query_type_raises() -> None:
-    """elastic_to_filter_tree raises for a query type outside the known ElasticQuery union."""
-
-    class UnsupportedQuery:
-        pass
-
-    with pytest.raises(ValueError, match="Unsupported ES DSL query type"):
-        elastic_to_filter_tree(UnsupportedQuery())  # type: ignore[arg-type]
-
-
-def test_translate_bool_no_children_raises() -> None:
-    """elastic_to_filter_tree raises if must/should/must_not clauses translate to no children."""
-    from orchestrator.core.search.filters.elastic_dsl import BoolClause, BoolQuery
-
-    clause = BoolClause.model_construct(must=[], should=[], must_not=[])
-    query = BoolQuery.model_construct(bool=clause)
-
-    with pytest.raises(ValueError, match="bool query produced no children"):
-        elastic_to_filter_tree(query)
-
-
 @pytest.mark.parametrize(
     "query_type, payload",
     [

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -20,7 +20,7 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from orchestrator.core.schemas.search_requests import SearchRequest
-from orchestrator.core.search.core.types import BooleanOperator, FilterOp, UIType
+from orchestrator.core.search.core.types import BooleanOperator, EntityType, FilterOp, UIType
 from orchestrator.core.search.filters import FilterTree, PathFilter
 from orchestrator.core.search.filters.base import ContainsFilter, EqualityFilter, StringFilter
 from orchestrator.core.search.filters.date_filters import DateRangeFilter, DateValueFilter
@@ -617,9 +617,10 @@ def test_search_request_accepts_elastic_dsl(
     filters: dict[str, Any], expected_op: BooleanOperator, expected_children: int
 ) -> None:
     request = SearchRequest(filters=filters)  # type: ignore[arg-type]
-    assert isinstance(request.filters, FilterTree)
-    assert request.filters.op == expected_op
-    assert len(request.filters.children) == expected_children
+    query = request.to_query(EntityType.SUBSCRIPTION)
+    assert isinstance(query.filters, FilterTree)
+    assert query.filters.op == expected_op
+    assert len(query.filters.children) == expected_children
 
 
 def test_search_request_accepts_filter_tree() -> None:
@@ -689,30 +690,12 @@ def test_must_not_contains_inverts_to_not_contains() -> None:
     assert leaf.condition.value == ".*LIR.*"
 
 
-def test_must_not_not_contains_inverts_to_contains() -> None:
-    es = ElasticQueryAdapter.validate_python(
-        {
-            "bool": {
-                "must_not": [
-                    {
-                        "regexp": {"description": ".*LIR.*"},
-                    }
-                ]
-            }
-        }
-    )
-    tree = elastic_to_filter_tree(es)
-    leaf = tree.children[0]
-    assert isinstance(leaf, PathFilter)
-    assert isinstance(leaf.condition, ContainsFilter)
-    assert leaf.condition.op == FilterOp.NOT_CONTAINS
-
-
 def test_search_request_accepts_contains_filter() -> None:
     request = SearchRequest(filters={"regexp": {"subscription.description": {"value": ".*fiber.*"}}})  # type: ignore[arg-type]
-    assert isinstance(request.filters, FilterTree)
-    assert len(request.filters.children) == 1
-    leaf = request.filters.children[0]
+    query = request.to_query(EntityType.SUBSCRIPTION)
+    assert isinstance(query.filters, FilterTree)
+    assert len(query.filters.children) == 1
+    leaf = query.filters.children[0]
     assert isinstance(leaf, PathFilter)
     assert isinstance(leaf.condition, ContainsFilter)
     assert leaf.condition.op == FilterOp.CONTAINS

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -370,20 +370,22 @@ def test_value_kind_inference(value: Any, expected_kind: UIType) -> None:
 
 def test_resolve_value_kind_falls_back_when_resolver_returns_none() -> None:
     """When the resolver can't resolve a digit-only string, inference is used instead."""
-    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
-
-    assert _resolve_value_kind("field", "26", lambda _field, _value: None) == UIType.NUMBER
+    es = ElasticQueryAdapter.validate_python({"term": {"field": "26"}})
+    tree = elastic_to_filter_tree(es, value_kind_resolver=lambda _field, _value: None)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.NUMBER
 
 
 def test_resolve_value_kind_uses_resolver_for_digit_only_string() -> None:
-    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
-
-    assert _resolve_value_kind("field", "26", lambda _field, _value: UIType.STRING) == UIType.STRING
+    es = ElasticQueryAdapter.validate_python({"term": {"field": "26"}})
+    tree = elastic_to_filter_tree(es, value_kind_resolver=lambda _field, _value: UIType.STRING)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.STRING
 
 
 def test_resolve_value_kind_ignores_resolver_for_non_digit_string() -> None:
-    from orchestrator.core.search.filters.elastic_dsl import _resolve_value_kind
-
     resolver_called = False
 
     def resolver(_field: str, _value: Any) -> UIType | None:
@@ -391,7 +393,11 @@ def test_resolve_value_kind_ignores_resolver_for_non_digit_string() -> None:
         resolver_called = True
         return UIType.STRING
 
-    assert _resolve_value_kind("field", "not-digits", resolver) == UIType.STRING
+    es = ElasticQueryAdapter.validate_python({"term": {"field": "not-digits"}})
+    tree = elastic_to_filter_tree(es, value_kind_resolver=resolver)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.STRING
     assert resolver_called is False
 
 
@@ -406,25 +412,24 @@ def test_empty_bool_raises() -> None:
 
 
 def test_translate_node_unsupported_query_type_raises() -> None:
-    """_translate_node raises for a query type outside the known ElasticQuery union."""
-    from orchestrator.core.search.filters.elastic_dsl import _translate_node
+    """elastic_to_filter_tree raises for a query type outside the known ElasticQuery union."""
 
     class UnsupportedQuery:
         pass
 
     with pytest.raises(ValueError, match="Unsupported ES DSL query type"):
-        _translate_node(UnsupportedQuery())  # type: ignore[arg-type]
+        elastic_to_filter_tree(UnsupportedQuery())  # type: ignore[arg-type]
 
 
 def test_translate_bool_no_children_raises() -> None:
-    """_translate_bool raises if must/should/must_not clauses translate to no children."""
-    from orchestrator.core.search.filters.elastic_dsl import BoolClause, BoolQuery, _translate_bool
+    """elastic_to_filter_tree raises if must/should/must_not clauses translate to no children."""
+    from orchestrator.core.search.filters.elastic_dsl import BoolClause, BoolQuery
 
     clause = BoolClause.model_construct(must=[], should=[], must_not=[])
     query = BoolQuery.model_construct(bool=clause)
 
     with pytest.raises(ValueError, match="bool query produced no children"):
-        _translate_bool(query)
+        elastic_to_filter_tree(query)
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -20,11 +20,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.core.domain.base import SubscriptionModel
-from orchestrator.core.search.core.types import EntityType, FieldType
+from orchestrator.core.search.core.types import EntityType, FieldType, UIType
 from orchestrator.core.search.indexing.field_types import (
     _collect_field_types,
     clear_field_type_cache,
     resolve_field_types,
+    resolve_field_value_kind,
 )
 from test.unit_tests.search.fixtures.blocks import BasicBlock, ComputedBlock
 
@@ -119,6 +120,37 @@ def test_resolve_field_types_global_path_matches_any_depth() -> None:
     clear_field_type_cache()
 
     assert types == frozenset({FieldType.INTEGER})
+
+
+def test_resolve_field_value_kind_returns_only_unambiguous_types() -> None:
+    class StringSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        string_value: str
+        ambiguous_value: str
+
+    class NumericSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        numeric_value: int
+        ambiguous_value: int
+
+    clear_field_type_cache()
+    with patch.dict(
+        SUBSCRIPTION_MODEL_REGISTRY,
+        {"STRING": StringSubscription, "NUMERIC": NumericSubscription},
+        clear=True,
+    ):
+        string_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "string_value")
+        numeric_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "numeric_value")
+        ambiguous_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "ambiguous_value")
+        other_entity_kind = resolve_field_value_kind(EntityType.WORKFLOW, "string_value")
+    clear_field_type_cache()
+
+    assert string_kind == UIType.STRING
+    assert numeric_kind == UIType.NUMBER
+    assert ambiguous_kind is None
+    assert other_entity_kind is None
 
 
 def test_resolve_field_types_unknown_path_returns_empty() -> None:

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -1,0 +1,92 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for orchestrator.core.search.indexing.field_types: subscription field type indexing and resolution."""
+
+from collections import defaultdict
+from unittest.mock import patch
+
+from pydantic import BaseModel, ConfigDict
+
+from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
+from orchestrator.core.domain.base import SubscriptionModel
+from orchestrator.core.search.core.types import EntityType, FieldType
+from orchestrator.core.search.indexing.field_types import (
+    _collect_field_types,
+    _subscription_field_types,
+    resolve_field_types,
+)
+from test.unit_tests.search.fixtures.blocks import BasicBlock
+
+
+def test_collect_field_types_stops_at_self_referential_ancestor() -> None:
+    """A model that references itself must not recurse infinitely."""
+
+    class RecursiveModel(BaseModel):
+        name: str
+        child: "RecursiveModel | None" = None
+
+    RecursiveModel.model_rebuild()
+
+    field_types: dict[str, set[FieldType]] = defaultdict(set)
+    _collect_field_types(RecursiveModel, "subscription", field_types, set())
+
+    assert dict(field_types) == {"subscription.name": {FieldType.STRING}}
+
+
+def test_resolve_field_types_non_subscription_entity_returns_empty() -> None:
+    assert resolve_field_types(EntityType.WORKFLOW, "name") == frozenset()
+
+
+def test_resolve_field_types_resolves_nested_block_path() -> None:
+    class BlockSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        basic_block: BasicBlock
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"BLOCK": BlockSubscription}, clear=True):
+        types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.basic_block.value")
+    _subscription_field_types.cache_clear()
+
+    assert types == frozenset({FieldType.INTEGER})
+
+
+def test_resolve_field_types_global_path_matches_any_depth() -> None:
+    """A dotless path (no ltree segments) matches the field name at any depth."""
+
+    class BlockSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        basic_block: BasicBlock
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"BLOCK": BlockSubscription}, clear=True):
+        types = resolve_field_types(EntityType.SUBSCRIPTION, "value")
+    _subscription_field_types.cache_clear()
+
+    assert types == frozenset({FieldType.INTEGER})
+
+
+def test_resolve_field_types_unknown_path_returns_empty() -> None:
+    class SimpleSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        name: str
+
+    _subscription_field_types.cache_clear()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"SIMPLE": SimpleSubscription}, clear=True):
+        types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.does_not_exist")
+    _subscription_field_types.cache_clear()
+
+    assert types == frozenset()

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -23,7 +23,7 @@ from orchestrator.core.domain.base import SubscriptionModel
 from orchestrator.core.search.core.types import EntityType, FieldType
 from orchestrator.core.search.indexing.field_types import (
     _collect_field_types,
-    _subscription_field_types,
+    clear_field_type_cache,
     resolve_field_types,
 )
 from test.unit_tests.search.fixtures.blocks import BasicBlock
@@ -48,16 +48,39 @@ def test_resolve_field_types_non_subscription_entity_returns_empty() -> None:
     assert resolve_field_types(EntityType.WORKFLOW, "name") == frozenset()
 
 
+def test_clear_field_type_cache_refreshes_registered_models() -> None:
+    class InitialSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        initial_field: str
+
+    class RegisteredLaterSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        registered_later_field: int
+
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"INITIAL": InitialSubscription}, clear=True):
+        clear_field_type_cache()
+        assert resolve_field_types(EntityType.SUBSCRIPTION, "registered_later_field") == frozenset()
+
+        SUBSCRIPTION_MODEL_REGISTRY["REGISTERED_LATER"] = RegisteredLaterSubscription
+        clear_field_type_cache()
+
+        assert resolve_field_types(EntityType.SUBSCRIPTION, "registered_later_field") == frozenset({FieldType.INTEGER})
+
+    clear_field_type_cache()
+
+
 def test_resolve_field_types_resolves_nested_block_path() -> None:
     class BlockSubscription(SubscriptionModel, is_base=True):
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
         basic_block: BasicBlock
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"BLOCK": BlockSubscription}, clear=True):
         types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.basic_block.value")
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
 
     assert types == frozenset({FieldType.INTEGER})
 
@@ -70,10 +93,10 @@ def test_resolve_field_types_global_path_matches_any_depth() -> None:
 
         basic_block: BasicBlock
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"BLOCK": BlockSubscription}, clear=True):
         types = resolve_field_types(EntityType.SUBSCRIPTION, "value")
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
 
     assert types == frozenset({FieldType.INTEGER})
 
@@ -84,9 +107,9 @@ def test_resolve_field_types_unknown_path_returns_empty() -> None:
 
         name: str
 
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"SIMPLE": SimpleSubscription}, clear=True):
         types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.does_not_exist")
-    _subscription_field_types.cache_clear()
+    clear_field_type_cache()
 
     assert types == frozenset()

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -16,7 +16,7 @@
 from collections import defaultdict
 from unittest.mock import patch
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
 from orchestrator.core.domain.base import SubscriptionModel
@@ -26,7 +26,7 @@ from orchestrator.core.search.indexing.field_types import (
     clear_field_type_cache,
     resolve_field_types,
 )
-from test.unit_tests.search.fixtures.blocks import BasicBlock
+from test.unit_tests.search.fixtures.blocks import BasicBlock, ComputedBlock
 
 
 def test_collect_field_types_stops_at_self_referential_ancestor() -> None:
@@ -83,6 +83,26 @@ def test_resolve_field_types_resolves_nested_block_path() -> None:
     clear_field_type_cache()
 
     assert types == frozenset({FieldType.INTEGER})
+
+
+def test_resolve_field_types_uses_domain_field_registries() -> None:
+    class DomainFieldsSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        renamed_value: int = Field(alias="value")
+        basic_block: BasicBlock
+        computed_block: ComputedBlock
+
+    clear_field_type_cache()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"DOMAIN": DomainFieldsSubscription}, clear=True):
+        scalar_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.value")
+        nested_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.basic_block.value")
+        computed_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.computed_block.display_name")
+    clear_field_type_cache()
+
+    assert scalar_types == frozenset({FieldType.INTEGER})
+    assert nested_types == frozenset({FieldType.INTEGER})
+    assert computed_types == frozenset({FieldType.STRING})
 
 
 def test_resolve_field_types_global_path_matches_any_depth() -> None:

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -13,36 +13,36 @@
 
 """Tests for orchestrator.core.search.indexing.field_types: subscription field type indexing and resolution."""
 
-from collections import defaultdict
 from unittest.mock import patch
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
 from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
-from orchestrator.core.domain.base import SubscriptionModel
+from orchestrator.core.domain.base import ProductBlockModel, SubscriptionModel
 from orchestrator.core.search.core.types import EntityType, FieldType, UIType
 from orchestrator.core.search.indexing.field_types import (
-    _collect_field_types,
     clear_field_type_cache,
     resolve_field_types,
     resolve_field_value_kind,
 )
-from test.unit_tests.search.fixtures.blocks import BasicBlock, ComputedBlock
+from test.unit_tests.search.fixtures.blocks import BasicBlock, ComputedBlock, ListBlock
 
 
-def test_collect_field_types_stops_at_self_referential_ancestor() -> None:
-    """A model that references itself must not recurse infinitely."""
+def test_resolve_field_types_handles_recursive_subscription_model() -> None:
+    class RecursiveSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    class RecursiveModel(BaseModel):
         name: str
-        child: "RecursiveModel | None" = None
+        child: "RecursiveSubscription | None" = None
 
-    RecursiveModel.model_rebuild()
+    RecursiveSubscription.model_rebuild()
 
-    field_types: dict[str, set[FieldType]] = defaultdict(set)
-    _collect_field_types(RecursiveModel, "subscription", field_types, set())
+    clear_field_type_cache()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"RECURSIVE": RecursiveSubscription}, clear=True):
+        types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.name")
+    clear_field_type_cache()
 
-    assert dict(field_types) == {"subscription.name": {FieldType.STRING}}
+    assert types == frozenset({FieldType.STRING})
 
 
 def test_resolve_field_types_non_subscription_entity_returns_empty() -> None:
@@ -86,6 +86,20 @@ def test_resolve_field_types_resolves_nested_block_path() -> None:
     assert types == frozenset({FieldType.INTEGER})
 
 
+def test_resolve_field_types_indexes_annotated_list_fields_with_wildcard_path() -> None:
+    class ListSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        list_block: ListBlock
+
+    clear_field_type_cache()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"LIST": ListSubscription}, clear=True):
+        types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.list_block.required_ids.0")
+    clear_field_type_cache()
+
+    assert types == frozenset({FieldType.INTEGER})
+
+
 def test_resolve_field_types_uses_domain_field_registries() -> None:
     class DomainFieldsSubscription(SubscriptionModel, is_base=True):
         model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -123,33 +137,39 @@ def test_resolve_field_types_global_path_matches_any_depth() -> None:
 
 
 def test_resolve_field_value_kind_returns_only_unambiguous_types() -> None:
-    class StringSubscription(SubscriptionModel, is_base=True):
+    class StringBlock(ProductBlockModel):
+        ambiguous_value: str
+
+    class NumericBlock(ProductBlockModel):
+        ambiguous_value: int
+
+    class BlockSubscription(SubscriptionModel, is_base=True):
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
         string_value: str
-        ambiguous_value: str
-
-    class NumericSubscription(SubscriptionModel, is_base=True):
-        model_config = ConfigDict(arbitrary_types_allowed=True)
-
         numeric_value: int
-        ambiguous_value: int
+        string_block: StringBlock
+        numeric_block: NumericBlock
 
     clear_field_type_cache()
-    with patch.dict(
-        SUBSCRIPTION_MODEL_REGISTRY,
-        {"STRING": StringSubscription, "NUMERIC": NumericSubscription},
-        clear=True,
-    ):
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"BLOCK": BlockSubscription}, clear=True):
         string_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "string_value")
         numeric_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "numeric_value")
         ambiguous_kind = resolve_field_value_kind(EntityType.SUBSCRIPTION, "ambiguous_value")
+        qualified_string_kind = resolve_field_value_kind(
+            EntityType.SUBSCRIPTION, "subscription.string_block.ambiguous_value"
+        )
+        qualified_numeric_kind = resolve_field_value_kind(
+            EntityType.SUBSCRIPTION, "subscription.numeric_block.ambiguous_value"
+        )
         other_entity_kind = resolve_field_value_kind(EntityType.WORKFLOW, "string_value")
     clear_field_type_cache()
 
     assert string_kind == UIType.STRING
     assert numeric_kind == UIType.NUMBER
     assert ambiguous_kind is None
+    assert qualified_string_kind == UIType.STRING
+    assert qualified_numeric_kind == UIType.NUMBER
     assert other_entity_kind is None
 
 

--- a/test/unit_tests/search/test_subscription_traversal.py
+++ b/test/unit_tests/search/test_subscription_traversal.py
@@ -14,10 +14,24 @@
 """Tests for SubscriptionTraverser: end-to-end model traversal for simple, nested, and computed property subscriptions."""
 
 import pytest
+from pydantic import BaseModel, computed_field
 
 from orchestrator.core.search.core.types import EntityType
 from orchestrator.core.search.indexing.registry import ENTITY_CONFIG_REGISTRY
+from orchestrator.core.search.indexing.schema import iter_model_field_annotations
 from orchestrator.core.search.indexing.traverse import SubscriptionTraverser
+
+
+def test_iter_model_field_annotations_includes_declared_and_computed_fields() -> None:
+    class TestModel(BaseModel):
+        name: str
+
+        @computed_field  # type: ignore[prop-decorator]
+        @property
+        def name_length(self) -> int:
+            return len(self.name)
+
+    assert dict(iter_model_field_annotations(TestModel)) == {"name": str, "name_length": int}
 
 
 def _assert_traverse_fields_match(mock_load_model, mock_db_subscription, subscription_instance, expected_fields):

--- a/test/unit_tests/search/test_type_mapping.py
+++ b/test/unit_tests/search/test_type_mapping.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime
 from enum import Enum, IntEnum
-from typing import Annotated, List, Literal, Union
+from typing import Annotated, List, Literal, Sequence, Union
 from uuid import UUID
 
 import pytest
@@ -37,6 +37,7 @@ from test.unit_tests.search.fixtures.blocks import MTU, MTUChoice, PriorityIntEn
         pytest.param(PriorityIntEnum, FieldType.INTEGER, id="int-enum"),
         pytest.param(List[int], FieldType.INTEGER, id="List-int"),
         pytest.param(list[int], FieldType.INTEGER, id="list-int"),
+        pytest.param(Sequence[int], FieldType.INTEGER, id="sequence-int"),
         pytest.param(list[float], FieldType.FLOAT, id="list-float"),
         pytest.param(list[bool], FieldType.BOOLEAN, id="list-bool"),
         pytest.param(list[StatusEnum], FieldType.STRING, id="list-str-enum"),
@@ -60,6 +61,7 @@ from test.unit_tests.search.fixtures.blocks import MTU, MTUChoice, PriorityIntEn
         pytest.param(Annotated[datetime, "timezone"], FieldType.DATETIME, id="annotated-datetime"),
         pytest.param(Annotated[UUID, "version"], FieldType.UUID, id="annotated-uuid"),
         pytest.param(Annotated[list[str], "min_length"], FieldType.STRING, id="annotated-list-str"),
+        pytest.param(Annotated[Sequence[int], "min_length"], FieldType.INTEGER, id="annotated-sequence-int"),
         pytest.param(Annotated[Union[int, None], "optional"], FieldType.INTEGER, id="annotated-optional-int"),
         pytest.param(list[MTU], FieldType.INTEGER, id="list-annotated-mtu"),
         pytest.param(Union[MTU, None], FieldType.INTEGER, id="optional-annotated-mtu"),


### PR DESCRIPTION
## Summary

Preserve the intended type of digit-only Elasticsearch DSL term values for subscription fields.

Previously, a value such as `"26"` was inferred as numeric solely because it contains digits. This is incorrect for string-backed subscription fields, such as a VLAN range, and can cause filters to return no matching subscriptions.

## Changes

- Accept `FilterTree` and validated Elasticsearch DSL filters in `SearchRequest`.
- Convert Elasticsearch DSL to `FilterTree` in `SearchRequest.to_query(entity_type)`, where the entity type is available.
- Derive and cache searchable field types from registered subscription models and their lifecycle variants.
- Resolve digit-only term values from the schema when the field type is unambiguous:
  - string fields remain strings;
  - integer and float fields become numbers;
  - unknown or ambiguous paths retain the existing generic inference.
- Support exact paths, dotless suffix paths, nested fields, list fields, aliases, and computed fields.
- Preserve existing behavior for native `FilterTree` filters, non-digit strings, JSON numeric values, and callers that do not provide a schema resolver.

## Verification

- Added resolver coverage for unique, exact, ambiguous, unknown, nested, computed, aliased, and list-indexed fields.
- Added request-level coverage for string-backed and numeric subscription fields.
- Ran focused Elasticsearch DSL, request-schema, field-type, and type-mapping test modules.
- Ran mypy for the changed modules.


## Related Issues
Fixes # (issue number)

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
