### PR TITLE
Delay codecov status check until all 10 coverage tests have completed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  notify:
+    # This is the number of total jobs running codecov/codecov-action. Note: each matrix strategy counts as 1 job.
+    # Doing this prevents code coverage failures after each job posts their results individually.
+    # It also means less load on the codecov API.
+    after_n_builds: 10
 ignore:
   - "docs"
   - "test"


### PR DESCRIPTION
## Summary

Reduce unnecessary strain on codecov API and prevent the coverage check failing on intermittent submissions.

## Related Issues

n/a

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [ ] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [ ] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
