### PR TITLE
Fix: change schema-aware ES DSL type inference to use FieldType

### DIFF
--- a/orchestrator/core/search/filters/elastic_dsl.py
+++ b/orchestrator/core/search/filters/elastic_dsl.py
@@ -150,8 +150,8 @@ _RANGE_KEYS = frozenset({"gt", "gte", "lt", "lte"})
 
 
 def _resolve_value_kind(field: str, value: Any, value_kind_resolver: ValueKindResolver | None) -> UIType:
-    """Resolve digit-only strings from the indexed model schema when available."""
-    if value_kind_resolver and isinstance(value, str) and value.isdigit():
+    """Resolve ambiguous numeric values from the indexed model schema when available."""
+    if value_kind_resolver and FieldType.infer(value) in (FieldType.INTEGER, FieldType.FLOAT):
         if value_kind := value_kind_resolver(field, value):
             return value_kind
     return _infer_value_kind(value)

--- a/test/unit_tests/schemas/test_search_requests.py
+++ b/test/unit_tests/schemas/test_search_requests.py
@@ -13,6 +13,7 @@
 
 """Tests for SearchRequest validation: limit bounds, order_by/query exclusivity, filter conversion, and to_query."""
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -113,6 +114,35 @@ def test_to_query_resolves_digit_only_term_from_subscription_schema(field: str, 
     clear_field_type_cache()
     with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanSubscription}, clear=True):
         request = SearchRequest(filters={"term": {field: "26"}})  # type: ignore[arg-type]
+        query = request.to_query(EntityType.SUBSCRIPTION)
+
+    clear_field_type_cache()
+    assert query.filters is not None
+    leaf = query.filters.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == expected_kind
+
+
+@pytest.mark.parametrize(
+    "value, expected_kind",
+    [
+        pytest.param("26", UIType.STRING, id="quoted-string"),
+        pytest.param(26, UIType.STRING, id="unquoted-int"),
+        pytest.param(26.0, UIType.STRING, id="unquoted-float"),
+    ],
+)
+def test_to_query_resolves_unquoted_numeric_term_for_string_field(value: Any, expected_kind: UIType) -> None:
+    class VlanRange(str):
+        pass
+
+    class VlanSubscription(SubscriptionModel, is_base=True):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        vlanrange: VlanRange | None = None
+
+    clear_field_type_cache()
+    with patch.dict(SUBSCRIPTION_MODEL_REGISTRY, {"VLAN": VlanSubscription}, clear=True):
+        request = SearchRequest(filters={"term": {"vlanrange": value}})  # type: ignore[arg-type]
         query = request.to_query(EntityType.SUBSCRIPTION)
 
     clear_field_type_cache()

--- a/test/unit_tests/search/filters/test_elastic_dsl.py
+++ b/test/unit_tests/search/filters/test_elastic_dsl.py
@@ -401,6 +401,31 @@ def test_resolve_value_kind_ignores_resolver_for_non_digit_string() -> None:
     assert resolver_called is False
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(26, id="int"),
+        pytest.param(26.0, id="float"),
+    ],
+)
+def test_resolve_value_kind_uses_resolver_for_numeric_value(value: Any) -> None:
+    """Unquoted numeric values from the database payload should also be schema-resolved."""
+    es = ElasticQueryAdapter.validate_python({"term": {"field": value}})
+    tree = elastic_to_filter_tree(es, value_kind_resolver=lambda _field, _value: UIType.STRING)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.STRING
+
+
+def test_resolve_value_kind_falls_back_for_numeric_value_when_resolver_returns_none() -> None:
+    """When the resolver can't resolve a numeric value, inference is used instead."""
+    es = ElasticQueryAdapter.validate_python({"term": {"field": 26}})
+    tree = elastic_to_filter_tree(es, value_kind_resolver=lambda _field, _value: None)
+    leaf = tree.children[0]
+    assert isinstance(leaf, PathFilter)
+    assert leaf.value_kind == UIType.NUMBER
+
+
 # ---------------------------------------------------------------------------
 # validation / edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The schema-aware value-kind resolver introduced for search only handled ambiguous string values (e.g. "26"). When a filter value arrived as an unquoted number from the database payload (e.g. 26 or 26.0), it was inferred directly as NUMBER and never checked against the subscription schema. For fields like VlanRanges that are modelled as strings but may be serialised as unquoted numbers, this caused the filter to target numeric index rows while the actual indexed value was stored as a string, producing empty results.

### Change
• _resolve_value_kind now delegates the "is this value ambiguous?" decision to FieldType.infer. Any value that infers to INTEGER or FLOAT — whether it is an int, a float, a digit-only string, or a decimal string — is passed to the schema resolver before falling back to inference.  

### Tests
• test/unit_tests/search/filters/test_elastic_dsl.py — added coverage for int/float values being schema-resolved and falling back to inference when the resolver returns None.  
• test/unit_tests/schemas/test_search_requests.py — added an end-to-end test that verifies a VlanRange-typed field resolves to UIType.STRING for "26", 26, and 26.0.  


- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.

## Checklist
- [ ] I have updated relevant documentation.
- [ ] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [ ] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
