### PR TITLE
Fix search `HAS_` and `NOT_HAS_COMPONENT`

### DIFF
--- a/orchestrator/core/search/filters/base.py
+++ b/orchestrator/core/search/filters/base.py
@@ -260,6 +260,23 @@ class FilterTree(BaseModel):
                 leaves.extend(child.get_all_leaves())
         return leaves
 
+    def get_highlightable_leaves(self) -> list[PathFilter]:
+        """Collect the leaves that produce a matching field in search results.
+
+        Component-existence filters are excluded: `not_has_component` matches entities
+        without a corresponding index row, and `has_component` is satisfied by every
+        result by definition, so neither carries information worth reporting.
+
+        The retriever and the result resolver both index matches by position in this
+        list, so they must use this same method to stay aligned.
+        """
+        existence_ops = {FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT}
+        return [
+            leaf
+            for leaf in self.get_all_leaves()
+            if not (isinstance(leaf.condition, LtreeFilter) and leaf.condition.op in existence_ops)
+        ]
+
     @staticmethod
     def _build_correlates(
         alias: Any, entity_id_col: SQLAColumn, entity_type_value: str | None

--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -49,6 +49,8 @@ _INVERT_OP: dict[FilterOp, FilterOp] = {
     FilterOp.LTE: FilterOp.GT,
     FilterOp.CONTAINS: FilterOp.NOT_CONTAINS,
     FilterOp.NOT_CONTAINS: FilterOp.CONTAINS,
+    FilterOp.HAS_COMPONENT: FilterOp.NOT_HAS_COMPONENT,
+    FilterOp.NOT_HAS_COMPONENT: FilterOp.HAS_COMPONENT,
 }
 
 
@@ -214,11 +216,15 @@ def _translate_regexp(query: RegexpQuery) -> PathFilter:
 
 
 def _translate_exists(query: ExistsQuery) -> PathFilter:
-    """Convert an exists query to a PathFilter with LtreeFilter(ENDS_WITH)."""
+    """Convert an exists query to a PathFilter with LtreeFilter(HAS_COMPONENT).
+
+    HAS_COMPONENT matches the field anywhere in the path (lquery ``*.field.*``,
+    where ``*`` matches zero labels), covering both component and leaf fields.
+    """
     field_name = query.exists["field"]
     return PathFilter(
         path="*",
-        condition=LtreeFilter(op=FilterOp.ENDS_WITH, value=field_name),
+        condition=LtreeFilter(op=FilterOp.HAS_COMPONENT, value=field_name),
         value_kind=UIType.COMPONENT,
     )
 
@@ -228,10 +234,15 @@ def _invert_path_filter(pf: PathFilter) -> PathFilter:
     match pf.condition:
         case EqualityFilter(op=op, value=value):
             return pf.model_copy(update={"condition": EqualityFilter(op=_INVERT_OP[op], value=value)})  # type: ignore[arg-type]
-        case DateValueFilter(op=op) | NumericValueFilter(op=op) | ContainsFilter(op=op):
+        case (
+            DateValueFilter(op=op)
+            | NumericValueFilter(op=op)
+            | ContainsFilter(op=op)
+            | LtreeFilter(op=FilterOp.HAS_COMPONENT | FilterOp.NOT_HAS_COMPONENT as op)
+        ):
             return pf.model_copy(update={"condition": pf.condition.model_copy(update={"op": _INVERT_OP[op]})})
         case _:
-            # For range/string/ltree filters, we cannot simply invert.
+            # For range/string and other ltree filters, we cannot simply invert.
             # Return as-is; the caller wraps in must_not logic at the tree level.
             return pf
 
@@ -256,7 +267,13 @@ def _invert_range_to_or(
 def _negate_node(node: FilterTree | PathFilter) -> FilterTree | PathFilter:
     """Negate a single translated node for must_not semantics."""
     match node:
-        case PathFilter(condition=EqualityFilter() | DateValueFilter() | NumericValueFilter() | ContainsFilter()):
+        case PathFilter(
+            condition=EqualityFilter()
+            | DateValueFilter()
+            | NumericValueFilter()
+            | ContainsFilter()
+            | LtreeFilter(op=FilterOp.HAS_COMPONENT | FilterOp.NOT_HAS_COMPONENT)
+        ):
             return _invert_path_filter(node)
         case PathFilter(condition=DateRangeFilter(value=range_val)):
             return _invert_range_to_or(node, range_val, DateValueFilter)

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -335,7 +335,7 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
     """Resolve matching fields from the retriever's aggregated JSON highlight column.
 
     The retriever emits a ``highlight_matches`` JSON column shaped as an array of arrays:
-    one inner array per positive filter leaf, containing the index rows that matched
+    one inner array per highlightable filter leaf, containing the index rows that matched
     that leaf (``{"value", "path", "idx"}``) — all matching rows for value filters, a
     single representative row for path-predicate (ltree) filters. Flattening gives every
     (value, path) pair that satisfied any filter, deduplicated across leaves.
@@ -347,11 +347,7 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
     if not leaf_arrays:
         return []
 
-    positive_leaves = [
-        leaf
-        for leaf in filters.get_all_leaves()
-        if not (isinstance(leaf.condition, LtreeFilter) and leaf.condition.op == FilterOp.NOT_HAS_COMPONENT)
-    ]
+    positive_leaves = filters.get_highlightable_leaves()
 
     flat_matches = [m for inner in leaf_arrays if inner for m in inner]
     unique_matches = {(str(m["value"]), str(m["path"])): m for m in flat_matches}
@@ -367,7 +363,7 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
         term = str(getattr(leaf.condition, "value", "") or "") if leaf else ""
         match leaf.condition if leaf else None:
             case LtreeFilter():
-                # Path-predicate leaves (has_component, ends_with, ...) match on the row's
+                # Path-predicate leaves (ends_with, matches_lquery, ...) match on the row's
                 # path, not its value text, so there is no substring to highlight.
                 return MatchingField(text=text, path=path, highlight_indices=None)
             case ContainsFilter():

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -335,10 +335,9 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
     """Resolve matching fields from the retriever's aggregated JSON highlight column.
 
     The retriever emits a ``highlight_matches`` JSON column shaped as an array of arrays:
-    one inner array per highlightable filter leaf, containing the index rows that matched
-    that leaf (``{"value", "path", "idx"}``) — all matching rows for value filters, a
-    single representative row for path-predicate (ltree) filters. Flattening gives every
-    (value, path) pair that satisfied any filter, deduplicated across leaves.
+    one inner array per highlightable filter leaf, containing all index rows that matched
+    that leaf (``{"value", "path", "idx"}``). Flattening gives every (value, path) pair
+    that satisfied any filter, deduplicated across leaves.
     """
     from orchestrator.core.search.filters import ContainsFilter, EqualityFilter, LtreeFilter, StringFilter
     from orchestrator.core.search.retrieval.retrievers import Retriever

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -232,8 +232,8 @@ def generate_regex_highlight_indices(text: str, pattern: str) -> list[tuple[int,
     if not text or not pattern:
         return []
 
-    core = re.sub(r"^(?:\.[*+])+", "", pattern) # removes leading greedy wildcard
-    core = re.sub(r"(?:\.[*+])+$", "", core) # removes trailing greedy wildcard
+    core = re.sub(r"^(?:\.[*+])+", "", pattern)  # removes leading greedy wildcard
+    core = re.sub(r"(?:\.[*+])+$", "", core)  # removes trailing greedy wildcard
     if not core:
         return []
     try:
@@ -365,6 +365,10 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
             return MatchingField(text=text, path=path, highlight_indices=None)
         term = str(getattr(leaf.condition, "value", "") or "") if leaf else ""
         match leaf.condition if leaf else None:
+            case LtreeFilter():
+                # Path-predicate leaves (has_component, ends_with, ...) match on the row's
+                # path, not its value text, so there is no substring to highlight.
+                return MatchingField(text=text, path=path, highlight_indices=None)
             case ContainsFilter():
                 indices = generate_regex_highlight_indices(text, term)
             case StringFilter():

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -335,9 +335,10 @@ def _resolve_structured_matching_fields(row: "RowMapping", filters: "FilterTree"
     """Resolve matching fields from the retriever's aggregated JSON highlight column.
 
     The retriever emits a ``highlight_matches`` JSON column shaped as an array of arrays:
-    one inner array per positive filter leaf, each containing all index rows that matched
-    that leaf (``{"value", "path", "idx"}``). Flattening gives every (value, path) pair
-    that satisfied any filter, deduplicated across leaves.
+    one inner array per positive filter leaf, containing the index rows that matched
+    that leaf (``{"value", "path", "idx"}``) — all matching rows for value filters, a
+    single representative row for path-predicate (ltree) filters. Flattening gives every
+    (value, path) pair that satisfied any filter, deduplicated across leaves.
     """
     from orchestrator.core.search.filters import ContainsFilter, EqualityFilter, LtreeFilter, StringFilter
     from orchestrator.core.search.retrieval.retrievers import Retriever

--- a/orchestrator/core/search/retrieval/retrievers/structured.py
+++ b/orchestrator/core/search/retrieval/retrievers/structured.py
@@ -18,7 +18,7 @@ from sqlalchemy_utils import Ltree
 
 from orchestrator.core.db.models import AiSearchIndex
 from orchestrator.core.search.core.types import SearchMetadata
-from orchestrator.core.search.filters import FilterTree, LtreeFilter, PathFilter
+from orchestrator.core.search.filters import FilterTree, PathFilter
 from orchestrator.core.search.query.mixins import OrderDirection, StructuredOrderBy
 
 from ..pagination import PageCursor
@@ -28,28 +28,15 @@ ORDER_VALUE_LABEL = "order_value"
 
 
 def _leaf_matches_json(cand: Subquery, leaf: PathFilter, idx: int) -> ColumnElement:
-    """JSON array of the index rows matched by one filter leaf, as a correlated scalar subquery.
+    """JSON array of all index rows matched by one filter leaf, as a correlated scalar subquery.
 
-    Value-filter leaves aggregate every matching row, so a global filter
-    (e.g. ``status = 'active'``) returns every matching path (``product.status``,
-    ``product_block.test.status``, …) rather than just the shallowest one.
-
-    Path-predicate leaves (ltree) match on the row's path, so every row under a
-    matched subtree would satisfy them; a single row — the shallowest matching
-    path — is enough evidence of the match.
+    Aggregating every matching row means a filter that can match in several places
+    (e.g. a global ``status = 'active'`` or ``ends_with status``) reports every
+    matching path (``subscription.status``, ``subscription.block.status``, …),
+    not just the first.
     """
     alias = aliased(AiSearchIndex)
     row_json = func.json_build_object("value", alias.value, "path", cast(alias.path, String), "idx", literal(idx))
-
-    if isinstance(leaf.condition, LtreeFilter):
-        return (
-            select(func.json_build_array(row_json))
-            .where(alias.entity_id == cand.c.entity_id, leaf.matched_row_predicate(alias))
-            .order_by(func.nlevel(alias.path), alias.path)
-            .limit(1)
-            .correlate(cand)
-            .scalar_subquery()
-        )
     return (
         select(func.json_agg(row_json))
         .where(alias.entity_id == cand.c.entity_id, leaf.matched_row_predicate(alias))

--- a/orchestrator/core/search/retrieval/retrievers/structured.py
+++ b/orchestrator/core/search/retrieval/retrievers/structured.py
@@ -42,27 +42,46 @@ def _positive_leaves(filters: FilterTree | None) -> list[PathFilter]:
     ]
 
 
-def _highlight_matches_column(cand: Subquery, leaves: list[PathFilter]) -> Label:
-    """Single JSON array column — one json_agg subquery per positive filter leaf.
+def _leaf_matches_json(cand: Subquery, leaf: PathFilter, idx: int) -> ColumnElement:
+    """JSON array of the index rows matched by one filter leaf, as a correlated scalar subquery.
 
-    Each element in the outer array is itself a JSON array of all index rows that
-    matched the leaf, so a global filter (e.g. ``status = 'active'``) returns every
-    matching path (``product.status``, ``product_block.test.status``, …) rather than
-    just the shallowest one.
+    Value-filter leaves aggregate every matching row, so a global filter
+    (e.g. ``status = 'active'``) returns every matching path (``product.status``,
+    ``product_block.test.status``, …) rather than just the shallowest one.
+
+    Path-predicate leaves (ltree) match on the row's path, so every row under a
+    matched component would satisfy them; a single row — the shallowest matching
+    path — is enough evidence of the match. For ``has_component`` the field values
+    are irrelevant to the filter, so the component itself is reported: its label as
+    the value, and the matched row's path truncated at that label.
     """
-    json_arrays = []
-    for i, leaf in enumerate(leaves):
-        alias = aliased(AiSearchIndex)
-        json_arrays.append(
-            select(
-                func.json_agg(
-                    func.json_build_object("value", alias.value, "path", cast(alias.path, String), "idx", literal(i))
-                )
-            )
+    alias = aliased(AiSearchIndex)
+    row_json = func.json_build_object("value", alias.value, "path", cast(alias.path, String), "idx", literal(idx))
+
+    if isinstance(leaf.condition, LtreeFilter):
+        if leaf.condition.op == FilterOp.HAS_COMPONENT:
+            label = leaf.condition.value
+            component_path = func.subltree(alias.path, 0, func.index(alias.path, func.text2ltree(label)) + 1)
+            row_json = func.json_build_object("value", label, "path", cast(component_path, String), "idx", literal(idx))
+        return (
+            select(func.json_build_array(row_json))
             .where(alias.entity_id == cand.c.entity_id, leaf.matched_row_predicate(alias))
+            .order_by(func.nlevel(alias.path), alias.path)
+            .limit(1)
             .correlate(cand)
             .scalar_subquery()
         )
+    return (
+        select(func.json_agg(row_json))
+        .where(alias.entity_id == cand.c.entity_id, leaf.matched_row_predicate(alias))
+        .correlate(cand)
+        .scalar_subquery()
+    )
+
+
+def _highlight_matches_column(cand: Subquery, leaves: list[PathFilter]) -> Label:
+    """Single JSON array column — one matches subquery per positive filter leaf."""
+    json_arrays = [_leaf_matches_json(cand, leaf, i) for i, leaf in enumerate(leaves)]
     return func.json_build_array(*json_arrays).label(Retriever.HIGHLIGHT_MATCHES_LABEL)
 
 

--- a/orchestrator/core/search/retrieval/retrievers/structured.py
+++ b/orchestrator/core/search/retrieval/retrievers/structured.py
@@ -17,7 +17,7 @@ from sqlalchemy.sql.elements import ColumnElement, Label
 from sqlalchemy_utils import Ltree
 
 from orchestrator.core.db.models import AiSearchIndex
-from orchestrator.core.search.core.types import FilterOp, SearchMetadata
+from orchestrator.core.search.core.types import SearchMetadata
 from orchestrator.core.search.filters import FilterTree, LtreeFilter, PathFilter
 from orchestrator.core.search.query.mixins import OrderDirection, StructuredOrderBy
 
@@ -25,21 +25,6 @@ from ..pagination import PageCursor
 from .base import Retriever
 
 ORDER_VALUE_LABEL = "order_value"
-
-
-def _positive_leaves(filters: FilterTree | None) -> list[PathFilter]:
-    """Return all filter leaves that have a matchable index row.
-
-    Absence filters (`not_has_component`) match entities without a corresponding
-    index row, so there is nothing to highlight for them.
-    """
-    if filters is None:
-        return []
-    return [
-        leaf
-        for leaf in filters.get_all_leaves()
-        if not (isinstance(leaf.condition, LtreeFilter) and leaf.condition.op == FilterOp.NOT_HAS_COMPONENT)
-    ]
 
 
 def _leaf_matches_json(cand: Subquery, leaf: PathFilter, idx: int) -> ColumnElement:
@@ -50,19 +35,13 @@ def _leaf_matches_json(cand: Subquery, leaf: PathFilter, idx: int) -> ColumnElem
     ``product_block.test.status``, …) rather than just the shallowest one.
 
     Path-predicate leaves (ltree) match on the row's path, so every row under a
-    matched component would satisfy them; a single row — the shallowest matching
-    path — is enough evidence of the match. For ``has_component`` the field values
-    are irrelevant to the filter, so the component itself is reported: its label as
-    the value, and the matched row's path truncated at that label.
+    matched subtree would satisfy them; a single row — the shallowest matching
+    path — is enough evidence of the match.
     """
     alias = aliased(AiSearchIndex)
     row_json = func.json_build_object("value", alias.value, "path", cast(alias.path, String), "idx", literal(idx))
 
     if isinstance(leaf.condition, LtreeFilter):
-        if leaf.condition.op == FilterOp.HAS_COMPONENT:
-            label = leaf.condition.value
-            component_path = func.subltree(alias.path, 0, func.index(alias.path, func.text2ltree(label)) + 1)
-            row_json = func.json_build_object("value", label, "path", cast(component_path, String), "idx", literal(idx))
         return (
             select(func.json_build_array(row_json))
             .where(alias.entity_id == cand.c.entity_id, leaf.matched_row_predicate(alias))
@@ -154,7 +133,7 @@ class StructuredRetriever(Retriever):
 
     def _highlight_columns(self, cand: Subquery) -> list[Label]:
         """Single JSON column aggregating per-leaf matched index rows."""
-        leaves = _positive_leaves(self.filters)
+        leaves = self.filters.get_highlightable_leaves() if self.filters else []
         if not leaves:
             return []
         return [_highlight_matches_column(cand, leaves)]

--- a/test/integration_tests/search/retrieval/retrievers/test_retrievers.py
+++ b/test/integration_tests/search/retrieval/retrievers/test_retrievers.py
@@ -25,6 +25,10 @@ from sqlalchemy.dialects import postgresql
 
 from orchestrator.core.db import db
 from orchestrator.core.db.models import AiSearchIndex
+from orchestrator.core.search.core.types import BooleanOperator, FilterOp, UIType
+from orchestrator.core.search.filters import FilterTree, PathFilter
+from orchestrator.core.search.filters.base import EqualityFilter
+from orchestrator.core.search.filters.ltree_filters import LtreeFilter
 from orchestrator.core.search.query.mixins import OrderDirection, StructuredOrderBy
 from orchestrator.core.search.retrieval.pagination import PageCursor
 from orchestrator.core.search.retrieval.retrievers.fuzzy import FuzzyRetriever
@@ -93,6 +97,36 @@ def test_structured_retriever_pagination_with_order_by(candidate_query, query_id
     query = retriever.apply(candidate_query)
     sql = compile_query_to_sql(query)
     assert_sql_matches_snapshot("StructuredRetriever.test_pagination_structure_with_order_by", sql, request)
+
+
+@pytest.mark.parametrize(
+    "leaf",
+    [
+        pytest.param(
+            PathFilter(
+                path="*",
+                condition=LtreeFilter(op=FilterOp.HAS_COMPONENT, value="port"),
+                value_kind=UIType.COMPONENT,
+            ),
+            id="has-component",
+        ),
+        pytest.param(
+            PathFilter(
+                path="subscription.status",
+                condition=EqualityFilter(op=FilterOp.EQ, value="active"),
+                value_kind=UIType.STRING,
+            ),
+            id="equality",
+        ),
+    ],
+)
+def test_structured_retriever_highlight_matches_executes(candidate_query, leaf):
+    """The highlight-matches subqueries (json_agg and single-representative-row) are valid PostgreSQL."""
+    filters = FilterTree(op=BooleanOperator.AND, children=[leaf])
+    retriever = StructuredRetriever(cursor=None, filters=filters)
+    query = retriever.apply(candidate_query)
+    rows = db.session.execute(query).mappings().all()
+    assert isinstance(rows, list)
 
 
 @pytest.mark.parametrize(

--- a/test/integration_tests/search/retrieval/test_structured_matching_field.py
+++ b/test/integration_tests/search/retrieval/test_structured_matching_field.py
@@ -137,6 +137,47 @@ async def test_ends_with_filter_returns_full_path_per_entity(indexed_subscriptio
     assert matching_by_id[str(sub_b)][0].text == "provisioning"
 
 
+@pytest.fixture
+def indexed_subscription_with_ports() -> UUID:
+    """One subscription with a root-level port component and a deeper port nested under a sap block."""
+    sub = uuid4()
+    db.session.add_all(
+        [
+            _index_row(sub, "subscription.description", "port subscription", title="port sub"),
+            _index_row(sub, "subscription.port.ims_circuit_id", "440572", title="port sub"),
+            _index_row(sub, "subscription.port.admin_state", "enabled", title="port sub"),
+            _index_row(sub, "subscription.sap.port.node_name", "asd001a-jnx", title="port sub"),
+        ]
+    )
+    db.session.commit()
+    return sub
+
+
+async def test_has_component_reports_component_not_field_value(indexed_subscription_with_ports):
+    """has_component reports the component itself, not an arbitrary field under it."""
+    sub = indexed_subscription_with_ports
+    filters = FilterTree(
+        op=BooleanOperator.AND,
+        children=[
+            PathFilter(
+                path="*",
+                condition=LtreeFilter(op=FilterOp.HAS_COMPONENT, value="port"),
+                value_kind=UIType.COMPONENT,
+            )
+        ],
+    )
+
+    response = await engine.execute_search(_select_query(filters), db.session)
+
+    assert [r.entity_id for r in response.results] == [str(sub)]
+    fields = response.results[0].matching_fields
+    assert len(fields) == 1
+    assert fields[0].text == "port"
+    # Shallowest instance wins: subscription.port, not subscription.sap.port.
+    assert fields[0].path == "subscription.port"
+    assert fields[0].highlight_indices is None
+
+
 async def test_multi_leaf_filter_returns_all_matching_fields(indexed_subscriptions):
     """With multiple filter leaves, a MatchingField is returned for each positive leaf."""
     sub_a, _ = indexed_subscriptions

--- a/test/integration_tests/search/retrieval/test_structured_matching_field.py
+++ b/test/integration_tests/search/retrieval/test_structured_matching_field.py
@@ -153,6 +153,44 @@ def indexed_subscription_with_ports() -> UUID:
     return sub
 
 
+@pytest.fixture
+def indexed_subscription_with_two_statuses() -> UUID:
+    """One subscription with a status field at the root and another inside a block."""
+    sub = uuid4()
+    db.session.add_all(
+        [
+            _index_row(sub, "subscription.status", "active", title="two status sub"),
+            _index_row(sub, "subscription.block.status", "provisioning", title="two status sub"),
+        ]
+    )
+    db.session.commit()
+    return sub
+
+
+async def test_ends_with_returns_all_matching_rows(indexed_subscription_with_two_statuses):
+    """An ends_with filter reports every matching row, not just the shallowest one."""
+    sub = indexed_subscription_with_two_statuses
+    filters = FilterTree(
+        op=BooleanOperator.AND,
+        children=[
+            PathFilter(
+                path="*",
+                condition=LtreeFilter(op=FilterOp.ENDS_WITH, value="status"),
+                value_kind=UIType.COMPONENT,
+            )
+        ],
+    )
+
+    response = await engine.execute_search(_select_query(filters), db.session)
+
+    assert [r.entity_id for r in response.results] == [str(sub)]
+    fields = response.results[0].matching_fields
+    assert {(f.path, f.text) for f in fields} == {
+        ("subscription.status", "active"),
+        ("subscription.block.status", "provisioning"),
+    }
+
+
 async def test_has_component_returns_result_without_matching_fields(indexed_subscription_with_ports):
     """has_component is satisfied by every result, so no matching field is reported for it."""
     sub = indexed_subscription_with_ports

--- a/test/integration_tests/search/retrieval/test_structured_matching_field.py
+++ b/test/integration_tests/search/retrieval/test_structured_matching_field.py
@@ -153,8 +153,8 @@ def indexed_subscription_with_ports() -> UUID:
     return sub
 
 
-async def test_has_component_reports_component_not_field_value(indexed_subscription_with_ports):
-    """has_component reports the component itself, not an arbitrary field under it."""
+async def test_has_component_returns_result_without_matching_fields(indexed_subscription_with_ports):
+    """has_component is satisfied by every result, so no matching field is reported for it."""
     sub = indexed_subscription_with_ports
     filters = FilterTree(
         op=BooleanOperator.AND,
@@ -170,12 +170,7 @@ async def test_has_component_reports_component_not_field_value(indexed_subscript
     response = await engine.execute_search(_select_query(filters), db.session)
 
     assert [r.entity_id for r in response.results] == [str(sub)]
-    fields = response.results[0].matching_fields
-    assert len(fields) == 1
-    assert fields[0].text == "port"
-    # Shallowest instance wins: subscription.port, not subscription.sap.port.
-    assert fields[0].path == "subscription.port"
-    assert fields[0].highlight_indices is None
+    assert response.results[0].matching_fields == []
 
 
 async def test_multi_leaf_filter_returns_all_matching_fields(indexed_subscriptions):

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -14,7 +14,7 @@
 """Tests for orchestrator.core.search.filters.elastic_dsl: Elasticsearch DSL to FilterTree conversion, including term, range, wildcard, exists, and bool queries."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
@@ -79,10 +79,18 @@ def test_term_preserves_path() -> None:
 @pytest.mark.parametrize(
     "es_op, value, expected_filter_type, expected_op, expected_value_kind, expected_value",
     [
-        pytest.param("gt", "2025-01-01", DateValueFilter, FilterOp.GT, UIType.DATETIME, datetime(2025, 1, 1), id="date-gt"),
-        pytest.param("gte", "2025-06-15", DateValueFilter, FilterOp.GTE, UIType.DATETIME, datetime(2025, 6, 15), id="date-gte"),
-        pytest.param("lt", "2025-12-31", DateValueFilter, FilterOp.LT, UIType.DATETIME, datetime(2025, 12, 31), id="date-lt"),
-        pytest.param("lte", "2025-03-01", DateValueFilter, FilterOp.LTE, UIType.DATETIME, datetime(2025, 3, 1), id="date-lte"),
+        pytest.param(
+            "gt", "2025-01-01", DateValueFilter, FilterOp.GT, UIType.DATETIME, datetime(2025, 1, 1), id="date-gt"
+        ),
+        pytest.param(
+            "gte", "2025-06-15", DateValueFilter, FilterOp.GTE, UIType.DATETIME, datetime(2025, 6, 15), id="date-gte"
+        ),
+        pytest.param(
+            "lt", "2025-12-31", DateValueFilter, FilterOp.LT, UIType.DATETIME, datetime(2025, 12, 31), id="date-lt"
+        ),
+        pytest.param(
+            "lte", "2025-03-01", DateValueFilter, FilterOp.LTE, UIType.DATETIME, datetime(2025, 3, 1), id="date-lte"
+        ),
         pytest.param("gt", 100, NumericValueFilter, FilterOp.GT, UIType.NUMBER, 100, id="num-gt"),
         pytest.param("gte", 0, NumericValueFilter, FilterOp.GTE, UIType.NUMBER, 0, id="num-gte"),
         pytest.param("lt", 9999, NumericValueFilter, FilterOp.LT, UIType.NUMBER, 9999, id="num-lt"),
@@ -107,7 +115,15 @@ def test_range_single_bound(
 @pytest.mark.parametrize(
     "start, end, expected_filter_type, expected_value_kind, expected_start, expected_end",
     [
-        pytest.param("2025-01-01", "2025-12-31", DateRangeFilter, UIType.DATETIME, datetime(2025, 1, 1), datetime(2025, 12, 31), id="date-between"),
+        pytest.param(
+            "2025-01-01",
+            "2025-12-31",
+            DateRangeFilter,
+            UIType.DATETIME,
+            datetime(2025, 1, 1),
+            datetime(2025, 12, 31),
+            id="date-between",
+        ),
         pytest.param(100, 10000, NumericRangeFilter, UIType.NUMBER, 100, 10000, id="numeric-between"),
     ],
 )
@@ -158,9 +174,63 @@ def test_exists_to_ltree_filter() -> None:
     leaf = _parse_and_get_leaf({"exists": {"field": "node"}})
     assert leaf.path == "*"
     assert isinstance(leaf.condition, LtreeFilter)
-    assert leaf.condition.op == FilterOp.ENDS_WITH
+    assert leaf.condition.op == FilterOp.HAS_COMPONENT
     assert leaf.condition.value == "node"
     assert leaf.value_kind == UIType.COMPONENT
+
+
+def test_must_not_exists_inverts_to_not_has_component() -> None:
+    leaf = _parse_and_get_leaf({"bool": {"must_not": [{"exists": {"field": "port"}}]}})
+    assert leaf.path == "*"
+    assert isinstance(leaf.condition, LtreeFilter)
+    assert leaf.condition.op == FilterOp.NOT_HAS_COMPONENT
+    assert leaf.condition.value == "port"
+    assert leaf.value_kind == UIType.COMPONENT
+
+
+@pytest.mark.parametrize(
+    "op, inverted_op",
+    [
+        pytest.param(FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT, id="has-to-not-has"),
+        pytest.param(FilterOp.NOT_HAS_COMPONENT, FilterOp.HAS_COMPONENT, id="not-has-to-has"),
+    ],
+)
+def test_invert_path_filter_component_ops(
+    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT], inverted_op: FilterOp
+) -> None:
+    pf = PathFilter(
+        path="*",
+        condition=LtreeFilter(op=op, value="port"),
+        value_kind=UIType.COMPONENT,
+    )
+    result = _invert_path_filter(pf)
+    assert isinstance(result.condition, LtreeFilter)
+    assert result.condition.op == inverted_op
+    assert result.condition.value == "port"
+
+
+def test_beta_subscriptions_not_has_component_payload() -> None:
+    """The full ES DSL payload sent by the beta-subscriptions page for 'doesn't have component port'."""
+    es = ElasticQueryAdapter.validate_python(
+        {
+            "bool": {
+                "must": [
+                    {"bool": {"should": [{"term": {"subscription.status": "active"}}]}},
+                    {"bool": {"must": [{"bool": {"must_not": {"exists": {"field": "port"}}}}]}},
+                ]
+            }
+        }
+    )
+    tree = elastic_to_filter_tree(es)
+    assert isinstance(tree, FilterTree)
+    assert tree.op == BooleanOperator.AND
+    status_leaf, component_leaf = tree.children
+    assert isinstance(status_leaf, PathFilter)
+    assert status_leaf.path == "subscription.status"
+    assert isinstance(component_leaf, PathFilter)
+    assert isinstance(component_leaf.condition, LtreeFilter)
+    assert component_leaf.condition.op == FilterOp.NOT_HAS_COMPONENT
+    assert component_leaf.condition.value == "port"
 
 
 # ---------------------------------------------------------------------------
@@ -340,9 +410,7 @@ def test_range_no_recognised_bounds_raises() -> None:
 )
 def test_bool_clause_accepts_single_query_object(clause_key: str) -> None:
     """A bare query dict (not wrapped in a list) is accepted, matching ES behaviour."""
-    es = ElasticQueryAdapter.validate_python(
-        {"bool": {clause_key: {"term": {"subscription.status": "active"}}}}
-    )
+    es = ElasticQueryAdapter.validate_python({"bool": {clause_key: {"term": {"subscription.status": "active"}}}})
     tree = elastic_to_filter_tree(es)
     assert len(tree.children) == 1
 

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -171,46 +171,42 @@ def test_wildcard_pattern_conversion(es_pattern: str, expected_sql: str) -> None
 
 
 def test_exists_to_ltree_filter() -> None:
-    leaf = _parse_and_get_leaf({"exists": {"field": "node"}})
-    assert leaf.path == "*"
-    assert isinstance(leaf.condition, LtreeFilter)
-    assert leaf.condition.op == FilterOp.HAS_COMPONENT
-    assert leaf.condition.value == "node"
-    assert leaf.value_kind == UIType.COMPONENT
+    es = ElasticQueryAdapter.validate_python({"exists": {"field": "node"}})
+    assert elastic_to_filter_tree(es).model_dump(mode="json") == {
+        "op": "AND",
+        "children": [{"path": "*", "condition": {"op": "has_component", "value": "node"}, "value_kind": "component"}],
+    }
 
 
 def test_must_not_exists_inverts_to_not_has_component() -> None:
-    leaf = _parse_and_get_leaf({"bool": {"must_not": [{"exists": {"field": "port"}}]}})
-    assert leaf.path == "*"
-    assert isinstance(leaf.condition, LtreeFilter)
-    assert leaf.condition.op == FilterOp.NOT_HAS_COMPONENT
-    assert leaf.condition.value == "port"
-    assert leaf.value_kind == UIType.COMPONENT
+    es = ElasticQueryAdapter.validate_python({"bool": {"must_not": [{"exists": {"field": "port"}}]}})
+    assert elastic_to_filter_tree(es).model_dump(mode="json") == {
+        "op": "AND",
+        "children": [
+            {"path": "*", "condition": {"op": "not_has_component", "value": "port"}, "value_kind": "component"}
+        ],
+    }
 
 
 @pytest.mark.parametrize(
     "op, inverted_op",
     [
-        pytest.param(FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT, id="has-to-not-has"),
-        pytest.param(FilterOp.NOT_HAS_COMPONENT, FilterOp.HAS_COMPONENT, id="not-has-to-has"),
+        pytest.param(FilterOp.HAS_COMPONENT, "not_has_component", id="has-to-not-has"),
+        pytest.param(FilterOp.NOT_HAS_COMPONENT, "has_component", id="not-has-to-has"),
     ],
 )
 def test_invert_path_filter_component_ops(
-    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT], inverted_op: FilterOp
+    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT], inverted_op: str
 ) -> None:
-    pf = PathFilter(
-        path="*",
-        condition=LtreeFilter(op=op, value="port"),
-        value_kind=UIType.COMPONENT,
-    )
-    result = _invert_path_filter(pf)
-    assert isinstance(result.condition, LtreeFilter)
-    assert result.condition.op == inverted_op
-    assert result.condition.value == "port"
+    pf = PathFilter(path="*", condition=LtreeFilter(op=op, value="port"), value_kind=UIType.COMPONENT)
+    assert _invert_path_filter(pf).model_dump(mode="json") == {
+        "path": "*",
+        "condition": {"op": inverted_op, "value": "port"},
+        "value_kind": "component",
+    }
 
 
-def test_beta_subscriptions_not_has_component_payload() -> None:
-    """The full ES DSL payload sent by the beta-subscriptions page for 'doesn't have component port'."""
+def test_subscriptions_not_has_component_payload() -> None:
     es = ElasticQueryAdapter.validate_python(
         {
             "bool": {
@@ -221,16 +217,17 @@ def test_beta_subscriptions_not_has_component_payload() -> None:
             }
         }
     )
-    tree = elastic_to_filter_tree(es)
-    assert isinstance(tree, FilterTree)
-    assert tree.op == BooleanOperator.AND
-    status_leaf, component_leaf = tree.children
-    assert isinstance(status_leaf, PathFilter)
-    assert status_leaf.path == "subscription.status"
-    assert isinstance(component_leaf, PathFilter)
-    assert isinstance(component_leaf.condition, LtreeFilter)
-    assert component_leaf.condition.op == FilterOp.NOT_HAS_COMPONENT
-    assert component_leaf.condition.value == "port"
+    assert elastic_to_filter_tree(es).model_dump(mode="json") == {
+        "op": "AND",
+        "children": [
+            {
+                "path": "subscription.status",
+                "condition": {"op": "eq", "value": "active"},
+                "value_kind": "string",
+            },
+            {"path": "*", "condition": {"op": "not_has_component", "value": "port"}, "value_kind": "component"},
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -13,6 +13,7 @@
 
 """Tests for orchestrator.core.search.query.results -- text truncation with highlights, aggregation response formatting, and filter field extraction."""
 
+from typing import Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -315,6 +316,42 @@ def test_resolve_ltree_has_component():
     result = _resolve_structured_matching_fields(row, tree)
     assert len(result) == 1
     assert result[0].text == "node"
+    assert result[0].highlight_indices is None
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(FilterOp.HAS_COMPONENT, id="has-component"),
+        pytest.param(FilterOp.ENDS_WITH, id="ends-with"),
+        pytest.param(FilterOp.MATCHES_LQUERY, id="matches-lquery"),
+    ],
+)
+def test_resolve_ltree_leaf_returns_null_highlight_indices(
+    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.ENDS_WITH, FilterOp.MATCHES_LQUERY],
+):
+    """Path-predicate leaves match on the row's path, not its value — nothing to highlight.
+
+    The stored value is returned as context (e.g. "SN8 IRB Service Port"), but no
+    highlight spans: highlighting the filter term inside the value would be coincidental,
+    and a full-span fallback would falsely claim the value matched.
+    """
+    tree = FilterTree(
+        op=BooleanOperator.AND,
+        children=[
+            PathFilter(
+                path="*",
+                condition=LtreeFilter(op=op, value="port"),
+                value_kind=UIType.COMPONENT,
+            )
+        ],
+    )
+    row = _row_with_highlights([("SN8 IRB Service Port", "subscription.port.name")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert len(result) == 1
+    assert result[0].text == "SN8 IRB Service Port"
+    assert result[0].path == "subscription.port.name"
+    assert result[0].highlight_indices is None
 
 
 def test_resolve_ltree_not_has_component_returns_empty():
@@ -442,6 +479,7 @@ def test_resolve_ltree_matches_lquery():
     result = _resolve_structured_matching_fields(row, tree)
     assert len(result) == 1
     assert isinstance(result[0], MatchingField)
+    assert result[0].highlight_indices is None
 
 
 @pytest.mark.parametrize(
@@ -599,8 +637,8 @@ def test_format_structured_response_uses_highlight_columns_for_full_path():
     assert fields[0].highlight_indices == [(0, len("active"))]
 
 
-def test_format_structured_response_highlights_full_text_when_value_not_in_text():
-    """When the filter term does not occur in the stored value, the whole value is highlighted."""
+def test_format_structured_response_ltree_leaf_has_no_highlight_indices():
+    """Path-predicate leaves report the stored value as context without highlight spans."""
     tree = FilterTree(
         op=BooleanOperator.AND,
         children=[
@@ -621,7 +659,7 @@ def test_format_structured_response_highlights_full_text_when_value_not_in_text(
     assert len(fields) == 1
     assert fields[0].path == "subscription.status"
     assert fields[0].text == "active"
-    assert fields[0].highlight_indices == [(0, len("active"))]
+    assert fields[0].highlight_indices is None
 
 
 def test_format_structured_response_without_highlight_columns_returns_empty():

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -300,35 +300,15 @@ def test_resolve_missing_highlight_columns_returns_empty():
     assert result == []
 
 
-def test_resolve_ltree_has_component():
-    """LtreeFilter with HAS_COMPONENT returns one MatchingField from DB columns."""
-    tree = FilterTree(
-        op=BooleanOperator.AND,
-        children=[
-            PathFilter(
-                path="subscription",
-                condition=LtreeFilter(op=FilterOp.HAS_COMPONENT, value="node"),
-                value_kind=UIType.COMPONENT,
-            )
-        ],
-    )
-    row = _row_with_highlights([("node", "subscription.node")])
-    result = _resolve_structured_matching_fields(row, tree)
-    assert len(result) == 1
-    assert result[0].text == "node"
-    assert result[0].highlight_indices is None
-
-
 @pytest.mark.parametrize(
     "op",
     [
-        pytest.param(FilterOp.HAS_COMPONENT, id="has-component"),
         pytest.param(FilterOp.ENDS_WITH, id="ends-with"),
         pytest.param(FilterOp.MATCHES_LQUERY, id="matches-lquery"),
     ],
 )
 def test_resolve_ltree_leaf_returns_null_highlight_indices(
-    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.ENDS_WITH, FilterOp.MATCHES_LQUERY],
+    op: Literal[FilterOp.ENDS_WITH, FilterOp.MATCHES_LQUERY],
 ):
     """Path-predicate leaves match on the row's path, not its value — nothing to highlight.
 
@@ -354,14 +334,21 @@ def test_resolve_ltree_leaf_returns_null_highlight_indices(
     assert result[0].highlight_indices is None
 
 
-def test_resolve_ltree_not_has_component_returns_empty():
-    """NOT_HAS_COMPONENT is excluded from positive leaves — returns empty."""
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(FilterOp.HAS_COMPONENT, id="has-component"),
+        pytest.param(FilterOp.NOT_HAS_COMPONENT, id="not-has-component"),
+    ],
+)
+def test_resolve_component_existence_returns_empty(op: Literal[FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT]):
+    """Component-existence leaves are excluded from highlightable leaves — returns empty."""
     tree = FilterTree(
         op=BooleanOperator.AND,
         children=[
             PathFilter(
                 path="subscription",
-                condition=LtreeFilter(op=FilterOp.NOT_HAS_COMPONENT, value="node"),
+                condition=LtreeFilter(op=op, value="node"),
                 value_kind=UIType.COMPONENT,
             )
         ],
@@ -440,8 +427,17 @@ def test_resolve_or_filter_both_branches_returned():
     assert paths == {"subscription.status", "subscription.product.name"}
 
 
-def test_resolve_not_has_component_excluded_from_indexing():
-    """NOT_HAS_COMPONENT leaf is excluded; only the EQ leaf is indexed at position 0."""
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(FilterOp.HAS_COMPONENT, id="has-component"),
+        pytest.param(FilterOp.NOT_HAS_COMPONENT, id="not-has-component"),
+    ],
+)
+def test_resolve_component_existence_excluded_from_indexing(
+    op: Literal[FilterOp.HAS_COMPONENT, FilterOp.NOT_HAS_COMPONENT],
+):
+    """Component-existence leaves are excluded; only the EQ leaf is indexed at position 0."""
     tree = FilterTree(
         op=BooleanOperator.AND,
         children=[
@@ -452,7 +448,7 @@ def test_resolve_not_has_component_excluded_from_indexing():
             ),
             PathFilter(
                 path="subscription",
-                condition=LtreeFilter(op=FilterOp.NOT_HAS_COMPONENT, value="node"),
+                condition=LtreeFilter(op=op, value="node"),
                 value_kind=UIType.COMPONENT,
             ),
         ],

--- a/test/unit_tests/search/retrieval/test_structured_highlights.py
+++ b/test/unit_tests/search/retrieval/test_structured_highlights.py
@@ -13,9 +13,9 @@
 
 """Tests for the StructuredRetriever highlight-matches column SQL.
 
-Value-filter leaves aggregate every matching index row (json_agg), while
-path-predicate leaves (has_component, ends_with, ...) return a single
-representative row: the shallowest matching path.
+Every highlightable leaf aggregates all of its matching index rows (json_agg);
+component-existence leaves (has_component, not_has_component) produce no
+highlight column at all.
 """
 
 import pytest
@@ -51,31 +51,26 @@ def _value_leaf() -> PathFilter:
     )
 
 
-def test_ends_with_leaf_selects_single_representative_row() -> None:
-    """ends_with matches leaf fields, so the row's own value and full path are reported."""
-    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.ENDS_WITH, value="status")])
-    sql = _compile(filters)
-    assert "nlevel" in sql
-    assert "LIMIT" in sql
-    assert "subltree" not in sql
-    assert "json_agg" not in sql
-
-
-def test_value_leaf_aggregates_all_matching_rows() -> None:
-    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf()])
+@pytest.mark.parametrize(
+    "leaf_factory",
+    [
+        pytest.param(_value_leaf, id="value-leaf"),
+        pytest.param(lambda: _component_leaf(FilterOp.ENDS_WITH, value="status"), id="ends-with-leaf"),
+    ],
+)
+def test_highlightable_leaf_aggregates_all_matching_rows(leaf_factory) -> None:
+    filters = FilterTree(op=BooleanOperator.AND, children=[leaf_factory()])
     sql = _compile(filters)
     assert "json_agg" in sql
-    assert "nlevel" not in sql
     assert "LIMIT" not in sql
 
 
-def test_mixed_value_and_ends_with_leaves_use_both_strategies() -> None:
+def test_mixed_value_and_ends_with_leaves_each_aggregate() -> None:
     filters = FilterTree(
         op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.ENDS_WITH, value="status")]
     )
     sql = _compile(filters)
-    assert "json_agg" in sql
-    assert "nlevel" in sql
+    assert sql.count("json_agg(") == 2
 
 
 @pytest.mark.parametrize(
@@ -95,9 +90,7 @@ def test_component_existence_leaf_produces_no_highlight_column(op: FilterOp) -> 
 def test_mixed_value_and_has_component_highlights_value_leaf_only() -> None:
     filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.HAS_COMPONENT)])
     sql = _compile(filters)
