### PR TITLE
Cap oauth2-lib below 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,9 @@ dependencies = [
     "jinja2==3.1.6",
     "more-itertools~=11.1.0",
     "nwa-stdlib~=1.12.1",
-    "oauth2-lib>=2.6.1",
+    # Capped at <3: oauth2-lib 3.0.0 swaps httpx for httpx2, which changes the client type passed to
+    # OIDCAuth subclasses downstream. Lift to <4 once #1834 lands and the change can be announced.
+    "oauth2-lib>=2.6.1,<3",
     "orjson==3.11.9",
     "pgvector>=0.4.1",
     "prometheus-client==0.25.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2895,7 +2895,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.80.0" },
     { name = "more-itertools", specifier = "~=11.1.0" },
     { name = "nwa-stdlib", specifier = "~=1.12.1" },
-    { name = "oauth2-lib", specifier = ">=2.6.1" },
+    { name = "oauth2-lib", specifier = ">=2.6.1,<3" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pgvector", specifier = ">=0.4.1" },
     { name = "prometheus-client", specifier = "==0.25.0" },


### PR DESCRIPTION
Closes #1836.

`oauth2-lib>=2.6.1` had no upper bound, so we would resolve oauth2-lib 3.0.0 the moment it is
published — via renovate `lockFileMaintenance`, in a PR that never mentions oauth2-lib.

Our own code is fine with 3.0.0, so CI would stay green. The risk is downstream: a consumer doing a
routine **minor** upgrade could silently land on it and break their `OIDCAuth` subclass — mypy on the
`userinfo` annotation, or `TypeError` at runtime if they pass an `httpx.BasicAuth`/`Timeout`/`Limits`
into the client.

#1834 lifts this to `<4` once the dual-stack work lands and can go in release notes.

No functional change; 1482 unit tests pass, and the relock touches only the specifier.
