### PR TITLE
Feature/1269 store process subscription

### DIFF
--- a/docs/guides/product-modeling/imports.md
+++ b/docs/guides/product-modeling/imports.md
@@ -29,7 +29,23 @@ user input from a form page, but could also be provided programmatically by eith
 called. Data sources can include external API resources, CSV- or YAML files, etc. If desired, interaction with all
 external provisioning systems can be skipped, resulting in a creation workflow that could be as simple as follows.
 
-=== "`orchestrator-core` ≥ 5.0"
+=== "`orchestrator-core` ≥ 5.1"
+
+    ```python
+    from orchestrator.core.workflow import StepList, begin
+    from orchestrator.core.workflows.utils import create_workflow
+
+    @create_workflow("Create imported Node")
+    def create_imported_node() -> StepList:
+        """Workflow to import a Node without provisioning it."""
+        return (
+            begin
+            >> create_subscription
+            >> initialize_subscription
+        )
+    ```
+
+=== "`orchestrator-core` == 5.0"
 
     ```python
     from orchestrator.core.workflow import StepList, begin

--- a/docs/guides/product-modeling/imports.md
+++ b/docs/guides/product-modeling/imports.md
@@ -29,7 +29,7 @@ user input from a form page, but could also be provided programmatically by eith
 called. Data sources can include external API resources, CSV- or YAML files, etc. If desired, interaction with all
 external provisioning systems can be skipped, resulting in a creation workflow that could be as simple as follows.
 
-=== "`orchestrator-core` ≥ 5.1"
+=== "`orchestrator-core` ≥ 5.4"
 
     ```python
     from orchestrator.core.workflow import StepList, begin

--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -260,7 +260,7 @@ requests confirmation before proceeding:
 Finally, we wire this all up in our StepList. Instead of including the step
 directly, provide the step as a parameter to the interaction function:
 
-=== "`orchestrator-core` ≥ 5.1"
+=== "`orchestrator-core` ≥ 5.4"
 
     ```python
     from orchestrator.core.types import SubscriptionLifecycle

--- a/docs/reference-docs/workflows/callbacks.md
+++ b/docs/reference-docs/workflows/callbacks.md
@@ -260,10 +260,28 @@ requests confirmation before proceeding:
 Finally, we wire this all up in our StepList. Instead of including the step
 directly, provide the step as a parameter to the interaction function:
 
-=== "`orchestrator-core` ≥ 5.0"
+=== "`orchestrator-core` ≥ 5.1"
 
     ```python
     from orchestrator.core.types import SubscriptionLifecycle
+    from orchestrator.core.workflows.utils import create_workflow
+
+
+    @create_workflow("Example workflow", initial_input_form=initial_input_form_generator)
+    def create_l2vpn() -> StepList:
+        return (
+            begin
+            >> construct_model
+            >> callback_interaction(call_ansible_playbook)
+            >> set_status(SubscriptionLifecycle.ACTIVE)
+        )
+    ```
+
+=== "`orchestrator-core` == 5.0"
+
+    ```python
+    from orchestrator.core.types import SubscriptionLifecycle
+    from orchestrator.core.workflows.steps import store_process_subscription
     from orchestrator.core.workflows.utils import create_workflow
 
 