-    assert "json_agg" in sql
-    assert "nlevel" not in sql
-    assert "LIMIT" not in sql
+    assert sql.count("json_agg(") == 1
 
 
 def test_no_filters_produces_no_highlight_column() -> None:

--- a/test/unit_tests/search/retrieval/test_structured_highlights.py
+++ b/test/unit_tests/search/retrieval/test_structured_highlights.py
@@ -18,6 +18,7 @@ path-predicate leaves (has_component, ends_with, ...) return a single
 representative row: the shallowest matching path.
 """
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 
@@ -50,16 +51,6 @@ def _value_leaf() -> PathFilter:
     )
 
 
-def test_has_component_leaf_synthesizes_component_field() -> None:
-    """has_component reports the component itself: path truncated at the label, label as value."""
-    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.HAS_COMPONENT)])
-    sql = _compile(filters)
-    assert "subltree" in sql
-    assert "nlevel" in sql
-    assert "LIMIT" in sql
-    assert "json_agg" not in sql
-
-
 def test_ends_with_leaf_selects_single_representative_row() -> None:
     """ends_with matches leaf fields, so the row's own value and full path are reported."""
     filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.ENDS_WITH, value="status")])
@@ -78,17 +69,35 @@ def test_value_leaf_aggregates_all_matching_rows() -> None:
     assert "LIMIT" not in sql
 
 
