### PR TITLE
Fix highlight indices in new search page

### DIFF
--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -315,7 +315,7 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
     that leaf (``{"value", "path", "idx"}``). Flattening gives every (value, path) pair
     that satisfied any filter, deduplicated across leaves.
     """
-    from orchestrator.core.search.filters import ContainsFilter, EqualityFilter, LtreeFilter
+    from orchestrator.core.search.filters import ContainsFilter, EqualityFilter, LtreeFilter, StringFilter
     from orchestrator.core.search.retrieval.retrievers import Retriever
 
     leaf_arrays: list[list[dict]] | None = row.get(Retriever.HIGHLIGHT_MATCHES_LABEL)
@@ -340,7 +340,11 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
         if is_negation:
             return MatchingField(text=text, path=path, highlight_indices=None)
         term = str(getattr(leaf.condition, "value", "") or "") if leaf else ""
-        indices = generate_highlight_indices(text, term) if term else []
+        if leaf is not None and isinstance(leaf.condition, StringFilter):
+            # LIKE patterns carry SQL wildcards that would never match literally;
+            # replace with spaces so the remaining words are highlighted individually.
+            term = term.replace("%", " ").replace("_", " ")
+        indices = generate_highlight_indices(text, term) if term.strip() else []
         return MatchingField(text=text, path=path, highlight_indices=indices or [(0, len(text))])
 
     return [build_matching_field(text, path, m) for (text, path), m in unique_matches.items()]

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -219,6 +219,30 @@ def generate_highlight_indices(text: str, term: str) -> list[tuple[int, int]]:
     return sorted(set(all_matches))
 
 
+def generate_regex_highlight_indices(text: str, pattern: str) -> list[tuple[int, int]]:
+    """Find spans matching a CONTAINS (``regexp``) filter pattern, ignoring greedy ``.*``/``.+`` wrappers.
+
+    Contains filters match in the database with the case-insensitive regex operator (``~*``),
+    so the pattern is applied as a regex here as well. Leading/trailing ``.*``/``.+`` are
+    stripped first so they don't swallow the surrounding text. An invalid pattern falls back
+    to literal word highlighting.
+    """
+    import re
+
+    if not text or not pattern:
+        return []
+
+    core = re.sub(r"^(?:\.[*+])+", "", pattern)
+    core = re.sub(r"(?:\.[*+])+$", "", core)
+    if not core:
+        return []
+    try:
+        spans = {m.span() for m in re.finditer(core, text, re.IGNORECASE) if m.start() < m.end()}
+    except re.error:
+        return generate_highlight_indices(text, pattern)
+    return sorted(spans)
+
+
 def format_search_response(
     db_rows: Sequence[RowMapping],
     query: "SelectQuery | ExportQuery",
@@ -340,11 +364,16 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
         if is_negation:
             return MatchingField(text=text, path=path, highlight_indices=None)
         term = str(getattr(leaf.condition, "value", "") or "") if leaf else ""
-        if leaf is not None and isinstance(leaf.condition, StringFilter):
-            # LIKE patterns carry SQL wildcards that would never match literally;
-            # replace with spaces so the remaining words are highlighted individually.
-            term = term.replace("%", " ").replace("_", " ")
-        indices = generate_highlight_indices(text, term) if term.strip() else []
+        match leaf.condition if leaf else None:
+            case ContainsFilter():
+                indices = generate_regex_highlight_indices(text, term)
+            case StringFilter():
+                # LIKE patterns carry SQL wildcards that would never match literally;
+                # replace with spaces so the remaining words are highlighted individually.
+                term = term.replace("%", " ").replace("_", " ")
+                indices = generate_highlight_indices(text, term) if term.strip() else []
+            case _:
+                indices = generate_highlight_indices(text, term) if term.strip() else []
         return MatchingField(text=text, path=path, highlight_indices=indices or [(0, len(text))])
 
     return [build_matching_field(text, path, m) for (text, path), m in unique_matches.items()]

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -13,6 +13,7 @@
 
 """Query execution result models and formatting functions."""
 
+import re
 from collections.abc import Sequence
 from typing import Literal
 
@@ -227,7 +228,6 @@ def generate_regex_highlight_indices(text: str, pattern: str) -> list[tuple[int,
     stripped first so they don't swallow the surrounding text. An invalid pattern falls back
     to literal word highlighting.
     """
