### PR TITLE
Pin GitHub Actions to commit digests via Renovate

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,8 @@ kind/ci:
   - changed-files:
       - any-glob-to-any-file:
           - ".github/**"
+          - ".pre-commit-config.yaml"
+          - "codecov.yml"
 
 kind/build:
   - changed-files:
@@ -25,7 +27,10 @@ kind/build:
           - "pyproject.toml"
           - "uv.lock"
           - "Dockerfile"
+          - ".dockerignore"
           - "Justfile"
+          - "renovate.json"
+          - ".bumpversion.cfg"
 
 area/search:
   - changed-files:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["kind/dependencies"],
   "packageRules": [


### PR DESCRIPTION
## Summary

Adds the [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset to `renovate.json`. Renovate will then rewrite every external `uses:` reference to `action@<full-sha> # vX.Y.Z` and keep both the digest and the trailing version comment in sync from then on.

**Why.** Git tags are mutable. Anyone able to move `actions/checkout@v7` owns our next CI run — silently, with no diff, retroactively affecting workflows written months ago. Pinning by digest means a moved tag changes nothing for us until a Renovate PR lands, which turns a silent swap into a reviewable one. GitHub's [secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use) puts it plainly: *"Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release."*

Prior art: [mw-root/uv-lock-report](https://github.com/mw-root/uv-lock-report/blob/main/renovate.json) (the action behind our lockfile reports) uses this same preset.

### What to expect

Renovate will open a one-time pin PR converting all external actions, labeled `kind/ci` by the existing `github-actions` package rule. After that, digest bumps ride along with the normal version PRs.

Two things worth knowing:

- **`pypa/gh-action-pypi-publish@release/v1` gets pinned too.** That branch ref stops floating, so we rely on Renovate digest bumps for publishing fixes rather than picking them up implicitly. This is the one behavioral change; happy to exclude it with a `pinDigests: false` rule if reviewers prefer the moving ref.
- **Local reusable workflows are unaffected** (`./.github/workflows/run-unit-tests.yml` and friends), as are `docker://` references.

The existing `minimumReleaseAge: 3 days` still applies, and GitHub Actions updates are not automerged — so every digest change gets human review. That review step is what makes the scheme worth anything; blind-automerging digest updates would just rebuild tag-following with extra steps.

## Related Issues

N/A — proactive supply-chain hardening.

## Type of change

- [x] I have set a `kind/*` label describing the change (`kind/ci`).
- [x] If this is a breaking change, I have set `kind/breaking`. — Not breaking; config-only, no runtime or API impact.

## Checklist

- [x] I have updated relevant documentation. — No user-facing docs cover Renovate config.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in CONTRIBUTING, if applicable. — Not applicable.
- [x] My code follows the style guidelines of this project as described in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)