-def test_mixed_leaves_use_both_strategies() -> None:
-    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.HAS_COMPONENT)])
+def test_mixed_value_and_ends_with_leaves_use_both_strategies() -> None:
+    filters = FilterTree(
+        op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.ENDS_WITH, value="status")]
+    )
     sql = _compile(filters)
     assert "json_agg" in sql
     assert "nlevel" in sql
 
 
-def test_not_has_component_leaf_produces_no_highlight_column() -> None:
-    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.NOT_HAS_COMPONENT)])
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(FilterOp.HAS_COMPONENT, id="has-component"),
+        pytest.param(FilterOp.NOT_HAS_COMPONENT, id="not-has-component"),
+    ],
+)
+def test_component_existence_leaf_produces_no_highlight_column(op: FilterOp) -> None:
+    """Existence filters are satisfied by every result (or by absence) — nothing to highlight."""
+    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(op)])
     sql = _compile(filters)
     assert Retriever.HIGHLIGHT_MATCHES_LABEL not in sql
+
+
+def test_mixed_value_and_has_component_highlights_value_leaf_only() -> None:
+    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.HAS_COMPONENT)])
+    sql = _compile(filters)
+    assert "json_agg" in sql
+    assert "nlevel" not in sql
+    assert "LIMIT" not in sql
 
 
 def test_no_filters_produces_no_highlight_column() -> None:

