### PR TITLE
List subscriptions tool and raise on empty criteria searches for agents

### DIFF
--- a/docs/reference-docs/mcp.md
+++ b/docs/reference-docs/mcp.md
@@ -42,7 +42,7 @@ The default toolset covers the typical agent flow:
 | `abort_workflow_process`                  | Abort a running process (irreversible)               |
 | `get_process_status`                      | Inspect a running/suspended process                  |
 | `list_recent_processes`                   | List recent processes (with typed filters)           |
-| `search_subscriptions`                    | Search subscriptions with typed filters              |
+| `list_subscriptions`                      | List subscriptions, newest first                     |
 | `get_subscription_details`                | Get a flat header for a subscription                 |
 | `list_products`                           | List products                                        |
 | `get_product`                             | Get one product definition by id                     |

--- a/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
+++ b/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
@@ -39,6 +39,9 @@ Why these are curated rather than auto-generated from the existing REST API:
 * ``list_recent_processes`` —> REST ``GET /processes/?filter=k,v,k,v`` uses
   a flat positional filter syntax that LLMs handle poorly; this exposes
   named kwargs.
+* ``list_subscriptions`` —> no list route exists on ``/subscriptions``
+  (browsing lives in GraphQL) and ``search`` deliberately refuses to
+  enumerate without criteria; this gives agents a deterministic listing.
 * ``get_subscription_details`` —> REST ``GET /subscriptions/domain-model/{id}``
   returns the full product-block tree; this returns a flat header.
 """
@@ -54,7 +57,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from orchestrator.core.api.error_handling import raise_status
-from orchestrator.core.db import ProcessTable, WorkflowTable, db
+from orchestrator.core.db import ProcessTable, SubscriptionTable, WorkflowTable, db
 from orchestrator.core.mcp.server import AGENT_EXPOSED_TAG, READONLY_TOOL
 from orchestrator.core.schemas.mcp_search import (
     AggregateToolRequest,
@@ -72,6 +75,8 @@ from orchestrator.core.schemas.mcp_search import (
 from orchestrator.core.schemas.mcp_tools import (
     GetWorkflowFormRequest,
     ListRecentProcessesRequest,
+    ListSubscriptionsRequest,
+    ListSubscriptionsResponse,
     ListWorkflowsRequest,
     ProcessIdRequest,
     ProcessStatusResponse,
@@ -79,6 +84,7 @@ from orchestrator.core.schemas.mcp_tools import (
     ProductSummary,
     SubscriptionDetailsResponse,
     SubscriptionIdRequest,
+    SubscriptionSummary,
     WorkflowFormPage,
 )
 from orchestrator.core.schemas.workflow import SubscriptionWorkflowListsSchema, WorkflowSchema
@@ -262,6 +268,49 @@ def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[P
 
 
 @router.post(
+    "/list_subscriptions",
+    response_model=ListSubscriptionsResponse,
+    tags=[AGENT_EXPOSED_TAG],
+    operation_id="list_subscriptions",
+    openapi_extra=READONLY_TOOL,
+)
+def list_subscriptions_endpoint(params: ListSubscriptionsRequest) -> ListSubscriptionsResponse:
+    """List subscriptions, newest first, at most 10 per page.
+
+    While ``has_more`` is true, call again with ``offset=next_offset`` for the
+    next page. Returns flat summary rows without product blocks; use
+    get_subscription_details or get_subscription_domain_model for one
+    subscription's full data, and ``search`` to find or filter subscriptions.
+    """
+    stmt = (
+        select(SubscriptionTable)
+        .options(joinedload(SubscriptionTable.product))
+        .order_by(SubscriptionTable.start_date.desc().nulls_first(), SubscriptionTable.subscription_id)
+        .offset(params.offset)
+        .limit(params.limit + 1)
+    )
+    rows = db.session.scalars(stmt).unique().all()
+    has_more = len(rows) > params.limit
+    return ListSubscriptionsResponse(
+        subscriptions=[
+            SubscriptionSummary(
+                subscription_id=s.subscription_id,
+                description=s.description,
+                status=s.status,
+                insync=s.insync,
+                product_name=s.product.name,
+                customer_id=s.customer_id,
+                start_date=s.start_date,
+                end_date=s.end_date,
+            )
+            for s in rows[: params.limit]
+        ],
+        has_more=has_more,
+        next_offset=params.offset + params.limit if has_more else None,
+    )
+
+
+@router.post(
     "/get_subscription_details",
     response_model=SubscriptionDetailsResponse,
     tags=[AGENT_EXPOSED_TAG],
@@ -318,7 +367,9 @@ def get_subscription_details_endpoint(params: SubscriptionIdRequest) -> Subscrip
 async def search_endpoint(params: SearchToolRequest) -> SearchToolResponse:
     """Find and rank entities (subscriptions, products, workflows, processes).
 
