### PR TITLE
Add documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Introduction
+
+orchestrator-core is a workflow engine, built in Python on top of FastAPI and Pydantic.
+It allows to manage the lifecycle of customer-facing and resource-facing products.
+
+A product is defined as a collection of `ProductBlock`s and `ResourceType`s. Subscribing a customer to a product
+creates a `Subscription`, and workflows move that subscription through its lifecycle: `Initial`, `Provisioning`,
+`Active`, `Terminated`. A workflow is a list of Python functions, executed in order by the engine, each storing its
+result to the database so it can be retried from that point if it fails.
+
+Start with [Getting Started](getting-started/versions.md) to install and run the orchestrator, or
+[Architecture](architecture/tldr.md) for how it's put together.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ extra_javascript:
   - "js/custom.js"
 
 nav:
+  - Introduction: index.md
   - Getting Started:
       - Prerequisites: getting-started/versions.md
       - Application:


### PR DESCRIPTION
## Summary

Add `docs/index.md` as basic landing page for https://workfloworchestrator.org/orchestrator-core/ (currently displays 404 not found).  Gathered the inspiration from the LSO docs which do have an intro.

Before (no Introduction)
<img width="257" height="596" alt="image" src="https://github.com/user-attachments/assets/dec14b69-9c8f-474a-b7ff-dc2dfa503178" />


After:

<img width="1018" height="874" alt="image" src="https://github.com/user-attachments/assets/89e66365-5b90-46e1-bcfd-45d2ed199787" />