--- a/test/unit_tests/search/retrieval/test_structured_highlights.py
+++ b/test/unit_tests/search/retrieval/test_structured_highlights.py
@@ -1,0 +1,96 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the StructuredRetriever highlight-matches column SQL.
+
+Value-filter leaves aggregate every matching index row (json_agg), while
+path-predicate leaves (has_component, ends_with, ...) return a single
+representative row: the shallowest matching path.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+
+from orchestrator.core.db.models import AiSearchIndex
+from orchestrator.core.search.core.types import BooleanOperator, FilterOp, UIType
+from orchestrator.core.search.filters import FilterTree, PathFilter
+from orchestrator.core.search.filters.base import EqualityFilter
+from orchestrator.core.search.filters.ltree_filters import LtreeFilter
+from orchestrator.core.search.retrieval.retrievers.base import Retriever
+from orchestrator.core.search.retrieval.retrievers.structured import StructuredRetriever
+
+
+def _compile(filters: FilterTree | None) -> str:
+    candidate = select(
+        AiSearchIndex.entity_id.label("entity_id"), AiSearchIndex.entity_title.label("entity_title")
+    ).distinct()
+    query = StructuredRetriever(cursor=None, filters=filters).apply(candidate)
+    return str(query.compile(dialect=postgresql.dialect()))
+
+
+def _component_leaf(op: FilterOp, value: str = "port") -> PathFilter:
+    return PathFilter(path="*", condition=LtreeFilter(op=op, value=value), value_kind=UIType.COMPONENT)  # type: ignore[arg-type]
+
+
+def _value_leaf() -> PathFilter:
+    return PathFilter(
+        path="subscription.status",
+        condition=EqualityFilter(op=FilterOp.EQ, value="active"),
+        value_kind=UIType.STRING,
+    )
+
+
+def test_has_component_leaf_synthesizes_component_field() -> None:
+    """has_component reports the component itself: path truncated at the label, label as value."""
+    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.HAS_COMPONENT)])
+    sql = _compile(filters)
+    assert "subltree" in sql
+    assert "nlevel" in sql
+    assert "LIMIT" in sql
+    assert "json_agg" not in sql
+
+
+def test_ends_with_leaf_selects_single_representative_row() -> None:
+    """ends_with matches leaf fields, so the row's own value and full path are reported."""
+    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.ENDS_WITH, value="status")])
+    sql = _compile(filters)
+    assert "nlevel" in sql
+    assert "LIMIT" in sql
+    assert "subltree" not in sql
+    assert "json_agg" not in sql
+
+
+def test_value_leaf_aggregates_all_matching_rows() -> None:
+    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf()])
+    sql = _compile(filters)
+    assert "json_agg" in sql
+    assert "nlevel" not in sql
+    assert "LIMIT" not in sql
+
+
+def test_mixed_leaves_use_both_strategies() -> None:
+    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.HAS_COMPONENT)])
+    sql = _compile(filters)
+    assert "json_agg" in sql
+    assert "nlevel" in sql
+
+
+def test_not_has_component_leaf_produces_no_highlight_column() -> None:
+    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(FilterOp.NOT_HAS_COMPONENT)])
+    sql = _compile(filters)
+    assert Retriever.HIGHLIGHT_MATCHES_LABEL not in sql
+
+
+def test_no_filters_produces_no_highlight_column() -> None:
+    sql = _compile(None)
+    assert Retriever.HIGHLIGHT_MATCHES_LABEL not in sql

