### PR TITLE
Support both oauth2-lib 2.x and 3.x (httpx and httpx2)

### DIFF
--- a/docs/reference-docs/auth-backend-and-frontend.md
+++ b/docs/reference-docs/auth-backend-and-frontend.md
@@ -273,6 +273,12 @@ workflows.
 
 Below is an example illustrating how to override the default configurations:
 
+!!! note "Which `AsyncClient` to import"
+
+    The client passed to `userinfo()` comes from oauth2-lib, so import it from the library oauth2-lib
+    uses: `httpx` on oauth2-lib 2.x, `httpx2` on 3.x. Values you pass back into that client
+    (`BasicAuth`, `Timeout`, `Limits`) must come from the same one.
+
 === "`orchestrator-core` ≥ 5.0"
 
     ```python

--- a/orchestrator/core/graphql/schema.py
+++ b/orchestrator/core/graphql/schema.py
@@ -19,7 +19,6 @@ import strawberry
 import structlog
 from fastapi.routing import APIRouter
 from graphql import GraphQLError
-from httpx import HTTPStatusError
 from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 from strawberry.schema.config import StrawberryConfig
@@ -168,6 +167,12 @@ Mutation: type = merge_types("Mutation", (SettingsMutation, CustomerSubscription
 OrchestratorGraphqlRouter = GraphQLRouter
 
 
+def _is_not_found(error: BaseException | None) -> bool:
+    """Whether a resolver failed on a 404, whichever HTTP client it happened to use."""
+    response = getattr(error, "response", None)
+    return getattr(response, "status_code", None) == HTTPStatus.NOT_FOUND
+
+
 class OrchestratorSchema(strawberry.federation.Schema):
     def process_errors(
         self,
@@ -180,10 +185,7 @@ class OrchestratorSchema(strawberry.federation.Schema):
         """
         for error in errors:
             error_type = error.extensions.get("error_type") if error.extensions else None
-            if (
-                isinstance(error.original_error, HTTPStatusError)
-                and error.original_error.response.status_code == HTTPStatus.NOT_FOUND
-            ):
+            if _is_not_found(error.original_error):
                 message = str(error.original_error).splitlines()[0]  # Strip "For more info"
                 StrawberryLogger.logger.debug(message)
             elif error_type in (ErrorType.NOT_AUTHORIZED, ErrorType.NOT_AUTHENTICATED):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,12 @@ dependencies = [
     "deprecated>=1.2.18",
     "fastapi~=0.141.1",
     "fastapi-etag==0.4.0",
+    "httpx>=0.28.0,<1.0",
     "itsdangerous>=2.2.0",
     "jinja2==3.1.6",
     "more-itertools~=11.1.0",
     "nwa-stdlib~=1.12.1",
-    # Capped at <3: oauth2-lib 3.0.0 swaps httpx for httpx2, which changes the client type passed to
-    # OIDCAuth subclasses downstream. Lift to <4 once #1834 lands and the change can be announced.
-    "oauth2-lib>=2.6.1,<3",
+    "oauth2-lib>=2.6.1,<4",
     "orjson==3.11.9",
     "pgvector>=0.4.1",
     "prometheus-client==0.25.0",

--- a/test/unit_tests/graphql/test_schema_error_processing.py
+++ b/test/unit_tests/graphql/test_schema_error_processing.py
@@ -1,0 +1,62 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest import mock
+
+import httpx
+import pytest
+from graphql import GraphQLError
+
+from orchestrator.core.graphql.schema import OrchestratorSchema
+
+
+def httpx_error(status_code: int) -> Exception:
+    request = httpx.Request("GET", "https://example.test/thing")
+    return httpx.HTTPStatusError("not found", request=request, response=httpx.Response(status_code, request=request))
+
+
+def foreign_client_error(status_code: int) -> Exception:
+    """Any other client — httpx2 on oauth2-lib 3.x, requests, whatever a resolver reaches for."""
+    error = Exception("not found")
+    error.response = SimpleNamespace(status_code=status_code)  # type: ignore[attr-defined]
+    return error
+
+
+@pytest.mark.parametrize("make_error", [httpx_error, foreign_client_error], ids=["httpx", "foreign-client"])
+@pytest.mark.parametrize(
+    ("status_code", "debug_calls", "error_calls"),
+    [(HTTPStatus.NOT_FOUND, 1, 0), (HTTPStatus.INTERNAL_SERVER_ERROR, 0, 1)],
+)
+def test_process_errors_logs_404_at_debug(make_error, status_code, debug_calls, error_calls):
+    """A 404 is noise whichever client raised it; anything else is a real error.
+
+    Resolvers pick their own HTTP client, so this must not depend on the exception's class.
+    """
+    error = GraphQLError("boom", original_error=make_error(status_code))
+
+    with mock.patch("orchestrator.core.graphql.schema.StrawberryLogger") as logger:
+        OrchestratorSchema.process_errors(mock.MagicMock(), [error])
+
+    assert logger.logger.debug.call_count == debug_calls
+    assert logger.error.call_count == error_calls
+
+
+def test_process_errors_reports_error_without_response():
+    error = GraphQLError("boom", original_error=ValueError("no response attribute"))
+
+    with mock.patch("orchestrator.core.graphql.schema.StrawberryLogger") as logger:
+        OrchestratorSchema.process_errors(mock.MagicMock(), [error])
+
+    logger.error.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 
 [options]
@@ -2828,6 +2829,7 @@ dependencies = [
     { name = "deprecated" },
     { name = "fastapi" },
     { name = "fastapi-etag" },
+    { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "litellm" },
@@ -2935,12 +2937,13 @@ requires-dist = [
     { name = "fastapi", specifier = "~=0.141.1" },
     { name = "fastapi-etag", specifier = "==0.4.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0" },
+    { name = "httpx", specifier = ">=0.28.0,<1.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "litellm", specifier = ">=1.80.0" },
     { name = "more-itertools", specifier = "~=11.1.0" },
     { name = "nwa-stdlib", specifier = "~=1.12.1" },
-    { name = "oauth2-lib", specifier = ">=2.6.1,<3" },
+    { name = "oauth2-lib", specifier = ">=2.6.1,<4" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pgvector", specifier = ">=0.4.1" },
     { name = "prometheus-client", specifier = "==0.25.0" },


### PR DESCRIPTION
Closes #1834. Lets consumers move to oauth2-lib 3.0.0 (`httpx` -> `httpx2`) without a major release
here.

**We were already compatible with both.** orchestrator-core never touches the client it passes to
`OIDCAuth` subclasses — it only accepts one at `app.py:343`. All eleven oauth2-lib symbols we import
are byte-identical between 2.7.0 and 3.0.0. The widening to `<4` is the substance; the rest is
cleanup it exposed.

### Why we still declare `httpx`

Two imports, neither about oauth2-lib:

- `mcp/server.py:106` — `_forward_auth_header(request: httpx.Request)` is a hook handed to fastmcp's
  `httpx_client_kwargs`. fastmcp constructs that request and pins `httpx<1.0` until v4, so the
  annotation must match what fastmcp passes.
- `graphql/schema.py` — see below.

httpx was previously resolved transitively through oauth2-lib, which drops it on 3.x. `litellm`
requires it unconditionally, so it is always installed; the declaration makes that honest.

### The 404 check was never about oauth2-lib

`process_errors` matched `httpx.HTTPStatusError` to log a downstream 404 at debug. That check
predates httpx2, and oauth2-lib raises `HTTPStatusError` nowhere (verified against 2.7.0 and 3.0.0) —
it exists for 404s from **consumer resolvers' own HTTP calls**. The real axis is whichever client the
resolver used, so matching `{httpx, httpx2}` would be an arbitrary slice of an open set.

It now matches on `.response.status_code`, covering httpx, httpx2, `requests` and whatever follows.
That also removed a conditional import, a `cast`, and an `httpx2` dev dependency an earlier draft
carried.

### Not fixed here

`nwastdlib`'s `ErrorHandlerExtension` has the same httpx-only match, and that one decides what the
**API client** sees — a non-httpx 404 currently arrives as `INTERNAL_ERROR` / "Internal Server Error".
Filed as workfloworchestrator/nwa-stdlib#73, fixed in workfloworchestrator/nwa-stdlib#74.

If that ships as 1.12.2, our `nwa-stdlib~=1.12.1` picks it up on the next lock refresh and nothing is
needed here; only a 1.13 would require a pin bump.

### Verification

1487 unit tests, ruff and format clean. `uv sync` fails locally because #1835 moved litellm to
1.95.0, whose Rust component needs a newer Cargo than mine, so I ran against the existing venv; CI
uses prebuilt wheels. mypy reports one pre-existing `context_getter` error, identical on `main`.

CI never resolves oauth2-lib 3.x (the lock pins 2.7.0), so the `<4` range is not exercised. A matrix
leg would add little, since the suite runs with `OAUTH2_ACTIVE=False`.

