### PR TITLE
Include inherited fields in subscription search field resolution

### DIFF
--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -14,6 +14,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 from functools import lru_cache
+from itertools import chain
 from typing import Any, get_args
 
 from pydantic import BaseModel
@@ -50,23 +51,35 @@ def _field_annotations(model_type: type[BaseModel]) -> Iterable[tuple[str, Any]]
 def _collect_field_types(
     model_type: type[BaseModel],
     path: str,
-    field_types: dict[str, set[FieldType]],
     ancestors: set[type[BaseModel]],
-) -> None:
+) -> Iterable[tuple[str, FieldType]]:
+    """Recursively yield indexed-path/FieldType entries for a model, guarding against recursive references."""
     if model_type in ancestors:
         return
 
     ancestors = ancestors | {model_type}
-    for name, annotation in _field_annotations(model_type):
-        field_path = f"{path}.{name}"
-        is_list = is_list_type(annotation)
-        indexed_path = f"{field_path}.*" if is_list else field_path
-        nested_model_types = _model_types(annotation)
-        if nested_model_types:
-            for nested_model_type in nested_model_types:
-                _collect_field_types(nested_model_type, indexed_path, field_types, ancestors)
-        else:
-            field_types[indexed_path].add(FieldType.from_type_hint(annotation))
+    yield from chain.from_iterable(
+        _field_type_entries(name, annotation, path, ancestors) for name, annotation in _field_annotations(model_type)
+    )
+
+
+def _field_type_entries(
+    name: str,
+    annotation: Any,
+    path: str,
+    ancestors: set[type[BaseModel]],
+) -> Iterable[tuple[str, FieldType]]:
+    """Return the indexed-path/FieldType entries contributed by a single field."""
+    field_path = f"{path}.{name}"
+    indexed_path = f"{field_path}.*" if is_list_type(annotation) else field_path
+    nested_model_types = _model_types(annotation)
+    if not nested_model_types:
+        yield indexed_path, FieldType.from_type_hint(annotation)
+        return
+
+    yield from chain.from_iterable(
+        _collect_field_types(nested_model_type, indexed_path, ancestors) for nested_model_type in nested_model_types
+    )
 
 
 def _specialized_subscription_types(model_type: type[SubscriptionModel]) -> set[type[SubscriptionModel]]:
@@ -83,8 +96,10 @@ def _subscription_field_types() -> dict[str, frozenset[FieldType]]:
         for registered_model_type in SUBSCRIPTION_MODEL_REGISTRY.values()
         for specialized_type in _specialized_subscription_types(registered_model_type)
     }
-    for model_type in model_types:
-        _collect_field_types(model_type, "subscription", field_types, set())
+    for path, field_type in chain.from_iterable(
+        _collect_field_types(model_type, "subscription", set()) for model_type in model_types
+    ):
+        field_types[path].add(field_type)
     return {path: frozenset(types) for path, types in field_types.items()}
 
 

--- a/orchestrator/core/search/indexing/field_types.py
+++ b/orchestrator/core/search/indexing/field_types.py
@@ -37,11 +37,20 @@ def _model_types(annotation: Any) -> set[type[BaseModel]]:
 def _field_annotations(model_type: type[BaseModel]) -> Iterable[tuple[str, Any]]:
     """Yield fields using domain-model classification when available."""
     if issubclass(model_type, DomainModel):
+        classified_fields = {
+            *model_type._non_product_block_fields_,
+            *model_type._product_block_fields_,
+        }
         yield from model_type._non_product_block_fields_.items()
         yield from model_type._product_block_fields_.items()
         yield from (
             (name, computed_field.return_type)
             for name, computed_field in getattr(model_type, "__pydantic_computed_fields__", {}).items()
+        )
+        yield from (
+            (name, field.annotation)
+            for name, field in model_type.model_fields.items()
+            if name not in classified_fields
         )
         return
 

--- a/test/unit_tests/search/indexing/test_field_types.py
+++ b/test/unit_tests/search/indexing/test_field_types.py
@@ -120,6 +120,28 @@ def test_resolve_field_types_uses_domain_field_registries() -> None:
     assert computed_types == frozenset({FieldType.STRING})
 
 
+def test_resolve_field_types_includes_inherited_subscription_fields() -> None:
+    class InheritedFieldsSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        own_field: str
+
+    clear_field_type_cache()
+    try:
+        with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"INHERITED": InheritedFieldsSubscription}, clear=True):
+            customer_id_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.customer_id")
+            description_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.description")
+            note_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.note")
+            product_name_types = resolve_field_types(EntityType.SUBSCRIPTION, "subscription.product.name")
+    finally:
+        clear_field_type_cache()
+
+    assert customer_id_types == frozenset({FieldType.STRING})
+    assert description_types == frozenset({FieldType.STRING})
+    assert note_types == frozenset({FieldType.STRING})
+    assert product_name_types == frozenset({FieldType.STRING})
+
+
 def test_resolve_field_types_global_path_matches_any_depth() -> None:
     """A dotless path (no ltree segments) matches the field name at any depth."""
 


### PR DESCRIPTION
## Summary
• Include inherited Pydantic fields when collecting subscription field types.  
• Refactor field-type collection to separate traversal from accumulating results, simplifying the nested recursion and conditional logic.  

Testing
- Added unit coverage for inherited fields:  
    ▪ customer_id  
    ▪ description  
    ▪ note  
    ▪ product.name  


- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [ ] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [ ] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