--- a/test/unit_tests/search/retrieval/test_structured_highlights.py
+++ b/test/unit_tests/search/retrieval/test_structured_highlights.py
@@ -11,11 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the StructuredRetriever highlight-matches column SQL.
+"""Tests that component-existence filters produce no highlight-matches column.
 
-Every highlightable leaf aggregates all of its matching index rows (json_agg);
-component-existence leaves (has_component, not_has_component) produce no
-highlight column at all.
+`has_component` / `not_has_component` are satisfied by every result (or by absence),
+so there is nothing to report; the StructuredRetriever must omit the column entirely.
+What the column contains for other filter leaves is covered end-to-end by the
+integration tests in test_structured_matching_field.py.
 """
 
 import pytest
@@ -25,7 +26,6 @@ from sqlalchemy.dialects import postgresql
 from orchestrator.core.db.models import AiSearchIndex
 from orchestrator.core.search.core.types import BooleanOperator, FilterOp, UIType
 from orchestrator.core.search.filters import FilterTree, PathFilter
-from orchestrator.core.search.filters.base import EqualityFilter
 from orchestrator.core.search.filters.ltree_filters import LtreeFilter
 from orchestrator.core.search.retrieval.retrievers.base import Retriever
 from orchestrator.core.search.retrieval.retrievers.structured import StructuredRetriever
