### PR TITLE
Enable 'does not contain' search filter in core

### DIFF
--- a/orchestrator/core/search/filters/definitions.py
+++ b/orchestrator/core/search/filters/definitions.py
@@ -95,6 +95,7 @@ def value_schema_for(ft: FieldType) -> dict[FilterOp, ValueSchema]:
         FilterOp.EQ: ValueSchema(kind=UIType.STRING),
         FilterOp.NEQ: ValueSchema(kind=UIType.STRING),
         FilterOp.LIKE: ValueSchema(kind=UIType.STRING),
+        FilterOp.NOT_CONTAINS: ValueSchema(kind=UIType.STRING),
     }
 
 

--- a/test/unit_tests/search/filters/test_definitions.py
+++ b/test/unit_tests/search/filters/test_definitions.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.search
 _NUMERIC_OPS = [FilterOp.EQ, FilterOp.NEQ, FilterOp.LT, FilterOp.LTE, FilterOp.GT, FilterOp.GTE, FilterOp.BETWEEN]
 _BOOLEAN_OPS = [FilterOp.EQ, FilterOp.NEQ]
 _DATETIME_OPS = [FilterOp.EQ, FilterOp.NEQ, FilterOp.LT, FilterOp.LTE, FilterOp.GT, FilterOp.GTE, FilterOp.BETWEEN]
-_STRING_OPS = [FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE]
+_STRING_OPS = [FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE, FilterOp.NOT_CONTAINS]
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +62,7 @@ def test_operators_for_field_type(field_type: FieldType, expected_ops: list[Filt
         pytest.param(FieldType.FLOAT, 7, id="float"),
         pytest.param(FieldType.BOOLEAN, 2, id="boolean"),
         pytest.param(FieldType.DATETIME, 7, id="datetime"),
-        pytest.param(FieldType.STRING, 3, id="string"),
+        pytest.param(FieldType.STRING, 4, id="string"),
     ],
 )
 def test_operators_count(field_type: FieldType, expected_count: int) -> None:
@@ -155,9 +155,9 @@ def test_datetime_non_between_ops_have_datetime_kind() -> None:
         pytest.param(FieldType.RESOURCE_TYPE, id="resource_type"),
     ],
 )
-def test_string_like_schema_has_three_ops_with_like(field_type: FieldType) -> None:
+def test_string_like_schema_has_four_ops_with_like_and_not_contains(field_type: FieldType) -> None:
     schema = value_schema_for(field_type)
-    assert set(schema.keys()) == {FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE}
+    assert set(schema.keys()) == {FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE, FilterOp.NOT_CONTAINS}
 
 
 @pytest.mark.parametrize(
@@ -171,7 +171,7 @@ def test_string_like_schema_has_three_ops_with_like(field_type: FieldType) -> No
 )
 def test_string_like_schema_ops_have_string_kind(field_type: FieldType) -> None:
     schema = value_schema_for(field_type)
-    for op in [FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE]:
+    for op in [FilterOp.EQ, FilterOp.NEQ, FilterOp.LIKE, FilterOp.NOT_CONTAINS]:
         assert schema[op].kind == UIType.STRING
 
 

--- a/test/unit_tests/search/query/test_validation.py
+++ b/test/unit_tests/search/query/test_validation.py
@@ -20,6 +20,7 @@ import pytest
 from orchestrator.core.search.aggregations import AggregationType
 from orchestrator.core.search.core.types import EntityType, FieldType, FilterOp, UIType
 from orchestrator.core.search.filters import (
+    ContainsFilter,
     DateValueFilter,
     EqualityFilter,
     LtreeFilter,
@@ -77,6 +78,18 @@ def test_ltree_filter_always_compatible(field_type: FieldType):
         ),
         pytest.param(EqualityFilter(op=FilterOp.EQ, value=True), FieldType.BOOLEAN, True, id="eq-boolean-valid"),
         pytest.param(EqualityFilter(op=FilterOp.EQ, value=1), FieldType.INTEGER, True, id="eq-integer-valid"),
+        pytest.param(
+            ContainsFilter(op=FilterOp.NOT_CONTAINS, value="core"),
+            FieldType.STRING,
+            True,
+            id="not-contains-string-valid",
+        ),
+        pytest.param(
+            ContainsFilter(op=FilterOp.NOT_CONTAINS, value="core"),
+            FieldType.INTEGER,
+            False,
+            id="not-contains-integer-invalid",
+        ),
     ],
 )
 def test_filter_compatibility_matrix(filter_condition, field_type: FieldType, expected: bool):


### PR DESCRIPTION
## Summary
Exposes the `not_regexp` (`FilterOp.NOT_CONTAINS`) operator for string fields in the search filter definitions, so the UI can offer a "does not contain" option in the operator dropdown.

The dropdown is driven by the definitions endpoint, which only advertised `eq`, `neq`, `like` for string fields — even though the engine already implements negated contains (`ContainsFilter`, added in #1686 for ES DSL `regexp` translation).

- `definitions.py`: add `NOT_CONTAINS` to the string value schema. No engine changes: the ES DSL path already translates `bool.must_not` + `regexp` to `NOT_CONTAINS`, and this also whitelists the operator for the MCP/agent validation path via `operators_for()`.
- Tests: updated operator-set expectations; added validation-matrix cases (`not_regexp` valid for STRING, invalid for INTEGER).
- The positive `CONTAINS` is deliberately not advertised: the UI's "contains" already travels as ES `regexp` via the `like` advertisement, and a second positive contains would render as a duplicate. A companion orchestrator-ui-library PR maps `not_regexp` → react-querybuilder's `doesNotContain`.

## Related Issues
Fixes https://git.ia.surf.nl/netdev/automation/projects/orchestrator/-/work_items/2896
orchestrator-ui-library https://github.com/workfloworchestrator/orchestrator-ui-library/pull/2706

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
