### PR TITLE
Replace deprecated .dict() with .model_dump() in generator

### DIFF
--- a/docs/reference-docs/forms.md
+++ b/docs/reference-docs/forms.md
@@ -167,7 +167,7 @@ def initial_input_form_generator(product: UUIDstr, product_name: str) -> FormGen
 
     user_input_node = yield NodeIdForm
 
-    return {**user_input.dict(), **user_input_node.dict()}
+    return user_input.model_dump() | user_input_node.model_dump()
 ```
 
 For multi-step forms especially, it can be useful to use the `orchestrator.core.forms.SubmitFormPage` class, which is just a subclass of `orchestrator.core.forms.FormPage` that has some metadata informing the frontend that this form is the last page in the flow so it can style the submit button differently. This is entirely optional.

--- a/orchestrator/core/cli/generator/templates/create_product.j2
+++ b/orchestrator/core/cli/generator/templates/create_product.j2
@@ -83,7 +83,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
         {%- endfor %}
 
     user_input = yield Create{{ product.type }}Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
     {% if product.config.summary_forms %}
     yield from base_summary(product_name, user_input_dict)
     {%- endif %}

--- a/orchestrator/core/cli/generator/templates/modify_product.j2
+++ b/orchestrator/core/cli/generator/templates/modify_product.j2
@@ -94,7 +94,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         {%- endfor %}
 
     user_input = yield Modify{{ product.type }}Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
     {% if product.config.summary_forms %}
     old_modify_form_data = Modify{{ product.type }}Form.model_construct().model_dump()
     yield from base_summary(subscription.product.name, user_input_dict, old_modify_form_data)

--- a/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
@@ -65,7 +65,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
         always_optional_str: str | None = None
 
     user_input = yield CreateExample1Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     yield from base_summary(product_name, user_input_dict)
 

--- a/test/acceptance_tests/cli/data/generate/workflows/example1/modify_example1.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example1/modify_example1.py
@@ -60,7 +60,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         always_optional_str: str | None = example1.always_optional_str
 
     user_input = yield ModifyExample1Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     old_modify_form_data = ModifyExample1Form.model_construct().model_dump()
     yield from base_summary(subscription.product.name, user_input_dict, old_modify_form_data)

--- a/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
@@ -52,7 +52,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
         example_int_enum_2: ExampleIntEnum2 | None = None
 
     user_input = yield CreateExample2Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     return user_input_dict
 

--- a/test/acceptance_tests/cli/data/generate/workflows/example2/modify_example2.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example2/modify_example2.py
@@ -49,7 +49,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         example_int_enum_2: ExampleIntEnum2 | None = example2.example_int_enum_2
 
     user_input = yield ModifyExample2Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     return user_input_dict | {"subscription": subscription}
 

--- a/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
@@ -51,7 +51,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
         num_val: int | None = None
 
     user_input = yield CreateExample4Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     return user_input_dict
 

--- a/test/acceptance_tests/cli/data/generate/workflows/example4/modify_example4.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example4/modify_example4.py
@@ -49,7 +49,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
         num_val: read_only_field(example4.num_val)
 
     user_input = yield ModifyExample4Form
-    user_input_dict = user_input.dict()
+    user_input_dict = user_input.model_dump()
 
     return user_input_dict | {"subscription": subscription}
 

--- a/test/integration_tests/cli/test_migrate_domain_models_with_instances.py
+++ b/test/integration_tests/cli/test_migrate_domain_models_with_instances.py
@@ -76,7 +76,7 @@ def test_migrate_domain_models_new_product_block(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -142,7 +142,7 @@ def test_migrate_domain_models_new_product_block_on_product_block(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -204,7 +204,7 @@ def test_migrate_domain_models_new_resource_type(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -262,7 +262,7 @@ def test_migrate_domain_models_new_product_block_and_resource_type(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -323,7 +323,7 @@ def test_migrate_domain_models_update_resource_type(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -391,7 +391,7 @@ def test_migrate_domain_models_create_and_rename_resource_type(test_product_type
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -474,7 +474,7 @@ def test_migrate_domain_models_create_and_rename_and_delete_resource_type(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -696,7 +696,7 @@ def test_migrate_domain_models_update_block_resource_type(
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()
 
@@ -765,6 +765,6 @@ def test_migrate_domain_models_rename_and_update_block_resource_type(test_produc
             db.session.execute(text(stmt))
         db.session.commit()
 
-    # Note that this check is done after patch.dict() restored the registries to their original state.
+    # Note that this check is done after patch.model_dump() restored the registries to their original state.
     # The subscription should now be the same as it was before.
     assert_subscription_has_initial_values()


### PR DESCRIPTION
## Summary
Remove `.dict()` calls from the product and workflow generator in favour of `.model_dump()`

## Related Issues
Fixes #1712

## Type of change
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