@@ -39,40 +39,6 @@ def _compile(filters: FilterTree | None) -> str:
     return str(query.compile(dialect=postgresql.dialect()))
 
 
-def _component_leaf(op: FilterOp, value: str = "port") -> PathFilter:
-    return PathFilter(path="*", condition=LtreeFilter(op=op, value=value), value_kind=UIType.COMPONENT)  # type: ignore[arg-type]
-
-
-def _value_leaf() -> PathFilter:
-    return PathFilter(
-        path="subscription.status",
-        condition=EqualityFilter(op=FilterOp.EQ, value="active"),
-        value_kind=UIType.STRING,
-    )
-
-
-@pytest.mark.parametrize(
-    "leaf_factory",
-    [
-        pytest.param(_value_leaf, id="value-leaf"),
-        pytest.param(lambda: _component_leaf(FilterOp.ENDS_WITH, value="status"), id="ends-with-leaf"),
-    ],
-)
-def test_highlightable_leaf_aggregates_all_matching_rows(leaf_factory) -> None:
-    filters = FilterTree(op=BooleanOperator.AND, children=[leaf_factory()])
-    sql = _compile(filters)
-    assert "json_agg" in sql
-    assert "LIMIT" not in sql
-
-
-def test_mixed_value_and_ends_with_leaves_each_aggregate() -> None:
-    filters = FilterTree(
-        op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.ENDS_WITH, value="status")]
-    )
-    sql = _compile(filters)
-    assert sql.count("json_agg(") == 2
-
-
 @pytest.mark.parametrize(
     "op",
     [
@@ -81,16 +47,14 @@ def test_mixed_value_and_ends_with_leaves_each_aggregate() -> None:
     ],
 )
 def test_component_existence_leaf_produces_no_highlight_column(op: FilterOp) -> None:
