### PR TITLE
fix(cli): do not overwrite existing workflows/shared.py

### DIFF
--- a/orchestrator/core/cli/generator/generator/workflow.py
+++ b/orchestrator/core/cli/generator/generator/workflow.py
@@ -176,7 +176,10 @@ def generate_shared_workflow_files(environment: Environment, config: dict, write
     template = environment.get_template("shared_workflows.j2")
     content = template.render()
     path = get_workflows_folder() / Path("shared.py")
-    writer(path, content)
+    if path.exists():
+        logger.warning("not overwriting existing shared workflow file", path=str(path))
+    else:
+        writer(path, content)
 
 
 def generate_workflow(f: Callable | None = None, workflow: str | None = None) -> Callable:

--- a/test/unit_tests/cli/test_cli_generate.py
+++ b/test/unit_tests/cli/test_cli_generate.py
@@ -79,3 +79,17 @@ def test_generate_unit_tests(mkdir_mock):
     result = runner.invoke(app, ["unit-tests", "--config-file", read_file("product_config3.yaml"), "--dryrun"])
     assert "def test_" in result.stdout
     assert result.exit_code == 0
+
+
+def test_generate_workflows_does_not_overwrite_existing_shared_py(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    shared = tmp_path / "workflows" / "shared.py"
+    shared.parent.mkdir(parents=True)
+    shared.write_text("# hand written shared workflow code\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["workflows", "--config-file", read_file("product_config3.yaml"), "--no-dryrun", "--force"]
+    )
+    assert result.exit_code == 0
+    assert shared.read_text() == "# hand written shared workflow code\n"


### PR DESCRIPTION
## Summary
`generate workflows` wrote the shared, product-independent `workflows/shared.py` unconditionally. Since regenerating a product requires `--force`, any hand-written change to that file was silently lost on every subsequent run.

`generate_shared_workflow_files` now skips the file when it already exists and logs a warning, mirroring how `insert_lazy_workflow_instances` already guards `workflows/__init__.py`. Product-specific generated files are unaffected and `--force` still applies to them.

## Related Issues
Fixes #1757

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).

Added `test_generate_workflows_does_not_overwrite_existing_shared_py` to `test/unit_tests/cli/test_cli_generate.py`; it fails without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