@@ -282,6 +300,7 @@ directly, provide the step as a parameter to the interaction function:
 
     ```python
     from orchestrator.types import SubscriptionLifecycle
+    from orchestrator.workflows.steps import store_process_subscription
     from orchestrator.workflows.utils import create_workflow
 
 

--- a/orchestrator/core/cli/generator/templates/create_product.j2
+++ b/orchestrator/core/cli/generator/templates/create_product.j2
@@ -25,7 +25,6 @@ from orchestrator.core.forms import FormPage
 from orchestrator.core.forms.validators import Divider, Label, CustomerId, MigrationSummary
 from orchestrator.core.types import SubscriptionLifecycle
 from orchestrator.core.workflow import StepList, begin, step
-from orchestrator.core.workflows.steps import store_process_subscription
 from orchestrator.core.workflows.utils import create_workflow
 
 {%- for namespace, type in types_to_import %}
@@ -129,6 +128,5 @@ def create_{{ product.variable }}() -> StepList:
     return (
         begin
         >> construct_{{ product.variable }}_model
-        >> store_process_subscription()
         # TODO add provision step(s)
     )

--- a/orchestrator/core/domain/base.py
+++ b/orchestrator/core/domain/base.py
@@ -63,6 +63,7 @@ from orchestrator.core.domain.subscription_instance_transform import (
     field_transformation_rules,
     transform_instance_fields,
 )
+from orchestrator.core.services.process_subscription import store_process_subscription_relation
 from orchestrator.core.services.products import get_product_by_id
 from orchestrator.core.types import (
     SAFE_USED_BY_TRANSITIONS_FOR_STATUS,
@@ -1197,6 +1198,7 @@ class SubscriptionModel(DomainModel):
         product_id: UUID | UUIDstr,
         customer_id: str,
         status: SubscriptionLifecycle = SubscriptionLifecycle.INITIAL,
+        process_id: UUID | UUIDstr | None = None,
         description: str | None = None,
         insync: bool = False,
         start_date: datetime | None = None,
@@ -1238,6 +1240,9 @@ class SubscriptionModel(DomainModel):
             version=version,
         )
         db.session.add(subscription)
+
+        if process_id:
+            store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
 
         fixed_inputs = {fi.name: fi.value for fi in product_db.fixed_inputs}
         instances = cls._init_instances(subscription_id)

--- a/orchestrator/core/services/process_subscription.py
+++ b/orchestrator/core/services/process_subscription.py
@@ -1,0 +1,37 @@
+# Copyright 2026 GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import UUID
+
+from orchestrator.core.db import ProcessSubscriptionTable, db
+from pydantic_forms.types import UUIDstr
+
+
+def store_process_subscription_relation(process_id: UUID | UUIDstr, subscription_id: UUID | UUIDstr) -> None:
+    """Idempotently create a Process Subscription relation.
+
+    This method can get simplified once the `store_process_subscription` step has been removed from the codebase.
+    """
+
+    process_subscription_exists = db.session.query(
+        db.session.query(ProcessSubscriptionTable)
+        .where(
+            ProcessSubscriptionTable.process_id == process_id,
+            ProcessSubscriptionTable.subscription_id == subscription_id,
+        )
+        .exists()
+    ).scalar()
+
+    if not process_subscription_exists:
+        process_subscription = ProcessSubscriptionTable(process_id=process_id, subscription_id=subscription_id)
+        db.session.add(process_subscription)

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -30,7 +30,13 @@ from nwastdlib.ex import show_ex
 from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.api.error_handling import raise_status
 from orchestrator.core.config.assignee import Assignee
-from orchestrator.core.db import EngineSettingsTable, ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
+from orchestrator.core.db import (
+    EngineSettingsTable,
+    ProcessStepTable,
+    ProcessSubscriptionTable,
+    ProcessTable,
+    db,
+)
 from orchestrator.core.db.database import transactional
 from orchestrator.core.db.models import FAILED_REASON_LENGTH, TRACEBACK_LENGTH
 from orchestrator.core.distlock import distlock_manager
@@ -529,10 +535,13 @@ def create_process(
     with transactional(db, logger):
         _db_create_process(pstat)
         if user_inputs and (subscription_id := user_inputs[0].get("subscription_id")):
-            # Only store the Process Subscription relation if a subscription ID is present
+            # Only store the Process Subscription relation in workflows where if a subscription ID is present.
             # For creation workflows where this is not the case, this is handled in
             # `SubscriptionModel.from_product_id()`.
-            store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
+            # For tasks, this is not stored.
+            workflow_table = get_workflow_by_name(workflow.name)
+            if workflow_table and not workflow_table.is_task:
+                store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
         store_input_state(process_id, state | initial_state, "initial_state")
 
     return pstat

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -37,6 +37,7 @@ from orchestrator.core.distlock import distlock_manager
 from orchestrator.core.schemas.engine_settings import WorkerStatus
 from orchestrator.core.services.executors.types import ExecutorFunction
 from orchestrator.core.services.input_state import store_input_state
+from orchestrator.core.services.process_subscription import store_process_subscription_relation
 from orchestrator.core.services.workflows import get_workflow_by_name
 from orchestrator.core.settings import ExecutorType, app_settings
 from orchestrator.core.types import BroadcastFunc
@@ -527,6 +528,11 @@ def create_process(
 
     with transactional(db, logger):
         _db_create_process(pstat)
+        if user_inputs and (subscription_id := user_inputs[0].get("subscription_id")):
+            # Only store the Process Subscription relation if a subscription ID is present
+            # For creation workflows where this is not the case, this is handled in
+            # `SubscriptionModel.from_product_id()`.
+            store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
         store_input_state(process_id, state | initial_state, "initial_state")
 
     return pstat

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -535,7 +535,7 @@ def create_process(
     with transactional(db, logger):
         _db_create_process(pstat)
         if user_inputs and (subscription_id := user_inputs[0].get("subscription_id")):
-            # Only store the Process Subscription relation in workflows where if a subscription ID is present.
+            # Only store the Process Subscription relation in workflows where a subscription ID is present.
             # For creation workflows where this is not the case, this is handled in
             # `SubscriptionModel.from_product_id()`.
             # For tasks, this is not stored.

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -76,7 +76,7 @@ from orchestrator.core.workflows import get_workflow
 from orchestrator.core.workflows.removed_workflow import removed_workflow
 from pydantic_forms.core import post_form
 from pydantic_forms.exceptions import FormValidationError
-from pydantic_forms.types import State
+from pydantic_forms.types import State, UUIDstr
 
 logger = structlog.get_logger(__name__)
 
@@ -532,16 +532,22 @@ def create_process(
         user_model=user_model,
     )
 
+    def _sid_in_initial_user_input(user_inputs: list[State] | None) -> UUIDstr | None:
+        return user_inputs[0].get("subscription_id") if user_inputs else None
+
+    def _is_proper_workflow(workflow_name: str) -> bool:
+        """Returns true if the workflow exists in the database and is NOT a task."""
+        workflow_table = get_workflow_by_name(workflow_name)
+        return not workflow_table.is_task if workflow_table else True
+
     with transactional(db, logger):
         _db_create_process(pstat)
-        if user_inputs and (subscription_id := user_inputs[0].get("subscription_id")):
-            # Only store the Process Subscription relation in workflows where a subscription ID is present.
-            # For creation workflows where this is not the case, this is handled in
-            # `SubscriptionModel.from_product_id()`.
-            # For tasks, this is not stored.
-            workflow_table = get_workflow_by_name(workflow.name)
-            if workflow_table and not workflow_table.is_task:
-                store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
+        # Only store the Process Subscription relation in workflows where a subscription ID is present.
+        # For creation workflows where this is not the case, this is handled in
+        # `SubscriptionModel.from_product_id()`.
+        # For tasks, this is never stored.
+        if (subscription_id := _sid_in_initial_user_input(user_inputs)) and _is_proper_workflow(workflow.name):
+            store_process_subscription_relation(process_id=process_id, subscription_id=subscription_id)
         store_input_state(process_id, state | initial_state, "initial_state")
 
     return pstat

--- a/orchestrator/core/workflows/modify_note.py
+++ b/orchestrator/core/workflows/modify_note.py
@@ -22,7 +22,7 @@ from orchestrator.core.settings import get_authorizers
 from orchestrator.core.targets import Target
 from orchestrator.core.utils.json import to_serializable
 from orchestrator.core.workflow import StepList, done, init, step, workflow
-from orchestrator.core.workflows.steps import refresh_subscription_search_index, store_process_subscription
+from orchestrator.core.workflows.steps import refresh_subscription_search_index
 from orchestrator.core.workflows.utils import wrap_modify_initial_input_form
 from pydantic_forms.types import FormGenerator, State, UUIDstr
 from pydantic_forms.validators import LongText
@@ -66,4 +66,4 @@ def store_subscription_note(subscription_id: UUIDstr, note: str) -> State:
     retry_auth_callback=authorizers.retry_auth_callback,
 )
 def modify_note() -> StepList:
-    return init >> store_process_subscription() >> store_subscription_note >> refresh_subscription_search_index >> done
+    return init >> store_subscription_note >> refresh_subscription_search_index >> done

--- a/orchestrator/core/workflows/steps.py
+++ b/orchestrator/core/workflows/steps.py
@@ -15,9 +15,8 @@ from copy import deepcopy
 import structlog
 from pydantic import ValidationError
 
-from orchestrator.core.db import db
-from orchestrator.core.db.models import ProcessSubscriptionTable
 from orchestrator.core.domain.base import SubscriptionModel
+from orchestrator.core.services.process_subscription import store_process_subscription_relation
 from orchestrator.core.services.settings import reset_search_index
 from orchestrator.core.services.subscriptions import get_subscription
 from orchestrator.core.targets import Target
@@ -109,23 +108,22 @@ def unsync_unchecked(subscription_id: UUIDstr) -> State:
     return {"subscription": subscription}
 
 
-def store_process_subscription_relationship(process_id: UUIDstr, subscription_id: UUIDstr) -> ProcessSubscriptionTable:
-    process_subscription = ProcessSubscriptionTable(process_id=process_id, subscription_id=subscription_id)
-    db.session.add(process_subscription)
-    return process_subscription
-
-
 def store_process_subscription(workflow_target: Target | None = None) -> Step:
     if workflow_target:
-        deprecation_warning = (
+        target_deprecation_warning = (
             "Providing a workflow target to function store_process_subscription() is deprecated. "
             "This information is already stored in the workflow table."
         )
-        logger.warning(deprecation_warning)
+        logger.warning(target_deprecation_warning)
+
+    deprecation_warning = (
+        "Calling store_process_subscription directly is deprecated. This is already taken care of by orchestrator-core."
+    )
+    logger.warning(deprecation_warning)
 
     @step("Create Process Subscription relation")
     def _store_process_subscription(process_id: UUIDstr, subscription_id: UUIDstr) -> None:
-        store_process_subscription_relationship(process_id, subscription_id)
+        store_process_subscription_relation(process_id, subscription_id)
 
     return _store_process_subscription
 

--- a/orchestrator/core/workflows/utils.py
+++ b/orchestrator/core/workflows/utils.py
@@ -47,7 +47,6 @@ from orchestrator.core.workflows.steps import (
     refresh_subscription_search_index,
     resync,
     set_status,
-    store_process_subscription,
     unsync,
     unsync_unchecked,
 )
@@ -360,7 +359,6 @@ def modify_workflow(
     def _modify_workflow(f: Callable[[], StepList]) -> Workflow:
         steplist = (
             init
-            >> store_process_subscription()
             >> unsync
             >> f()
             >> (additional_steps or StepList())
@@ -417,7 +415,6 @@ def terminate_workflow(
     def _terminate_workflow(f: Callable[[], StepList]) -> Workflow:
         steplist = (
             init
-            >> store_process_subscription()
             >> unsync
             >> f()
             >> (additional_steps or StepList())
@@ -467,7 +464,7 @@ def validate_workflow(
         _warn_description_deprecated()
 
     def _validate_workflow(f: Callable[[], StepList]) -> Workflow:
-        steplist = init >> store_process_subscription() >> unsync_unchecked >> f() >> resync >> done
+        steplist = init >> unsync_unchecked >> f() >> resync >> done
 
         return make_workflow(
             f,
@@ -515,7 +512,6 @@ def reconcile_workflow(
     def _reconcile_workflow(f: Callable[[], StepList]) -> Workflow:
         steplist = (
             init
-            >> store_process_subscription()
             >> unsync_unchecked
             >> f()
             >> (additional_steps or StepList())

--- a/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
@@ -75,6 +75,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
 def construct_example1_model(
     product: UUIDstr,
     customer_id: UUIDstr,
+    process_id: UUIDstr,
     example_str_enum_1: ExampleStrEnum1,
     unmodifiable_str: str,
     modifiable_boolean: bool,
@@ -84,6 +85,7 @@ def construct_example1_model(
     example1 = Example1Inactive.from_product_id(
         product_id=product,
         customer_id=customer_id,
+        process_id=process_id,
         status=SubscriptionLifecycle.INITIAL,
     )
     example1.example1.example_str_enum_1 = example_str_enum_1

--- a/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example1/create_example1.py
@@ -19,7 +19,6 @@ from orchestrator.core.forms.summary_form import base_summary
 from orchestrator.core.forms.validators import CustomerId, Divider, Label
 from orchestrator.core.types import SubscriptionLifecycle
 from orchestrator.core.workflow import StepList, begin, step
-from orchestrator.core.workflows.steps import store_process_subscription
 from orchestrator.core.workflows.utils import create_workflow
 from pydantic import AfterValidator, ConfigDict
 from pydantic_forms.types import FormGenerator, State, UUIDstr
@@ -109,6 +108,6 @@ additional_steps = begin
 @create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example1() -> StepList:
     return (
-        begin >> construct_example1_model >> store_process_subscription()
+        begin >> construct_example1_model
         # TODO add provision step(s)
     )

--- a/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
@@ -59,12 +59,14 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
 @step("Construct Subscription model")
 def construct_example2_model(
     product: UUIDstr,
+    process_id: UUIDstr,
     customer_id: UUIDstr,
     example_int_enum_2: ExampleIntEnum2 | None,
 ) -> State:
     example2 = Example2Inactive.from_product_id(
         product_id=product,
         customer_id=customer_id,
+        process_id=process_id,
         status=SubscriptionLifecycle.INITIAL,
     )
     example2.example2.example_int_enum_2 = example_int_enum_2

--- a/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example2/create_example2.py
@@ -17,7 +17,6 @@ from orchestrator.core.forms import FormPage
 from orchestrator.core.forms.validators import CustomerId, Divider, Label
 from orchestrator.core.types import SubscriptionLifecycle
 from orchestrator.core.workflow import StepList, begin, step
-from orchestrator.core.workflows.steps import store_process_subscription
 from orchestrator.core.workflows.utils import create_workflow
 from pydantic import ConfigDict
 from pydantic_forms.types import FormGenerator, State, UUIDstr
@@ -86,6 +85,6 @@ additional_steps = begin
 @create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example2() -> StepList:
     return (
-        begin >> construct_example2_model >> store_process_subscription()
+        begin >> construct_example2_model
         # TODO add provision step(s)
     )

--- a/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
@@ -58,12 +58,14 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
 @step("Construct Subscription model")
 def construct_example4_model(
     product: UUIDstr,
+    process_id: UUIDstr,
     customer_id: UUIDstr,
     num_val: int | None,
 ) -> State:
     example4 = Example4Inactive.from_product_id(
         product_id=product,
         customer_id=customer_id,
+        process_id=process_id,
         status=SubscriptionLifecycle.INITIAL,
     )
     example4.example4.num_val = num_val

--- a/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
+++ b/test/acceptance_tests/cli/data/generate/workflows/example4/create_example4.py
@@ -17,7 +17,6 @@ from orchestrator.core.forms import FormPage
 from orchestrator.core.forms.validators import CustomerId, Divider, Label
 from orchestrator.core.types import SubscriptionLifecycle
 from orchestrator.core.workflow import StepList, begin, step
-from orchestrator.core.workflows.steps import store_process_subscription
 from orchestrator.core.workflows.utils import create_workflow
 from pydantic import ConfigDict
 from pydantic_forms.types import FormGenerator, State, UUIDstr
@@ -85,6 +84,6 @@ additional_steps = begin
 @create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_example4() -> StepList:
     return (
-        begin >> construct_example4_model >> store_process_subscription()
+        begin >> construct_example4_model
         # TODO add provision step(s)
     )

--- a/test/integration_tests/services/test_process_subscription.py
+++ b/test/integration_tests/services/test_process_subscription.py
@@ -58,11 +58,30 @@ def test_process_subscription_relation_is_idempotent(generic_subscription_1):
         ).one()
 
 
+def test_process_subscription_none_for_task(generic_subscription_1):
+    class Form(FormPage):
+        subscription_id: UUID
+
+    @workflow(target=Target.VALIDATE, initial_input_form=const(Form))
+    def test_store_process_subscription():
+        return init >> done
+
+    with WorkflowInstanceForTests(test_store_process_subscription, "test_store_process_subscription"):
+        result, _, _ = run_workflow("test_store_process_subscription", [{"subscription_id": generic_subscription_1}])
+
+        assert_complete(result)
+        state = extract_state(result)
+        with pytest.raises(NoResultFound):
+            db.session.query(ProcessSubscriptionTable).filter(
+                ProcessSubscriptionTable.process_id == state["process_id"]
+            ).one()
+
+
 def test_process_subscription_relation_stored_in_workflow(generic_subscription_1):
     class Form(FormPage):
         subscription_id: UUID
 
-    @workflow(target=Target.SYSTEM, initial_input_form=const(Form))
+    @workflow(target=Target.MODIFY, initial_input_form=const(Form))
     def test_store_process_subscription():
         return init >> done
 

--- a/test/integration_tests/services/test_process_subscription.py
+++ b/test/integration_tests/services/test_process_subscription.py
@@ -105,7 +105,7 @@ def test_process_subscription_relation_stored_in_create_workflow(generic_product
         yield WaitForm
         return {}
 
-    @step("Create new subscription")
+    @step("Create new subscription")  # type: ignore[untyped-decorator]
     def create_subscription(process_id: UUIDstr) -> State:
         GenericProductOneInactive, _ = generic_product_type_1
         gen_subscription = GenericProductOneInactive.from_product_id(

--- a/test/integration_tests/services/test_process_subscription.py
+++ b/test/integration_tests/services/test_process_subscription.py
@@ -1,0 +1,117 @@
+# Copyright 2026 GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy.exc import NoResultFound
+
+from nwastdlib import const
+from orchestrator.core.config.assignee import Assignee
+from orchestrator.core.db import ProcessSubscriptionTable, db
+from orchestrator.core.targets import Target
+from orchestrator.core.workflow import done, init, inputstep, step, workflow
+from orchestrator.core.workflows.steps import store_process_subscription
+from pydantic_forms.core import FormPage
+from pydantic_forms.types import State, UUIDstr
+from test.integration_tests.workflows import (
+    WorkflowInstanceForTests,
+    assert_complete,
+    assert_suspended,
+    extract_state,
+    resume_workflow,
+    run_workflow,
+)
+
+CUSTOMER_ID: str = "f962d204-816a-4d7d-862a-3b4b4a42021a"
+
+
+def test_process_subscription_relation_is_idempotent(generic_subscription_1):
+    class Form(FormPage):
+        subscription_id: UUID
+
+    @workflow(target=Target.SYSTEM, initial_input_form=const(Form))
+    def test_store_process_subscription():
+        return (
+            init >> store_process_subscription() >> store_process_subscription() >> store_process_subscription() >> done
+        )
+
+    with WorkflowInstanceForTests(test_store_process_subscription, "test_store_process_subscription"):
+        result, _, _ = run_workflow("test_store_process_subscription", [{"subscription_id": generic_subscription_1}])
+
+        assert_complete(result)
+        state = extract_state(result)
+        db.session.query(ProcessSubscriptionTable).filter(
+            ProcessSubscriptionTable.process_id == state["process_id"],
+            ProcessSubscriptionTable.subscription_id == state["subscription_id"],
+        ).one()
+
+
+def test_process_subscription_relation_stored_in_workflow(generic_subscription_1):
+    class Form(FormPage):
+        subscription_id: UUID
+
+    @workflow(target=Target.SYSTEM, initial_input_form=const(Form))
+    def test_store_process_subscription():
+        return init >> done
+
+    with WorkflowInstanceForTests(test_store_process_subscription, "test_store_process_subscription"):
+        result, _, _ = run_workflow("test_store_process_subscription", [{"subscription_id": generic_subscription_1}])
+
+        assert_complete(result)
+        state = extract_state(result)
+        db.session.query(ProcessSubscriptionTable).filter(
+            ProcessSubscriptionTable.process_id == state["process_id"],
+            ProcessSubscriptionTable.subscription_id == state["subscription_id"],
+        ).one()
+
+
+def test_process_subscription_relation_stored_in_create_workflow(generic_product_1, generic_product_type_1):
+    @inputstep("Suspended", assignee=Assignee.SYSTEM)
+    def suspend():
+        class WaitForm(FormPage):
+            pass
+
+        yield WaitForm
+        return {}
+
+    @step("Create new subscription")
+    def create_subscription(process_id: UUIDstr) -> State:
+        GenericProductOneInactive, _ = generic_product_type_1
+        gen_subscription = GenericProductOneInactive.from_product_id(
+            generic_product_1.product_id, process_id=process_id, customer_id=CUSTOMER_ID, insync=True
+        )
+        return {"subscription": gen_subscription, "subscription_id": gen_subscription.subscription_id}
+
+    @workflow(target=Target.CREATE, initial_input_form=const(FormPage))
+    def test_store_process_subscription():
+        return init >> suspend >> create_subscription >> done
+
+    with WorkflowInstanceForTests(test_store_process_subscription, "test_store_process_subscription"):
+        result, process, step_log = run_workflow("test_store_process_subscription", {})
+        state = extract_state(result)
+        assert_suspended(result)
+        with pytest.raises(NoResultFound):
+            db.session.query(ProcessSubscriptionTable).where(
+                ProcessSubscriptionTable.process_id == state["process_id"]
+            ).one()
+
+        result, _ = resume_workflow(process, step_log, {})
+        assert_complete(result)
+
+        state = extract_state(result)
+        db.session.query(ProcessSubscriptionTable).where(
+            ProcessSubscriptionTable.process_id == state["process_id"],
+            ProcessSubscriptionTable.subscription_id == state["subscription_id"],
+        ).one()

--- a/test/integration_tests/workflows/test_workflow.py
+++ b/test/integration_tests/workflows/test_workflow.py
@@ -636,14 +636,14 @@ def test_step_group_with_inputform_resume():
     group = step_group("Multistep", begin >> step2 >> user_action >> validate_name)
 
     class Form(FormPage):
-        subscription_id: UUID
+        id: UUID
 
     @workflow(target=Target.CREATE, initial_input_form=const(Form))
     def test_wf():
         return init >> step1 >> group >> step3 >> done
 
     with WorkflowInstanceForTests(test_wf, "step_group_test_workflow"):
-        init_state = {"subscription_id": uuid4()}
+        init_state = {"id": uuid4()}
 
         result, process, step_log = run_workflow("step_group_test_workflow", init_state)
 

--- a/test/unit_tests/workflows/test_steps.py
+++ b/test/unit_tests/workflows/test_steps.py
@@ -156,7 +156,7 @@ def test_store_process_subscription_target_deprecation_warning():
 
     with patch("orchestrator.core.workflows.steps.logger") as mock_logger:
         store_process_subscription(Target.CREATE)
-        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_count == 2
         assert "deprecated" in mock_logger.warning.call_args[0][0].lower()
 
 

--- a/test/unit_tests/workflows/test_steps.py
+++ b/test/unit_tests/workflows/test_steps.py
@@ -151,11 +151,18 @@ def test_unsync_unchecked_works_when_already_out_of_sync(mock_from_sub, mock_inv
 # --- store_process_subscription ---
 
 
-def test_store_process_subscription_deprecation_warning():
+def test_store_process_subscription_target_deprecation_warning():
     from orchestrator.core.targets import Target
 
     with patch("orchestrator.core.workflows.steps.logger") as mock_logger:
         store_process_subscription(Target.CREATE)
+        mock_logger.warning.assert_called_once()
+        assert "deprecated" in mock_logger.warning.call_args[0][0].lower()
+
+
+def test_store_process_subscription_deprecation_warning():
+    with patch("orchestrator.core.workflows.steps.logger") as mock_logger:
+        store_process_subscription()
         mock_logger.warning.assert_called_once()
         assert "deprecated" in mock_logger.warning.call_args[0][0].lower()
 

--- a/test/unit_tests/workflows/test_utils.py
+++ b/test/unit_tests/workflows/test_utils.py
@@ -50,7 +50,6 @@ def test_reconcile_workflow_basic():
 
     expected_steps = [
         "Start",
-        "Create Process Subscription relation",
         "Lock subscription",
         "Done",
         "Unlock subscription",
@@ -78,7 +77,6 @@ def test_reconcile_workflow_additional_steps():
     step_names = [step.name for step in workflow.steps]
     expected_steps = [
         "Start",
-        "Create Process Subscription relation",
         "Lock subscription",
         "Done",
         "Extra Step",
@@ -106,7 +104,6 @@ def test_reconcile_workflow_empty_function_steps():
     step_names = [step.name for step in workflow.steps]
     expected_steps = [
         "Start",
-        "Create Process Subscription relation",
         "Lock subscription",
         "Unlock subscription",
         "Refresh subscription search index",


### PR DESCRIPTION
## Summary
Deprecate using the `store_process_subscription()` step in favor of having orchestrator-core do that automatically. It will:

* Store when creating a workflow (modify, terminate)
* **not** store when this workflow is a task (system, validate) or a creation workflow
* Store when calling `SubscriptionModel.from_product_id()` with a `process_id`

The function is idempotent, so we only store if not exists. The old step also still works, but now emits a deprecation warning.

## Related Issues
Fixes #1269

## Type of change
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