-    import re
 
     if not text or not pattern:
         return []
@@ -238,7 +238,7 @@ def generate_regex_highlight_indices(text: str, pattern: str) -> list[tuple[int,
         return []
     try:
         spans = {m.span() for m in re.finditer(core, text, re.IGNORECASE) if m.start() < m.end()}
-    except re.error:
+    except re.error:  # FIXME rename to re.PatternError when dropping support for python < 3.13
         return generate_highlight_indices(text, pattern)
     return sorted(spans)
 

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -232,8 +232,8 @@ def generate_regex_highlight_indices(text: str, pattern: str) -> list[tuple[int,
     if not text or not pattern:
         return []
 
-    core = re.sub(r"^(?:\.[*+])+", "", pattern)
-    core = re.sub(r"(?:\.[*+])+$", "", core)
+    core = re.sub(r"^(?:\.[*+])+", "", pattern) # removes leading greedy wildcard
+    core = re.sub(r"(?:\.[*+])+$", "", core) # removes trailing greedy wildcard
     if not core:
         return []
     try:

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -364,8 +364,16 @@ def _or_filter_tree() -> FilterTree:
     return FilterTree(
         op=BooleanOperator.OR,
         children=[
-            PathFilter(path="subscription.status", condition=EqualityFilter(op=FilterOp.EQ, value="active"), value_kind=UIType.STRING),
-            PathFilter(path="subscription.product.name", condition=StringFilter(op=FilterOp.LIKE, value="%fiber%"), value_kind=UIType.STRING),
+            PathFilter(
+                path="subscription.status",
+                condition=EqualityFilter(op=FilterOp.EQ, value="active"),
+                value_kind=UIType.STRING,
+            ),
+            PathFilter(
+                path="subscription.product.name",
+                condition=StringFilter(op=FilterOp.LIKE, value="%fiber%"),
+                value_kind=UIType.STRING,
+            ),
         ],
     )
 
@@ -453,6 +461,34 @@ def test_resolve_equality_filter_value_highlighted(value, expected_text: str):
     assert isinstance(result[0], MatchingField)
     assert result[0].text == expected_text
     assert result[0].highlight_indices == [(0, len(expected_text))]
+
+
+@pytest.mark.parametrize(
+    "pattern, text, expected_indices",
+    [
+        pytest.param("%aren%", "SingAren SURF", [(4, 8)], id="wrapped-wildcards"),
+        pytest.param("aren%", "SingAren SURF", [(4, 8)], id="trailing-wildcard"),
+        pytest.param("%aren%surf%", "SingAren SURF", [(4, 8), (9, 13)], id="multiple-wildcards"),
+        pytest.param("nsi_dev%", "prefix nsi.dev suffix", [(7, 10), (11, 14)], id="underscore-wildcard-splits-words"),
+    ],
+)
+def test_resolve_like_filter_strips_wildcards_before_highlighting(pattern, text, expected_indices):
+    """LIKE wildcards are stripped so the remaining words highlight at their real positions."""
+    tree = _single_leaf_filter_tree(StringFilter(op=FilterOp.LIKE, value=pattern), path="subscription.description")
+    row = _row_with_highlights([(text, "subscription.description")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert len(result) == 1
+    assert result[0].text == text
+    assert result[0].highlight_indices == expected_indices
+
+
+def test_resolve_like_filter_term_not_in_text_falls_back_to_full_text():
+    """When the LIKE words do not occur in the stored value, the whole value is highlighted."""
+    tree = _single_leaf_filter_tree(StringFilter(op=FilterOp.LIKE, value="%fiber%"), path="subscription.description")
+    row = _row_with_highlights([("Corelink 10G", "subscription.description")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert len(result) == 1
+    assert result[0].highlight_indices == [(0, len("Corelink 10G"))]
 
 
 def test_resolve_neq_filter_returns_null_highlight_indices():

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -466,10 +466,10 @@ def test_resolve_equality_filter_value_highlighted(value, expected_text: str):
 @pytest.mark.parametrize(
     "pattern, text, expected_indices",
     [
-        pytest.param("%aren%", "SingAren SURF", [(4, 8)], id="wrapped-wildcards"),
-        pytest.param("aren%", "SingAren SURF", [(4, 8)], id="trailing-wildcard"),
-        pytest.param("%aren%surf%", "SingAren SURF", [(4, 8), (9, 13)], id="multiple-wildcards"),
-        pytest.param("nsi_dev%", "prefix nsi.dev suffix", [(7, 10), (11, 14)], id="underscore-wildcard-splits-words"),
+        pytest.param("%base%", "Database backup", [(4, 8)], id="wrapped-wildcards"),
+        pytest.param("base%", "Database backup", [(4, 8)], id="trailing-wildcard"),
+        pytest.param("%base%backup%", "Database backup", [(4, 8), (9, 15)], id="multiple-wildcards"),
+        pytest.param("foo_bar%", "prefix foo.bar suffix", [(7, 10), (11, 14)], id="underscore-wildcard-splits-words"),
     ],
 )
 def test_resolve_like_filter_strips_wildcards_before_highlighting(pattern, text, expected_indices):
@@ -484,20 +484,20 @@ def test_resolve_like_filter_strips_wildcards_before_highlighting(pattern, text,
 
 def test_resolve_like_filter_term_not_in_text_falls_back_to_full_text():
     """When the LIKE words do not occur in the stored value, the whole value is highlighted."""
-    tree = _single_leaf_filter_tree(StringFilter(op=FilterOp.LIKE, value="%fiber%"), path="subscription.description")
-    row = _row_with_highlights([("Corelink 10G", "subscription.description")])
+    tree = _single_leaf_filter_tree(StringFilter(op=FilterOp.LIKE, value="%banana%"), path="subscription.description")
+    row = _row_with_highlights([("widget assembly", "subscription.description")])
     result = _resolve_structured_matching_fields(row, tree)
     assert len(result) == 1
-    assert result[0].highlight_indices == [(0, len("Corelink 10G"))]
+    assert result[0].highlight_indices == [(0, len("widget assembly"))]
 
 
 @pytest.mark.parametrize(
     "pattern, text, expected_indices",
     [
-        pytest.param(".*SP.*", "IRB SP ah001a-jnx-okt-rg8-0a", [(4, 6)], id="dot-star-wrapped"),
-        pytest.param("SP", "IRB SP ah001a-jnx-okt-rg8-0a", [(4, 6)], id="plain-substring"),
-        pytest.param(".+aren.+", "SingAren SURF", [(4, 8)], id="dot-plus-wrapped"),
-        pytest.param("irb|sp", "IRB SP port", [(0, 3), (4, 6)], id="alternation"),
+        pytest.param(".*OK.*", "job OK done", [(4, 6)], id="dot-star-wrapped"),
+        pytest.param("OK", "job OK done", [(4, 6)], id="plain-substring"),
+        pytest.param(".+base.+", "Database backup", [(4, 8)], id="dot-plus-wrapped"),
+        pytest.param("foo|bar", "FOO BAR baz", [(0, 3), (4, 7)], id="alternation"),
     ],
 )
 def test_resolve_contains_filter_highlights_regex_matches(pattern, text, expected_indices):
@@ -515,9 +515,9 @@ def test_resolve_contains_filter_highlights_regex_matches(pattern, text, expecte
 @pytest.mark.parametrize(
     "pattern, text",
     [
-        pytest.param("[SP", "IRB SP port", id="invalid-regex"),
-        pytest.param(".*", "IRB SP port", id="match-all-wildcard-only"),
-        pytest.param(".*fiber.*", "Corelink 10G", id="pattern-not-in-text"),
+        pytest.param("[foo", "FOO BAR baz", id="invalid-regex"),
+        pytest.param(".*", "FOO BAR baz", id="match-all-wildcard-only"),
+        pytest.param(".*banana.*", "widget assembly", id="pattern-not-in-text"),
     ],
 )
 def test_resolve_contains_filter_falls_back_to_full_text(pattern, text):

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -491,6 +491,46 @@ def test_resolve_like_filter_term_not_in_text_falls_back_to_full_text():
     assert result[0].highlight_indices == [(0, len("Corelink 10G"))]
 
 
+@pytest.mark.parametrize(
+    "pattern, text, expected_indices",
+    [
+        pytest.param(".*SP.*", "IRB SP ah001a-jnx-okt-rg8-0a", [(4, 6)], id="dot-star-wrapped"),
+        pytest.param("SP", "IRB SP ah001a-jnx-okt-rg8-0a", [(4, 6)], id="plain-substring"),
+        pytest.param(".+aren.+", "SingAren SURF", [(4, 8)], id="dot-plus-wrapped"),
+        pytest.param("irb|sp", "IRB SP port", [(0, 3), (4, 6)], id="alternation"),
+    ],
+)
+def test_resolve_contains_filter_highlights_regex_matches(pattern, text, expected_indices):
+    """CONTAINS (`regexp`) patterns highlight with regex semantics, ignoring greedy `.*`/`.+` wrappers."""
+    tree = _single_leaf_filter_tree(
+        ContainsFilter(op=FilterOp.CONTAINS, value=pattern), path="subscription.description"
+    )
+    row = _row_with_highlights([(text, "subscription.description")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert len(result) == 1
+    assert result[0].text == text
+    assert result[0].highlight_indices == expected_indices
+
+
+@pytest.mark.parametrize(
+    "pattern, text",
+    [
+        pytest.param("[SP", "IRB SP port", id="invalid-regex"),
+        pytest.param(".*", "IRB SP port", id="match-all-wildcard-only"),
+        pytest.param(".*fiber.*", "Corelink 10G", id="pattern-not-in-text"),
+    ],
+)
+def test_resolve_contains_filter_falls_back_to_full_text(pattern, text):
+    """Patterns that cannot be located in the stored value highlight the whole value."""
+    tree = _single_leaf_filter_tree(
+        ContainsFilter(op=FilterOp.CONTAINS, value=pattern), path="subscription.description"
+    )
+    row = _row_with_highlights([(text, "subscription.description")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert len(result) == 1
+    assert result[0].highlight_indices == [(0, len(text))]
+
+
 def test_resolve_neq_filter_returns_null_highlight_indices():
     """NEQ filter returns the stored value as context but highlight_indices=None (no term to highlight)."""
     tree = _single_leaf_filter_tree(EqualityFilter(op=FilterOp.NEQ, value="terminated"))

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -468,6 +468,8 @@ def test_resolve_equality_filter_value_highlighted(value, expected_text: str):
     [
         pytest.param("%base%", "Database backup", [(4, 8)], id="wrapped-wildcards"),
         pytest.param("base%", "Database backup", [(4, 8)], id="trailing-wildcard"),
+        pytest.param("%base%", "Database Database backup,", [(4, 8), (13, 17)], id="term-occurs-twice-in-text"),
+        pytest.param("%base%", "Databasebase", [(4, 8), (8, 12)], id="adjacent-matches-in-text"),
         pytest.param("%base%backup%", "Database backup", [(4, 8), (9, 15)], id="multiple-wildcards"),
         pytest.param("foo_bar%", "prefix foo.bar suffix", [(7, 10), (11, 14)], id="underscore-wildcard-splits-words"),
     ],


### PR DESCRIPTION
## Summary                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  Fixes incorrect `highlight_indices` in structured search results for two filter types. In both cases, the raw filter value was passed as a literal term to `generate_highlight_indices`, which never found a match, so 
  the code fell back to highlighting the **entire field value** instead of the matched substring.

### Changes                                                                                                                        
                                                                                                                                                                                                                         
  **`StringFilter` (LIKE) — wildcard patterns highlighted the whole value**                                                                                                                                              
                                                                                                                                                                                                                         
  A LIKE value such as `%aren%` was searched for literally, and `"%aren%"` never occurs in a stored value like `"SingAren SURF"`. SQL wildcards (`%`, `_`) are now replaced with spaces before highlighting, so the      
  remaining words are highlighted individually at their real positions (e.g. `%aren%surf%` → `[(4, 8), (9, 13)]`). If none of the words occur in the value, the full-value fallback still applies.                       
                                                                                                                                                                                                                         
  **`ContainsFilter` (contains / not contains) — regex patterns highlighted the whole value**                                                                                                                            
                                                                                                                                                                                                                         
  Contains filters match in the database with the case-insensitive regex operator (`~*`), but their pattern was regex-escaped and searched literally during highlighting. A new `generate_regex_highlight_indices`       
  applies the pattern as an actual case-insensitive regex, mirroring the database behavior:                                                                                                                              
                                                                                                                                                                                                                         
  - Leading/trailing `.*` / `.+` wrappers are stripped so greedy patterns don't swallow the surrounding text.                                                                                                            
  - Zero-width matches are ignored.                                                                                                                                                                                      
  - An invalid regex falls back to literal word highlighting.                                                                                                                                                            
                                                                                                                                                                                                                         
  Highlight resolution in `_resolve_structured_matching_fields` now dispatches on the leaf condition type: `ContainsFilter` → regex highlighting, `StringFilter` → wildcard-stripped word highlighting, all other filters
  → unchanged literal behavior. Negation filters still return `highlight_indices=None`.                                                                                                                                  
                                                                                                                                                                                                                         
  This directly affects the filter builder UI: the "∋ contains" operator produces a `ContainsFilter`, so any contains-based search previously rendered results with the entire matched field highlighted. LIKE patterns  
  come from the free-text/LLM query path and had the same symptom.  

### Example
**Search query**
<img width="1894" height="932" alt="image" src="https://github.com/user-attachments/assets/496a132b-9317-4561-ab92-d6e5e7fedf05" />

**API response**
```json
{
    "data": [
        {
            "entity_id": "f95b82be-84a3-4255-a6d0-9bbf5a1df987",
            "entity_type": "SUBSCRIPTION",
            "entity_title": "IRB SP ah001a-jnx-okt-rg8-0a",
            "score": 1.0,
            "perfect_match": 0,
            "matching_fields": [
                {
                    "text": "active",
                    "path": "subscription.status",
                    "highlight_indices": [
                        [
                            0,
                            6
                        ]
                    ]
                },
                {
                    "text": "IRB SP ah001a-jnx-okt-rg8-0a",
                    "path": "subscription.description",
                    "highlight_indices": [
                        [
                            4,
                            6
                        ]
                    ]
                }
            ],
            "response_columns": {
                "subscription.subscription_id": "f95b82be-84a3-4255-a6d0-9bbf5a1df987",
                "subscription.description": "IRB SP ah001a-jnx-okt-rg8-0a",
                "subscription.status": "active",
                "subscription.insync": "True",
                "subscription.product.name": "IRB Service Port",
                "subscription.product.tag": "IRBSP",
                "subscription.customer_name": "SURFnet netwerk",
                "subscription.customer_abbreviation": "SURFnetnetwerk",
                "subscription.start_date": "2026-07-17 15:34:03.912277+00:00",
                "subscription.end_date": null,
                "subscription.note": null,
                "subscription.metadata": null
            },
            "order_value": "f95b82be-84a3-4255-a6d0-9bbf5a1df987"
        },
        {
            "entity_id": "e65ad6b0-aada-418d-9960-5adb77cbced1",
            "entity_type": "SUBSCRIPTION",
            "entity_title": "TESTACCOUNT SP TAGGED LEDN005B 10 Gbit/s",
            "score": 1.0,
            "perfect_match": 0,
            "matching_fields": [
                {
                    "text": "active",
                    "path": "subscription.status",
                    "highlight_indices": [
                        [
                            0,
                            6
                        ]
                    ]
                },
                {
                    "text": "TESTACCOUNT SP TAGGED LEDN005B 10 Gbit/s",
                    "path": "subscription.description",
                    "highlight_indices": [
                        [
                            12,
                            14
                        ]
                    ]
                }
            ],
            "response_columns": {
                "subscription.subscription_id": "e65ad6b0-aada-418d-9960-5adb77cbced1",
                "subscription.description": "TESTACCOUNT SP TAGGED LEDN005B 10 Gbit/s",
                "subscription.status": "active",
                "subscription.insync": "True",
                "subscription.product.name": "Service Port 10G",
                "subscription.product.tag": "SP",
                "subscription.customer_name": "Testaccount Netwerkdashboard",
                "subscription.customer_abbreviation": "TESTACCOUNT",
                "subscription.start_date": "2026-07-17 15:34:32.607690+00:00",
                "subscription.end_date": null,
                "subscription.note": null,
                "subscription.metadata": null
            },
            "order_value": "e65ad6b0-aada-418d-9960-5adb77cbced1"
        },
        {
            "entity_id": "89d1c58e-03b7-49b8-a55a-bf550033d57b",
            "entity_type": "SUBSCRIPTION",
            "entity_title": "IRB SP ledn005b-jnx-okt-rg8-2a",
            "score": 1.0,
            "perfect_match": 0,
            "matching_fields": [
                {
                    "text": "active",
                    "path": "subscription.status",
                    "highlight_indices": [
                        [
                            0,
                            6
                        ]
                    ]
                },
                {
                    "text": "IRB SP ledn005b-jnx-okt-rg8-2a",
                    "path": "subscription.description",
                    "highlight_indices": [
                        [
                            4,
                            6
                        ]
                    ]
                }
            ],
            "response_columns": {
                "subscription.subscription_id": "89d1c58e-03b7-49b8-a55a-bf550033d57b",
                "subscription.description": "IRB SP ledn005b-jnx-okt-rg8-2a",
                "subscription.status": "active",
                "subscription.insync": "True",
                "subscription.product.name": "IRB Service Port",
                "subscription.product.tag": "IRBSP",
                "subscription.customer_name": "SURFnet netwerk",
                "subscription.customer_abbreviation": "SURFnetnetwerk",
                "subscription.start_date": "2026-07-17 15:34:24.127944+00:00",
                "subscription.end_date": null,
                "subscription.note": null,
                "subscription.metadata": null
            },
            "order_value": "89d1c58e-03b7-49b8-a55a-bf550033d57b"
        },
        {
            "entity_id": "40f6db8d-4686-43db-8c67-fa4dbc92f4cd",
            "entity_type": "SUBSCRIPTION",
            "entity_title": "TESTACCOUNT SP TAGGED AH001A 10 Gbit/s",
            "score": 1.0,
            "perfect_match": 0,
            "matching_fields": [
                {
                    "text": "active",
                    "path": "subscription.status",
                    "highlight_indices": [
                        [
                            0,
                            6
                        ]
                    ]
                },
                {
                    "text": "TESTACCOUNT SP TAGGED AH001A 10 Gbit/s",
                    "path": "subscription.description",
                    "highlight_indices": [
                        [
                            12,
                            14
                        ]
                    ]
                }
            ],
            "response_columns": {
                "subscription.subscription_id": "40f6db8d-4686-43db-8c67-fa4dbc92f4cd",
                "subscription.description": "TESTACCOUNT SP TAGGED AH001A 10 Gbit/s",
                "subscription.status": "active",
                "subscription.insync": "True",
                "subscription.product.name": "Service Port 10G",
                "subscription.product.tag": "SP",
                "subscription.customer_name": "Testaccount Netwerkdashboard",
                "subscription.customer_abbreviation": "TESTACCOUNT",
                "subscription.start_date": "2026-07-17 15:34:12.342124+00:00",
                "subscription.end_date": null,
                "subscription.note": null,
                "subscription.metadata": null
            },
            "order_value": "40f6db8d-4686-43db-8c67-fa4dbc92f4cd"
        }
    ],
    "page_info": {
        "has_next_page": false,
        "next_page_cursor": null
    },
    "search_metadata": {
        "search_type": "structured",
        "description": "This search performs a filter-based search using structured queries."
    },
    "cursor": {
        "total_items": 4,
        "start_cursor": 0,
        "end_cursor": 3
    }
}
```

### Issue
https://git.ia.surf.nl/netdev/automation/projects/orchestrator/-/work_items/2864