-    """Existence filters are satisfied by every result (or by absence) — nothing to highlight."""
-    filters = FilterTree(op=BooleanOperator.AND, children=[_component_leaf(op)])
+    filters = FilterTree(
+        op=BooleanOperator.AND,
+        children=[
+            PathFilter(path="*", condition=LtreeFilter(op=op, value="port"), value_kind=UIType.COMPONENT)  # type: ignore[arg-type]
+        ],
+    )
     sql = _compile(filters)
     assert Retriever.HIGHLIGHT_MATCHES_LABEL not in sql
-
-
-def test_mixed_value_and_has_component_highlights_value_leaf_only() -> None:
-    filters = FilterTree(op=BooleanOperator.AND, children=[_value_leaf(), _component_leaf(FilterOp.HAS_COMPONENT)])
-    sql = _compile(filters)
-    assert sql.count("json_agg(") == 1
 
 
 def test_no_filters_produces_no_highlight_column() -> None:


### PR DESCRIPTION
## Summary

Fixes the "has component / doesn't have component" filter on the (beta) subscriptions search, which returned no results, and stops these filters from producing meaningless matching fields.

**ES DSL translation (`elastic_dsl.py`)**
- `exists` now translates to `has_component` (lquery `*.port.*`) instead of `ends_with` (`*.port`). Component labels only appear mid-path in index rows, so the old pattern matched nothing — the root cause of the empty results.
- `must_not: {exists: ...}` now inverts to `not_has_component`; previously the negation was silently dropped.

**Matching fields**
- `has_component` / `not_has_component` no longer produce matching fields: every result satisfies them by definition, so the reported field was just noise (an arbitrary field from inside the component).
- The exclusion lives in a shared helper, `FilterTree.get_highlightable_leaves()`, used by both the retriever and the result resolver to keep leaf indexing aligned.
- Other path-predicate leaves (`ends_with`, …) still report all matching rows, but without highlight spans — they match on the path, not the value text.

Covered by unit tests and end-to-end integration tests against PostgreSQL.

## Related Issues
Fixes https://git.ia.surf.nl/netdev/automation/projects/orchestrator-ui/-/work_items/203