-    Pass ``query_text`` for semantic/fuzzy ranking and/or structured ``filters``. To filter: first call
+    Pass ``query_text`` for semantic/fuzzy ranking and/or structured ``filters``; at least one is
+    required, a call without criteria is rejected, use the ``list_*`` tools (e.g.
+    ``list_subscriptions``) to enumerate entities instead. To filter: first call
     discover_filter_paths for the fields you need, check operators with get_valid_operators, then build
     the filter_tree from ONLY those exact paths. If a filtered search returns nothing, it automatically
     broadens (drops filters, re-ranks by similarity) up to ``effort`` passes and sets

--- a/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
+++ b/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
@@ -54,7 +54,7 @@ import structlog
 from fastapi.routing import APIRouter
 from pydantic import ValidationError
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, raiseload
 
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.db import ProcessTable, SubscriptionTable, WorkflowTable, db
@@ -240,7 +240,7 @@ def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[P
     """
     stmt = (
         select(ProcessTable)
-        .options(joinedload(ProcessTable.workflow))
+        .options(joinedload(ProcessTable.workflow), raiseload("*"))
         .order_by(ProcessTable.started_at.desc())
         .limit(params.limit)
     )
@@ -275,22 +275,22 @@ def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[P
     openapi_extra=READONLY_TOOL,
 )
 async def list_subscriptions_endpoint(params: ListSubscriptionsRequest) -> ListSubscriptionsResponse:
-    """List subscriptions, newest first, at most 10 per page.
+    """List the newest subscriptions, at most 20.
 
-    While ``has_more`` is true, call again with ``offset=next_offset`` for the
-    next page. Returns flat summary rows without product blocks; use
+    Returns flat summary rows without product blocks; use
     get_subscription_details or get_subscription_domain_model for one
-    subscription's full data, and ``search`` to find or filter subscriptions.
+    subscription's full data. When ``has_more`` is true the listing is
+    truncated; use ``search`` to find or filter subscriptions instead of
+    listing further.
     """
     stmt = (
         select(SubscriptionTable)
-        .options(joinedload(SubscriptionTable.product))
+        .options(joinedload(SubscriptionTable.product), raiseload("*"))
+        # NULL start_date means not yet provisioned, i.e. the newest lifecycle stage.
         .order_by(SubscriptionTable.start_date.desc().nulls_first(), SubscriptionTable.subscription_id)
-        .offset(params.offset)
         .limit(params.limit + 1)
     )
     rows = db.session.scalars(stmt).unique().all()
-    has_more = len(rows) > params.limit
     return ListSubscriptionsResponse(
         subscriptions=[
             SubscriptionSummary(
@@ -305,8 +305,7 @@ async def list_subscriptions_endpoint(params: ListSubscriptionsRequest) -> ListS
             )
             for s in rows[: params.limit]
         ],
-        has_more=has_more,
-        next_offset=params.offset + params.limit if has_more else None,
+        has_more=len(rows) > params.limit,
     )
 
 

--- a/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
+++ b/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
@@ -274,7 +274,7 @@ def list_recent_processes_endpoint(params: ListRecentProcessesRequest) -> list[P
     operation_id="list_subscriptions",
     openapi_extra=READONLY_TOOL,
 )
-def list_subscriptions_endpoint(params: ListSubscriptionsRequest) -> ListSubscriptionsResponse:
+async def list_subscriptions_endpoint(params: ListSubscriptionsRequest) -> ListSubscriptionsResponse:
     """List subscriptions, newest first, at most 10 per page.
 
     While ``has_more`` is true, call again with ``offset=next_offset`` for the

--- a/orchestrator/core/schemas/mcp_search.py
+++ b/orchestrator/core/schemas/mcp_search.py
@@ -21,7 +21,7 @@ self-contained MCP tools so any agent can drive search/aggregation over MCP.
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from orchestrator.core.schemas.base import OrchestratorBaseModel
 from orchestrator.core.search.aggregations import Aggregation, TemporalGrouping
@@ -62,6 +62,22 @@ class SearchToolRequest(OrchestratorBaseModel):
         "'medium'=1, 'low'=0 (report no matches instead of broadening). Each pass drops the filters and "
         "re-ranks by similarity to surface the closest matches.",
     )
+
+    @model_validator(mode="after")
+    def require_search_criteria(self) -> "SearchToolRequest":
+        """Reject a criteria-less search instead of silently returning zero results.
+
+        Without this, a bare call ranks nothing (the engine returns an empty
+        response) and LLM callers report "no data" as fact. Failing loudly here
+        steers them to the enumeration tools instead.
+        """
+        if not self.query_text and self.filters is None:
+            raise ValueError(
+                "search requires query_text and/or filters; it does not enumerate entities. "
+                "To list entities without search criteria use the list tools instead: "
+                "list_subscriptions, list_products, list_workflows or list_recent_processes."
+            )
+        return self
 
 
 class AggregateToolRequest(OrchestratorBaseModel):

--- a/orchestrator/core/schemas/mcp_tools.py
+++ b/orchestrator/core/schemas/mcp_tools.py
@@ -65,12 +65,7 @@ class ListRecentProcessesRequest(OrchestratorBaseModel):
 
 
 class ListSubscriptionsRequest(OrchestratorBaseModel):
-    limit: int = Field(default=10, ge=1, le=10, description="Maximum number of subscriptions per page.")
-    offset: int = Field(
-        default=0,
-        ge=0,
-        description="Number of subscriptions to skip; pass next_offset from the previous page to continue.",
-    )
+    limit: int = Field(default=10, ge=1, le=20, description="Maximum number of subscriptions to return.")
 
 
 # Response models
@@ -125,10 +120,7 @@ class SubscriptionSummary(OrchestratorBaseModel):
 
 class ListSubscriptionsResponse(OrchestratorBaseModel):
     subscriptions: list[SubscriptionSummary]
-    has_more: bool = Field(description="True when more subscriptions exist beyond this page.")
-    next_offset: int | None = Field(
-        default=None, description="Pass as offset in the next call to fetch the following page; null on the last page."
-    )
+    has_more: bool = Field(description="True when more subscriptions exist beyond the returned limit.")
 
 
 class SubscriptionDetailsResponse(OrchestratorBaseModel):

--- a/orchestrator/core/schemas/mcp_tools.py
+++ b/orchestrator/core/schemas/mcp_tools.py
@@ -64,6 +64,15 @@ class ListRecentProcessesRequest(OrchestratorBaseModel):
     limit: int = Field(default=20, ge=1, le=100, description="Maximum number of processes to return.")
 
 
+class ListSubscriptionsRequest(OrchestratorBaseModel):
+    limit: int = Field(default=10, ge=1, le=10, description="Maximum number of subscriptions per page.")
+    offset: int = Field(
+        default=0,
+        ge=0,
+        description="Number of subscriptions to skip; pass next_offset from the previous page to continue.",
+    )
+
+
 # Response models
 
 
@@ -101,6 +110,25 @@ class ProductSummary(OrchestratorBaseModel):
     product_type: str
     tag: str | None = None
     description: str | None = None
+
+
+class SubscriptionSummary(OrchestratorBaseModel):
+    subscription_id: UUID
+    description: str | None = None
+    status: SubscriptionLifecycle
+    insync: bool
+    product_name: str
+    customer_id: str | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+
+
+class ListSubscriptionsResponse(OrchestratorBaseModel):
+    subscriptions: list[SubscriptionSummary]
+    has_more: bool = Field(description="True when more subscriptions exist beyond this page.")
+    next_offset: int | None = Field(
+        default=None, description="Pass as offset in the next call to fetch the following page; null on the last page."
+    )
 
 
 class SubscriptionDetailsResponse(OrchestratorBaseModel):

--- a/test/integration_tests/api/test_mcp_tools.py
+++ b/test/integration_tests/api/test_mcp_tools.py
@@ -1,0 +1,38 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+
+
+def test_list_subscriptions(product_type_1_subscription_factory, product_type_1_subscriptions_factory, test_client):
+    older_id, newer_id = product_type_1_subscriptions_factory(2)
+    initial_id = product_type_1_subscription_factory(description="not yet provisioned", start_date=None)
+
+    response = test_client.post("/api/agent/list_subscriptions", json={})
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["has_more"] is False
+    # Newest first; a NULL start_date means not yet provisioned, i.e. newest.
+    assert [s["subscription_id"] for s in body["subscriptions"]] == [initial_id, newer_id, older_id]
+
+
+def test_list_subscriptions_truncates_at_limit(product_type_1_subscriptions_factory, test_client):
+    product_type_1_subscriptions_factory(2)
+
+    response = test_client.post("/api/agent/list_subscriptions", json={"limit": 1})
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert len(body["subscriptions"]) == 1
+    assert body["has_more"] is True

--- a/test/unit_tests/mcp/test_mcp.py
+++ b/test/unit_tests/mcp/test_mcp.py
@@ -18,7 +18,7 @@ These tests verify that:
 1. The agent-tagged REST routes carry the ``AGENT_EXPOSED_TAG`` and have
    stable ``operation_id`` values that map 1:1 to the MCP tool names.
 2. ``FastMCP.from_fastapi`` introspects the FastAPI app's routes, derives
-   input schemas from their pydantic models, and produces exactly the 22
+   input schemas from their pydantic models, and produces exactly the 23
    tools we expect via ``RouteMap`` tag-based filtering.
 3. Each tool carries ``ToolAnnotations`` (read-only/idempotent/destructive
    hints + a humanized title) declared per route via ``openapi_extra``
@@ -28,11 +28,13 @@ These tests verify that:
 
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from orchestrator.core.api.api_v1.endpoints import (
     mcp_tools,
@@ -61,6 +63,7 @@ EXPECTED_TOOL_NAMES = {
     "get_subscription_available_workflows",
     "get_process_status",
     "list_recent_processes",
+    "list_subscriptions",
     "get_subscription_details",
     "get_product",  # GET /api/products/{product_id}
     "get_product_block",  # GET /api/product_blocks/{product_block_id}
@@ -281,3 +284,17 @@ async def test_query_validation_error_surfaces_as_422_through_mcp(
     message = str(excinfo.value)
     assert "422" in message
     assert expected_detail in message
+
+
+def test_search_without_criteria_rejected_as_422(app_with_agent_routes: FastAPI) -> None:
+    """A search call with neither ``query_text`` nor ``filters`` fails loudly.
+
+    Guards the ``SearchToolRequest`` validator: a criteria-less search used to
+    rank nothing and return an empty result set, which LLM callers reported as
+    "no data" instead of recognizing a bad call. (That a 422 reaches the MCP
+    caller as a ToolError is covered by
+    ``test_query_validation_error_surfaces_as_422_through_mcp``.)
+    """
+    client = TestClient(app_with_agent_routes)
+    response = client.post("/api/agent/search", json={"entity_type": "SUBSCRIPTION"})
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary
 When an agent is asked for some example subscriptions, or a list of all of them, it uses the search tool, which silently returns an empty list when no criteria are given. That is a valid design decision for interactive clients, which treat it as transient state and show an empty result page. An agent however takes it as ground truth and reports that there are no subscriptions. 

This PR  creates a new tool for listing subscriptions and raises a clear error when the search tool is called without search parameters,


## Related Issues
Fixes # (issue number)

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
