### PR TITLE
Enable to run specific workflows on a separate queue / worker

### DIFF
--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -116,6 +116,50 @@ celery.conf.task_routes = {
 
 If you decide to override the queue names in this configuration, you must also update the names accordingly after the `-Q` flag.
 
+### Dedicated queues per workflow target
+
+The four default queues separate tasks from workflows, but they cannot isolate a *class* of
+workflows whose volume or duration profile differs from interactive work. A typical example is a
+nightly job that fans out hundreds of `Target.RECONCILE` workflows: these are not tasks
+(`is_task=False`), so they land on `new_workflows`/`resume_workflows`, where they compete with
+user-initiated workflows and delay the resumption of suspended ones for the duration of the batch.
+The same shape applies to heavy `VALIDATE` sweeps or long-running `SYSTEM` migrations.
+
+The `CELERY_TARGET_QUEUES` setting routes workflows of a given `Target` to a dedicated queue,
+for both new starts and resumes. Env vars parse as JSON:
+
+```bash
+CELERY_TARGET_QUEUES='{"RECONCILE": "reconcile"}'
+```
+
+Then run a dedicated worker pool for the isolated class, alongside the existing ones:
+
+```shell
+celery -A your_orch.celery_worker worker -E -l INFO -Q reconcile
+```
+
+Notes on the semantics:
+
+- **Task names are unchanged.** A routed reconcile start is still a `tasks.new_workflow` message
+  that merely travels via the `reconcile` queue. Queue = *where*, task name = *what*; Flower and
+  event-based monitoring keep reporting accurate task types, and any worker can execute the
+  routed messages.
+- **Start and resume share the mapped queue**, keeping the whole workload class off the shared
+  queues so worker fleets and scaling policies stay per class (e.g. an HPA on a per-queue
+  utilization metric).
+- **Targets not listed keep the default routing**; the default (empty mapping) is exactly
+  today's behavior. Multiple classes compose naturally:
+  `CELERY_TARGET_QUEUES='{"RECONCILE": "reconcile", "VALIDATE": "validate"}'`.
+- **Fail-fast validation.** An unknown target key or an empty queue name fails at application
+  startup, not at enqueue time.
+- **Mapping `VALIDATE` also covers validation runs** started via the validation endpoints — they
+  start processes through the same path, so they follow the mapping like any other start.
+- **Ignored under `EXECUTOR="threadpool"`.**
+- **Rollback is config-only**: remove the mapping entry and routing reverts instantly; a worker
+  on the dedicated queue drains whatever remains.
+
+Kombu auto-declares the queue on first use, so no broker-side configuration is needed.
+
 ### Worker count
 
 How many workers one needs for each queue depends on the number of subscriptions they have, what resources (mostly RAM) they have available, and how demanding their workflows/tasks are on external systems.

--- a/orchestrator/core/services/executors/celery.py
+++ b/orchestrator/core/services/executors/celery.py
@@ -22,7 +22,7 @@ from sqlalchemy import select
 
 from orchestrator.core import app_settings
 from orchestrator.core.api.error_handling import raise_status
-from orchestrator.core.db import ProcessTable, db
+from orchestrator.core.db import ProcessTable, WorkflowTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.processes import (
@@ -33,10 +33,22 @@ from orchestrator.core.services.processes import (
     set_process_status,
 )
 from orchestrator.core.services.workflows import get_workflow_by_name
+from orchestrator.core.targets import Target
 from orchestrator.core.workflow import ProcessStat, ProcessStatus
 from pydantic_forms.types import State
 
 logger = structlog.get_logger(__name__)
+
+
+def _resolve_queue(workflow: WorkflowTable) -> str | None:
+    """Return the dedicated queue for this workflow's target, or None for default task_routes routing.
+
+    Pure lookup on an already-loaded workflow row; must never touch the database, as the
+    executor closes/commits its session right before publishing. The explicit Target()
+    conversion makes a corrupt persisted target fail loudly instead of silently routing
+    to the default queue.
+    """
+    return app_settings.CELERY_TARGET_QUEUES.get(Target(workflow.target))
 
 
 def _block_when_testing(task_result: AsyncResult) -> None:
@@ -60,13 +72,17 @@ def _celery_start_process(pstat: ProcessStat, user: str = SYSTEM_USER, **kwargs:
 
     task_name = NEW_TASK if wf_table.is_task else NEW_WORKFLOW
     trigger_task = get_celery_task(task_name)
+    # Resolve before the session boundary below; no workflow attribute may be read after it.
+    queue = _resolve_queue(wf_table)
 
     # Close the SessionTransaction on the API side.
     db.session.close()
 
     try:
         # Trigger the celery task. This will create a SessionTransaction on the worker to read the process.
-        result = trigger_task.delay(pstat.process_id, user)
+        options = {"queue": queue} if queue else {}
+        result = trigger_task.apply_async((pstat.process_id, user), **options)
+        logger.debug("Enqueued process", process_id=pstat.process_id, task=task_name, queue=queue or "default")
         _block_when_testing(result)
         return pstat.process_id
     except (ConnectionError, OperationalError) as e:
@@ -95,6 +111,8 @@ def _celery_resume_process(
 
     task_name = RESUME_TASK if process.workflow.is_task else RESUME_WORKFLOW
     trigger_task = get_celery_task(task_name)
+    # Resolve before the transaction boundary below; no workflow attribute may be read after it.
+    queue = _resolve_queue(process.workflow)
 
     # Final write action to the process: ensure the SessionTransaction is committed on the API side.
     with transactional(db, logger):
@@ -102,7 +120,9 @@ def _celery_resume_process(
 
     try:
         # Trigger the celery task. This will create a SessionTransaction on the worker to read the process.
-        result = trigger_task.delay(process.process_id, user)
+        options = {"queue": queue} if queue else {}
+        result = trigger_task.apply_async((process.process_id, user), **options)
+        logger.debug("Enqueued process", process_id=process.process_id, task=task_name, queue=queue or "default")
         _block_when_testing(result)
 
         return process.process_id

--- a/orchestrator/core/settings.py
+++ b/orchestrator/core/settings.py
@@ -16,12 +16,13 @@ import string
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import Field, NonNegativeInt, PostgresDsn, RedisDsn, Secret, SecretStr
+from pydantic import Field, NonNegativeInt, PostgresDsn, RedisDsn, Secret, SecretStr, field_validator
 from pydantic.main import BaseModel
 from pydantic_settings import BaseSettings
 
 from oauth2_lib.settings import oauth2lib_settings
 from orchestrator.core.services.settings_env_variables import expose_settings
+from orchestrator.core.targets import Target
 from orchestrator.core.utils.auth import AuthContext, Authorizer
 from pydantic_forms.types import strEnum
 
@@ -121,6 +122,23 @@ class AppSettings(BaseSettings):
     EXPOSE_OAUTH_SETTINGS: bool = False
     LIFECYCLE_VALIDATION_MODE: LifecycleValidationMode = LifecycleValidationMode.LOOSE
     MCP_ENABLED: bool = False
+    CELERY_TARGET_QUEUES: dict[Target, str] = Field(
+        default_factory=dict,
+        description=(
+            "Optional mapping of workflow Target to a dedicated Celery queue. "
+            "Workflows whose target appears in this mapping are routed to the given queue for both new "
+            "starts and resumes, instead of the default new_*/resume_* queues. Targets not listed keep "
+            "the default routing. Only used when EXECUTOR is 'celery'. "
+            'Example (env var, JSON): CELERY_TARGET_QUEUES=\'{"RECONCILE": "reconcile"}\''
+        ),
+    )
+
+    @field_validator("CELERY_TARGET_QUEUES")
+    @classmethod
+    def validate_celery_target_queues(cls, value: dict[Target, str]) -> dict[Target, str]:
+        if any(not queue.strip() for queue in value.values()):
+            raise ValueError("CELERY_TARGET_QUEUES queue names must be non-empty")
+        return value
 
 
 app_settings = AppSettings()

--- a/test/integration_tests/services/executors/test_celery.py
+++ b/test/integration_tests/services/executors/test_celery.py
@@ -26,6 +26,7 @@ from orchestrator.core.services.executors.celery import (
 )
 from orchestrator.core.services.processes import RESUMABLE_STATUSES
 from orchestrator.core.services.tasks import NEW_TASK, RESUME_WORKFLOW
+from orchestrator.core.targets import Target
 from orchestrator.core.workflow import ProcessStatus
 
 
@@ -34,16 +35,17 @@ from orchestrator.core.workflow import ProcessStatus
 @mock.patch("orchestrator.core.services.executors.celery.delete_process")
 def test_celery_start_process(mock_delete_process, mock_get_workflow_by_name, mock_get_celery_task):
     pstat = MagicMock()
+    mock_get_workflow_by_name.return_value.target = Target.SYSTEM
 
     trigger_task = MagicMock()
-    trigger_task.delay.get.return_value = uuid4()
+    trigger_task.apply_async.get.return_value = uuid4()
     mock_get_celery_task.return_value = trigger_task
 
     process_id = _celery_start_process(pstat)
 
     assert process_id == pstat.process_id
     mock_get_celery_task.assert_called_once_with(NEW_TASK)
-    trigger_task.delay.assert_called_once()
+    trigger_task.apply_async.assert_called_once()
     mock_get_workflow_by_name.assert_called_once()
     mock_delete_process.assert_not_called()
 
@@ -55,12 +57,13 @@ def test_celery_start_process_connection_error_should_delete_process(
     mock_delete_process, mock_get_workflow_by_name, mock_get_celery_task
 ):
     pstat = MagicMock()
+    mock_get_workflow_by_name.return_value.target = Target.SYSTEM
     trigger_task = MagicMock()
 
-    def raise_connection_error(x, y):
+    def raise_connection_error(args, **options):
         raise ConnectionError()
 
-    trigger_task.delay = raise_connection_error
+    trigger_task.apply_async = raise_connection_error
     mock_get_celery_task.return_value = trigger_task
 
     with pytest.raises(ConnectionError):
@@ -76,20 +79,21 @@ def test_celery_resume_process(mock_db, mock_get_celery_task):
     process = MagicMock(spec=ProcessTable)
     process.last_status = ProcessStatus.FAILED
     process.workflow.is_task = False
+    process.workflow.target = Target.MODIFY
 
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = process
     mock_db.session.execute.return_value = mock_result
 
     trigger_task = MagicMock()
-    trigger_task.delay.get.return_value = uuid4()
+    trigger_task.apply_async.get.return_value = uuid4()
     mock_get_celery_task.return_value = trigger_task
 
     process_id = _celery_resume_process(process)
 
     assert process_id == process.process_id
     mock_get_celery_task.assert_called_once_with(RESUME_WORKFLOW)
-    trigger_task.delay.assert_called_once()
+    trigger_task.apply_async.assert_called_once()
     assert process.last_status == ProcessStatus.RESUMED
 
 
@@ -102,13 +106,14 @@ def test_celery_resume_process_connection_error_should_revert_process_status(
     process = MagicMock(spec=ProcessTable)
     process.last_status = ProcessStatus.FAILED
     process.workflow.is_task = False
+    process.workflow.target = Target.MODIFY
 
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = process
     mock_db.session.execute.return_value = mock_result
 
     trigger_task = MagicMock()
-    trigger_task.delay.side_effect = ConnectionError("network down")
+    trigger_task.apply_async.side_effect = ConnectionError("network down")
     mock_get_celery_task.return_value = trigger_task
 
     with pytest.raises(ConnectionError):

--- a/test/unit_tests/services/executors/test_celery_routing.py
+++ b/test/unit_tests/services/executors/test_celery_routing.py
@@ -1,0 +1,132 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Routing tests for CELERY_TARGET_QUEUES.
+
+Workflows whose target appears in the mapping must be enqueued on the mapped
+queue (start and resume alike); everything else must keep the default
+task_routes routing, i.e. the ``queue`` option must be absent entirely
+(passing ``queue=None`` would be a routing regression).
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from orchestrator.core import app_settings
+from orchestrator.core.db.models import ProcessTable
+from orchestrator.core.services.executors.celery import (
+    _celery_resume_process,
+    _celery_start_process,
+    _resolve_queue,
+)
+from orchestrator.core.services.processes import SYSTEM_USER
+from orchestrator.core.services.tasks import NEW_TASK, NEW_WORKFLOW, RESUME_TASK, RESUME_WORKFLOW
+from orchestrator.core.targets import Target
+from orchestrator.core.workflow import ProcessStatus
+
+RECONCILE_ONLY = {Target.RECONCILE: "reconcile"}
+RECONCILE_AND_VALIDATE = {Target.RECONCILE: "reconcile", Target.VALIDATE: "validate"}
+
+ROUTING_MATRIX = [
+    pytest.param({}, Target.RECONCILE, False, None, id="empty-mapping-reconcile-default-queue"),
+    pytest.param(RECONCILE_ONLY, Target.RECONCILE, False, "reconcile", id="mapped-target-routed"),
+    pytest.param(RECONCILE_ONLY, Target.CREATE, False, None, id="unmapped-target-default-queue"),
+    pytest.param(RECONCILE_ONLY, Target.RECONCILE, True, "reconcile", id="mapped-target-is-task-routed"),
+    pytest.param(RECONCILE_AND_VALIDATE, Target.VALIDATE, True, "validate", id="second-mapping-entry-routed"),
+]
+
+
+def assert_enqueued_once(trigger_task, expected_args, expected_queue):
+    """The unmapped case must produce no queue option at all, not queue=None."""
+    if expected_queue is None:
+        trigger_task.apply_async.assert_called_once_with(expected_args)
+    else:
+        trigger_task.apply_async.assert_called_once_with(expected_args, queue=expected_queue)
+
+
+@pytest.mark.parametrize("mapping,target,is_task,expected_queue", ROUTING_MATRIX)
+@mock.patch("orchestrator.core.services.tasks.get_celery_task")
+@mock.patch("orchestrator.core.services.executors.celery.get_workflow_by_name")
+@mock.patch("orchestrator.core.services.executors.celery.db")
+def test_celery_start_process_routing(
+    mock_db, mock_get_workflow_by_name, mock_get_celery_task, mapping, target, is_task, expected_queue
+):
+    wf_table = MagicMock()
+    wf_table.is_task = is_task
+    wf_table.target = str(target)
+    mock_get_workflow_by_name.return_value = wf_table
+
+    pstat = MagicMock()
+    trigger_task = MagicMock()
+    trigger_task.apply_async.return_value.get.return_value = uuid4()
+    mock_get_celery_task.return_value = trigger_task
+
+    with mock.patch.object(app_settings, "CELERY_TARGET_QUEUES", mapping):
+        process_id = _celery_start_process(pstat)
+
+    assert process_id == pstat.process_id
+    # Queue overrides never change the task name: queue = where, task name = what.
+    mock_get_celery_task.assert_called_once_with(NEW_TASK if is_task else NEW_WORKFLOW)
+    assert_enqueued_once(trigger_task, (pstat.process_id, SYSTEM_USER), expected_queue)
+
+
+@pytest.mark.parametrize("mapping,target,is_task,expected_queue", ROUTING_MATRIX)
+@mock.patch("orchestrator.core.services.tasks.get_celery_task")
+@mock.patch("orchestrator.core.services.executors.celery.db")
+def test_celery_resume_process_routing(mock_db, mock_get_celery_task, mapping, target, is_task, expected_queue):
+    process = MagicMock(spec=ProcessTable)
+    process.last_status = ProcessStatus.FAILED
+    process.workflow.is_task = is_task
+    process.workflow.target = str(target)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = process
+    mock_db.session.execute.return_value = mock_result
+
+    trigger_task = MagicMock()
+    trigger_task.apply_async.return_value.get.return_value = uuid4()
+    mock_get_celery_task.return_value = trigger_task
+
+    with mock.patch.object(app_settings, "CELERY_TARGET_QUEUES", mapping):
+        process_id = _celery_resume_process(process, user="testuser")
+
+    assert process_id == process.process_id
+    mock_get_celery_task.assert_called_once_with(RESUME_TASK if is_task else RESUME_WORKFLOW)
+    assert_enqueued_once(trigger_task, (process.process_id, "testuser"), expected_queue)
+
+
+@pytest.mark.parametrize(
+    "mapping,target,expected_queue",
+    [
+        pytest.param({}, Target.RECONCILE, None, id="empty-mapping"),
+        pytest.param(RECONCILE_ONLY, Target.RECONCILE, "reconcile", id="mapped"),
+        pytest.param(RECONCILE_ONLY, Target.MODIFY, None, id="unmapped"),
+    ],
+)
+def test_resolve_queue(mapping, target, expected_queue):
+    workflow = MagicMock()
+    workflow.target = str(target)
+
+    with mock.patch.object(app_settings, "CELERY_TARGET_QUEUES", mapping):
+        assert _resolve_queue(workflow) == expected_queue
+
+
+def test_resolve_queue_corrupt_target_fails_loudly():
+    workflow = MagicMock()
+    workflow.target = "NOT_A_TARGET"
+
+    with mock.patch.object(app_settings, "CELERY_TARGET_QUEUES", RECONCILE_ONLY), pytest.raises(ValueError):
+        _resolve_queue(workflow)

--- a/test/unit_tests/test_settings.py
+++ b/test/unit_tests/test_settings.py
@@ -1,0 +1,53 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from orchestrator.core.settings import AppSettings
+from orchestrator.core.targets import Target
+
+
+def test_celery_target_queues_defaults_to_empty_mapping():
+    assert AppSettings().CELERY_TARGET_QUEUES == {}
+
+
+def test_celery_target_queues_env_var_json_round_trip(monkeypatch):
+    """Enum-keyed dict must parse from the JSON env-var source (pydantic-settings v2 smoke test)."""
+    monkeypatch.setenv("CELERY_TARGET_QUEUES", json.dumps({"RECONCILE": "reconcile", "VALIDATE": "validate"}))
+
+    settings = AppSettings()
+
+    assert settings.CELERY_TARGET_QUEUES == {Target.RECONCILE: "reconcile", Target.VALIDATE: "validate"}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param({"DOES_NOT_EXIST": "some-queue"}, id="unknown-target-key"),
+        pytest.param({"RECONCILE": ""}, id="empty-queue-name"),
+        pytest.param({"RECONCILE": "   "}, id="whitespace-only-queue-name"),
+    ],
+)
+def test_celery_target_queues_rejects_invalid_mapping(value):
+    with pytest.raises(ValidationError):
+        AppSettings(CELERY_TARGET_QUEUES=value)
+
+
+def test_celery_target_queues_rejects_invalid_env_var_at_startup(monkeypatch):
+    monkeypatch.setenv("CELERY_TARGET_QUEUES", json.dumps({"NOT_A_TARGET": "queue"}))
+
+    with pytest.raises(ValidationError):
+        AppSettings()


### PR DESCRIPTION
## Summary
Adds a `CELERY_TARGET_QUEUES` setting: an optional mapping of workflow `Target` to a dedicated Celery queue (e.g. `CELERY_TARGET_QUEUES='{"RECONCILE": "reconcile"}'`), so specific workflow targets can be processed by dedicated workers.

- Targets in the mapping are routed to their queue for both new starts (`_celery_start_process`) and resumes (`_celery_resume_process`); unlisted targets keep the default `task_routes` routing (`.delay()` behavior preserved via `apply_async` without a queue).
- Queue resolution happens before the session/transaction boundary in the executor, since no workflow attributes may be read after the session is closed.
- Setting is validated (non-empty queue names) and ignored under `EXECUTOR=threadpool`.
- Includes unit tests for routing and settings validation, a new "Scaling" docs section, and a CHANGELOG entry.

## Related Issues
Fixes # (issue number)

## Checklist
- [x] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).