### PR TITLE
fix(generator): default min_length to 0 for list fields without min_items

### DIFF
--- a/orchestrator/core/cli/generator/templates/list_definitions.j2
+++ b/orchestrator/core/cli/generator/templates/list_definitions.j2
@@ -1,5 +1,5 @@
 {% if lists_to_generate %}
 {% for list_type in lists_to_generate %}
-ListOf{{ list_type.name | capitalize }} = Annotated[list[SI], Len(min_length={{ list_type.min_items }}{% if list_type.max_items -%}, max_length={{ list_type.max_items }}{% endif %})]
+ListOf{{ list_type.name | capitalize }} = Annotated[list[SI], Len(min_length={{ list_type.min_items or 0 }}{% if list_type.max_items -%}, max_length={{ list_type.max_items }}{% endif %})]
 {% endfor %}
 {% endif -%}

--- a/test/unit_tests/cli/data/product_config3.yaml
+++ b/test/unit_tests/cli/data/product_config3.yaml
@@ -19,6 +19,9 @@ product_blocks:
       - name: list_val
         type: list
         list_type: str
+      - name: existing_block_list
+        type: list
+        list_type: MyExistingProductBlock
 workflows:
   - name: modify
     flows:

--- a/test/unit_tests/cli/test_cli_generate.py
+++ b/test/unit_tests/cli/test_cli_generate.py
@@ -63,6 +63,18 @@ def test_generate_product_blocks(existing_product_blocks_mock):
     assert result.exit_code == 0
 
 
+@mock.patch("orchestrator.core.cli.generator.generator.product_block.get_existing_product_blocks")
+def test_generate_product_blocks_list_field_without_min_items(existing_product_blocks_mock):
+    existing_product_blocks_mock.return_value = {
+        "MyExistingProductBlock": "products.product_blocks.my_existing_product_block"
+    }
+    runner = CliRunner()
+    result = runner.invoke(app, ["product-blocks", "--config-file", read_file("product_config3.yaml"), "--dryrun"])
+    assert "Len(min_length=0)" in result.stdout
+    assert "Len(min_length=)" not in result.stdout
+    assert result.exit_code == 0
+
+
 def test_generate_workflows():
     runner = CliRunner()
     result = runner.invoke(app, ["workflows", "--config-file", read_file("product_config3.yaml"), "--dryrun"])


### PR DESCRIPTION
## Summary
A product-block `list` field that omits `min_items` caused the generator to emit an invalid `Len(min_length=)`, leaving the generated product-block module unparseable.

## Root cause
`cli/generator/templates/list_definitions.j2` rendered `Len(min_length={{ list_type.min_items }}...)`. When `min_items` was absent the interpolation was empty. `max_items` was already guarded by an `{% if %}`; `min_items` was not.

## Fix
Default `min_items` to `0` in the template, so an omitted `min_items` produces an unbounded-below list: `Len(min_length=0)`.

## Tests
- Added `test_generate_product_blocks_list_field_without_min_items` asserting `Len(min_length=0)` is generated and `Len(min_length=)` is not.
- Extended `product_config3.yaml` with a list field using a non-primitive `list_type` and no `min_items`.
- Verified the test fails without the template fix and passes with it.
- `uv run pytest test/unit_tests/cli/` -> 116 passed; ruff format/check clean.

Closes #1724