### PR TITLE
Documentation: restore old index, update 5.0 guide to mention the UI, move guides up

### DIFF
--- a/docs/guides/upgrading/5.0.md
+++ b/docs/guides/upgrading/5.0.md
@@ -7,6 +7,12 @@ If you are not yet using v4.x, please consult the 4.0 upgrade guide first.
 If you are using scheduled tasks and/or workflow authorization callbacks, please consult the 4.7 and 4.8 upgrades first
 as well.
 
+## Orchestrator UI compatibility
+
+Upgrade `@orchestrator-ui/orchestrator-ui-components` to **8.1** when upgrading to Core 5.0.
+This is the recommended minimum UI version for Core 5.0.
+The UI upgrade guides can be found in the [Orchestrator UI Library docs](../../../../orchestrator-ui-library/).
+
 ## About 5.0
 
 In this release, the following breaking changes are introduced:

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,9 @@ This **Workflow Orchestrator** provides a framework through which you can manage
 framework helps and guides **you**, the person who needs to get things done, through the steps from
 automation to orchestration. With an easy to use set of API's and examples, you should be up and running and seeing
 results, before you completely understand all ins and outs of the project. The Workflow Orchestrator enables you to define
-products to which users can subscribe, and helps you intelligently manage the lifecycle, with the use of **Creation**, 
+products to which users can subscribe, and helps you intelligently manage the lifecycle, with the use of **Creation**,
 **Modification**, **Termination** and **Validation** workflows, of resources that you provide to your users.
-The Application extends a FastAPI application and therefore can make use of all the awesome features of FastAPI, 
+The Application extends a FastAPI application and therefore can make use of all the awesome features of FastAPI,
 pydantic and async python.
 
 ## What does a workflow look like? It must be pretty complex!!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,79 @@
-# Introduction
+---
+hide:
+  - toc
+---
 
-orchestrator-core is a workflow engine, built in Python on top of FastAPI and Pydantic.
-It allows to manage the lifecycle of customer-facing and resource-facing products.
+<p align="center"><em>Production ready Workflow Orchestration Framework to manage product lifecycle and workflows. Easy to use, Built on top of FastAPI</em></p>
 
-A product is defined as a collection of `ProductBlock`s and `ResourceType`s. Subscribing a customer to a product
-creates a `Subscription`, and workflows move that subscription through its lifecycle: `Initial`, `Provisioning`,
-`Active`, `Terminated`. A workflow is a list of Python functions, executed in order by the engine, each storing its
-result to the database so it can be retried from that point if it fails.
+<p align="center">
+    <a href="https://pepy.tech/project/orchestrator-core" target="_blank">
+    <img src="https://pepy.tech/badge/orchestrator-core/month" alt="Downloads">
+    </a>
+    <a href="https://codecov.io/gh/workfloworchestrator/orchestrator-core" target="_blank">
+    <img src="https://codecov.io/gh/workfloworchestrator/orchestrator-core/branch/main/graph/badge.svg?token=5ANQFI2DHS" alt="Coverage">
+    </a>
+    <a href="https://pypi.org/project/orchestrator-core" target="_blank">
+    <img src="https://img.shields.io/pypi/v/orchestrator-core?color=%2334D058&label=pypi%20package" alt="Pypi">
+    </a>
+    <a>  
+    <img alt="Discord" src="https://img.shields.io/discord/1295834294270558280?style=flat-square&logo=discord&label=discord">
+    </a>
 
-Start with [Getting Started](getting-started/versions.md) to install and run the orchestrator, or
-[Architecture](architecture/tldr.md) for how it's put together.
+</p>
+<br>
+<br>
+__The Workflow Orchestrator is a project developed by [SURF](https://www.surf.nl) to facilitate the orchestration of services.
+Together with [ESnet](https://www.es.net) this project has been open-sourced in [the commons conservancy](https://commonsconservancy.org)
+to help facilitate collaboration. We invite all who are interested to take a look and to contribute!__
+
+## Orchestration
+
+When do you orchestrate and when do you automate? The answer is you probably need both. Automation helps you execute repetitive
+tasks reliably and easily. Orchestration adds a layer and allows you to add more intelligence to the tasks you need to automate and
+to have a complete audit log of changes.
+
+> #### Orchestrate[*](https://www.lexico.com/en/definition/orchestrate) - Transitive Verb
+> /ˈôrkəˌstrāt/ /ˈɔrkəˌstreɪt/
+>
+>   1: Arrange or score (music) for orchestral performance.
+>   *‘the song cycle was stunningly arranged and orchestrated’*
+>
+>   2:  Arrange or direct the elements of (a situation) to produce a desired effect, especially surreptitiously.
+>   *‘the developers were able to orchestrate a favorable media campaign’*
+
+## Project Goal
+
+This **Workflow Orchestrator** provides a framework through which you can manage service orchestration for your end-users. The
+framework helps and guides **you**, the person who needs to get things done, through the steps from
+automation to orchestration. With an easy to use set of API's and examples, you should be up and running and seeing
+results, before you completely understand all ins and outs of the project. The Workflow Orchestrator enables you to define
+products to which users can subscribe, and helps you intelligently manage the lifecycle, with the use of **Creation**, 
+**Modification**, **Termination** and **Validation** workflows, of resources that you provide to your users.
+The Application extends a FastAPI application and therefore can make use of all the awesome features of FastAPI, 
+pydantic and async python.
+
+## What does a workflow look like? It must be pretty complex!!
+
+Programming a new workflow should be really easy, and at its core it is. By defining workflows as Python functions,
+all you need to do is understand how to write basic python code, the framework will help take care of the rest.
+
+```python
+@workflow("Name of the workflow", initial_input_form=input_form_generator)
+def workflow():
+    return (
+        init
+        >> arbitrary_step_func_1
+        >> arbitrary_step_func_2
+        >> arbitrary_step_func_3
+        >> done
+    )
+```
+
+## I'm convinced! Show me more!
+
+There are a number of options for getting started:
+
+- For those of you who would like to see it working, take a look at [this repo](https://github.com/workfloworchestrator/example-orchestrator) and follow the README to setup a
+  docker-compose so you can experiment on your localhost.
+- For those who are more adventurous, follow the guide on the [next page](getting-started/base.md) to
+  start coding right away.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,22 @@ nav:
       - Docker: getting-started/docker.md
       - Orchestrator UI: getting-started/orchestration-ui.md
       - Orchestrator Shell: getting-started/orchestrator-shell.md
+  - Guides:
+      - Product Modeling:
+          - Importing Existing Products: guides/product-modeling/imports.md
+          - Backfilling Existing Subscriptions: guides/product-modeling/backfilling.md
+      - Creating Tasks and Schedules: guides/tasks.md
+      - Testing: guides/testing.md
+      - Scaling the Orchestrator: guides/scaling.md
+      - Pausing the Orchestrator: guides/pause-and-resume.md
+      - Generating a Config File: guides/generate-config-file.md
+      - Upgrade Guides:
+          - v2.x: guides/upgrading/2.0.md
+          - v3.x: guides/upgrading/3.0.md
+          - v4.x: guides/upgrading/4.0.md
+          - v4.7: guides/upgrading/4.7.md
+          - v4.8: guides/upgrading/4.8.md
+          - v5.0: guides/upgrading/5.0.md
   - Architecture:
       - Architecture; TL;DR: architecture/tldr.md
       - Orchestration Philosophy: architecture/orchestration/philosophy.md
@@ -162,22 +178,6 @@ nav:
       - Extensibility:
           - Packaging: architecture/extensibility/packaging.md
           - Optional Modules: architecture/extensibility/modules.md
-  - Guides:
-      - Product Modeling:
-          - Importing Existing Products: guides/product-modeling/imports.md
-          - Backfilling Existing Subscriptions: guides/product-modeling/backfilling.md
-      - Creating Tasks and Schedules: guides/tasks.md
-      - Testing: guides/testing.md
-      - Scaling the Orchestrator: guides/scaling.md
-      - Pausing the Orchestrator: guides/pause-and-resume.md
-      - Generating a Config File: guides/generate-config-file.md
-      - Upgrade Guides:
-          - v2.x: guides/upgrading/2.0.md
-          - v3.x: guides/upgrading/3.0.md
-          - v4.x: guides/upgrading/4.0.md
-          - v4.7: guides/upgrading/4.7.md
-          - v4.8: guides/upgrading/4.8.md
-          - v5.0: guides/upgrading/5.0.md
   - Reference Documentation:
       - TL;DR: reference-docs/tldr.md
       - API docs:


### PR DESCRIPTION
## Summary

* Point 5.0 upgrade guide to the Orchestrator UI upgrade guides (#1765)
* Restore the old documentation index with some updates
* Move guides above architecture

## Related Issues

Relates to https://github.com/workfloworchestrator/orchestrator-core/issues/1765

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
