### PR TITLE
Feature/1729 rework last status handling

### DIFF
--- a/docs/reference-docs/workflows/process-step-handler.md
+++ b/docs/reference-docs/workflows/process-step-handler.md
@@ -1,0 +1,27 @@
+# Custom Process Step Handler
+
+After each workflow step is completed, the Orchestrator will store the output of this step in the `Process` table in the
+subscription database. By default, this will update the `last_status`, and in case the step was a failure, it will set
+the `failed_reason` and the `traceback`.
+
+You might want this function to include extra behaviour, custom error mapping, or special cases like setting the
+assignee of the process depending on step outcome. In this case, it is possible to override the default process function
+in `orchestrator.core.services.processes`. If you override this like the example below, you can include any kind of
+custom behaviour fit for your use-case.
+
+```python title="your_orchestrator/__init__.py"
+import orchestrator.core.services.processes
+
+def my_custom_handler(p: ProcessTable, process_state: WFProcess) -> ProcessTable:
+    """I want to set my custom assignees based on step outcome!"""
+
+    step_state: State = process_state.unwrap()
+    if process_state.isfailed():
+        error_name = step_state.get("class")
+
+        p.failed_reason = step_state.get("error", default="Blame the intern.")
+        p.assignee = "not-me@worfloworchestrator.org"
+        p.traceback = f"An '{error_name}' occurred! Help!"
+
+orchestrator.core.services.processes.PROCESS_STEP_HANDLER = my_custom_handler
+```

--- a/docs/reference-docs/workflows/process-step-handler.md
+++ b/docs/reference-docs/workflows/process-step-handler.md
@@ -1,5 +1,7 @@
 # Custom Process Step Handler
 
+!!! info "Added in version 5.4"
+
 After each workflow step is completed, the Orchestrator will store the output of this step in the `Process` table in the
 subscription database. By default, this will update the `last_status`, and in case the step was a failure, it will set
 the `failed_reason` and the `traceback`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,6 +206,7 @@ nav:
           - Callback step: reference-docs/workflows/callbacks.md
           - Run Predicates: reference-docs/workflows/run-predicates.md
           - Summary Forms: reference-docs/workflows/summary-form.md
+          - Process Step Handler: reference-docs/workflows/process-step-handler.md
       - Websockets: reference-docs/websockets.md
       - Search: reference-docs/search.md
       - AI / Hybrid Search: reference-docs/ai-search.md

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -193,35 +193,22 @@ def delete_process(process_id: UUID) -> None:
 def _default_process_func(p: ProcessTable, process_state: WFProcess) -> ProcessTable:
     """Default behaviour for setting the `last_status` and Assignee of a process."""
     step_state: State = process_state.unwrap()
-    if process_state.isfailed() or process_state.iswaiting():
-        failed_reason = step_state.get("error")
-        # pop also removes the traceback from the dict
-        traceback = step_state.pop("traceback", None)
-
-        # Truncate failed_reason (from end) and traceback (from start) to fit database constraints
-        p.failed_reason = failed_reason[:FAILED_REASON_LENGTH] if failed_reason else failed_reason
-        p.traceback = traceback[-TRACEBACK_LENGTH:] if traceback else traceback
-
-        if process_state.isfailed() and p.is_task:
-            # Check if we need a special failed status:
-            match step_state.get("class"):
-                case InconsistentDataError.__name__:
-                    p.last_status = ProcessStatus.INCONSISTENT_DATA
-                case MaxRetryError.__name__ | ApiException.__name__:
-                    p.last_status = ProcessStatus.API_UNAVAILABLE
-                case _:
-                    p.last_status = ProcessStatus.FAILED
-
-    else:
-        p.failed_reason = None
-        p.traceback = None
+    if process_state.isfailed() and p.is_task:
+        # Check if we need a special failed status:
+        match step_state.get("class"):
+            case InconsistentDataError.__name__:
+                p.last_status = ProcessStatus.INCONSISTENT_DATA
+            case MaxRetryError.__name__ | ApiException.__name__:
+                p.last_status = ProcessStatus.API_UNAVAILABLE
+            case _:
+                p.last_status = ProcessStatus.FAILED
 
     return p
 
 
 #: The Process Step handler function is called before each step is to be stored in the database.
-#: By default, it will set the failed reason, traceback, and last status of the process.
-#: This function can be replaced by a custom `ProcessHandlerFunc` if the user needs custom behavior or error handling.
+#: By default, it will set the last status of the process.
+#: This function can be replaced by a custom `ProcessHandlerFunc` if the user needs custom behavior.
 PROCESS_STEP_HANDLER: ProcessHandlerFunc = _default_process_func
 
 
@@ -234,6 +221,20 @@ def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> P
     p.last_step = step.name
     p.last_status = process_state.overall_status
     p.assignee = step.assignee
+
+    step_state: State = process_state.unwrap()
+    if process_state.isfailed() or process_state.iswaiting():
+        failed_reason = step_state.get("error")
+        # pop also removes the traceback from the dict
+        traceback = step_state.pop("traceback", None)
+
+        # Truncate failed_reason (from end) and traceback (from start) to fit database constraints
+        p.failed_reason = failed_reason[:FAILED_REASON_LENGTH] if failed_reason else failed_reason
+        p.traceback = traceback[-TRACEBACK_LENGTH:] if traceback else traceback
+    else:
+        p.failed_reason = None
+        p.traceback = None
+
     return PROCESS_STEP_HANDLER(p, process_state)
 
 

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -22,21 +22,15 @@ from uuid import UUID, uuid4
 import structlog
 from deepmerge.merger import Merger
 from pytz import utc
+from requests.adapters import MaxRetryError
 from sqlalchemy import delete, select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 from sqlalchemy.orm import joinedload
 
 from nwastdlib.ex import show_ex
 from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.api.error_handling import raise_status
-from orchestrator.core.config.assignee import Assignee
-from orchestrator.core.db import (
-    EngineSettingsTable,
-    ProcessStepTable,
-    ProcessSubscriptionTable,
-    ProcessTable,
-    db,
-)
+from orchestrator.core.db import EngineSettingsTable, ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
 from orchestrator.core.db.database import transactional
 from orchestrator.core.db.models import FAILED_REASON_LENGTH, TRACEBACK_LENGTH
 from orchestrator.core.distlock import distlock_manager
@@ -48,7 +42,7 @@ from orchestrator.core.services.workflows import get_workflow_by_name
 from orchestrator.core.settings import ExecutorType, app_settings
 from orchestrator.core.types import BroadcastFunc
 from orchestrator.core.utils.datetime import nowtz
-from orchestrator.core.utils.errors import StartPredicateError, error_state_to_dict
+from orchestrator.core.utils.errors import ApiException, InconsistentDataError, StartPredicateError, error_state_to_dict
 from orchestrator.core.utils.json import json_dumps, json_loads
 from orchestrator.core.websocket import (
     broadcast_invalidate_status_counts,
@@ -81,6 +75,7 @@ from pydantic_forms.types import State, UUIDstr
 logger = structlog.get_logger(__name__)
 
 StateMerger = Merger([(dict, ["merge"])], ["override"], ["override"])
+ProcessHandlerFunc = Callable[[ProcessTable, WFProcess], ProcessTable]
 
 SYSTEM_USER = "SYSTEM"
 
@@ -195,14 +190,8 @@ def delete_process(process_id: UUID) -> None:
     broadcast_invalidate_status_counts()
 
 
-def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> ProcessTable:
-    p = db.session.get(ProcessTable, process_id)
-    if p is None:
-        raise ValueError(f"Failed to write failure step to process: process with PID {process_id} not found")
-
-    p.last_step = step.name
-    p.last_status = process_state.overall_status
-    p.assignee = step.assignee
+def _default_process_func(p: ProcessTable, process_state: WFProcess) -> ProcessTable:
+    """Default behaviour for setting the `last_status` and Assignee of a process."""
     step_state: State = process_state.unwrap()
     if process_state.isfailed() or process_state.iswaiting():
         failed_reason = step_state.get("error")
@@ -215,30 +204,37 @@ def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> P
 
         if process_state.isfailed() and p.is_task:
             # Check if we need a special failed status:
-            # If it is an AssertionError:
-            if step_state.get("class") == "AssertionError" or step_state.get("class") == "InconsistentData":
-                p.assignee = Assignee.NOC
-                p.last_status = ProcessStatus.INCONSISTENT_DATA
-            # If we encounter a connectivity issue with an underlying api:
-            elif step_state.get("class") == "MaxRetryError" or (
-                step_state.get("class") == "ApiException"
-                and step_state.get("status_code")
-                in (
-                    HTTPStatus.BAD_GATEWAY,
-                    HTTPStatus.SERVICE_UNAVAILABLE,
-                    HTTPStatus.GATEWAY_TIMEOUT,
-                )
-            ):
-                p.assignee = Assignee.SYSTEM
-                p.last_status = ProcessStatus.API_UNAVAILABLE
-            else:
-                p.assignee = Assignee.SYSTEM
+            match step_state.get("class"):
+                case InconsistentDataError.__name__:
+                    p.last_status = ProcessStatus.INCONSISTENT_DATA
+                case MaxRetryError.__name__ | ApiException.__name__:
+                    p.last_status = ProcessStatus.API_UNAVAILABLE
+                case _:
+                    p.last_status = ProcessStatus.FAILED
 
     else:
         p.failed_reason = None
         p.traceback = None
 
     return p
+
+
+#: The Process Step handler function is called before each step is to be stored in the database.
+#: By default, it will set the failed reason, traceback, and last status of the process.
+#: This function can be replaced by a custom `ProcessHandlerFunc` if the user needs custom behavior or error handling.
+PROCESS_STEP_HANDLER: ProcessHandlerFunc = _default_process_func
+
+
+def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> ProcessTable:
+    try:
+        p = db.session.query(ProcessTable).where(ProcessTable.process_id == process_id).one()
+    except NoResultFound as e:
+        raise ValueError(f"Failed to write step to process: process with PID {process_id} not found") from e
+
+    p.last_step = step.name
+    p.last_status = process_state.overall_status
+    p.assignee = step.assignee
+    return PROCESS_STEP_HANDLER(p, process_state)
 
 
 def ensure_correct_process_status(process_id: UUID, last_status: str) -> None:
@@ -819,7 +815,7 @@ def abort_process(process: ProcessTable, user: str, broadcast_func: Callable | N
     return abort_wf(pstat, partial(safe_logstep, broadcast_func=broadcast_func))
 
 
-def fail_awaiting_process(process: ProcessTable, broadcast_func: Callable | None = None) -> WFProcess:
+def fail_awaiting_process(process: ProcessTable, broadcast_func: BroadcastFunc | None = None) -> WFProcess:
     """Fail a process that has been stuck awaiting a callback past its timeout."""
     pstat = load_process(process)
     return fail_awaiting_wf(pstat, partial(safe_logstep, broadcast_func=broadcast_func))
@@ -900,7 +896,7 @@ def set_process_status(process: ProcessTable, status: ProcessStatus) -> None:
 def marshall_processes(engine_settings: EngineSettingsTable, new_global_lock: bool) -> EngineSettingsTable | None:
     """Manage processes depending on the engine status.
 
-    This function only has to act when in the transitioning fases, i.e Pausing and Starting
+    This function only has to act when in the transitioning phases, i.e Pausing and Starting
 
     Args:
         engine_settings: Engine status containing the lock and status fields

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -227,7 +227,7 @@ PROCESS_STEP_HANDLER: ProcessHandlerFunc = _default_process_func
 
 def _update_process(process_id: UUID, step: Step, process_state: WFProcess) -> ProcessTable:
     try:
-        p = db.session.query(ProcessTable).where(ProcessTable.process_id == process_id).one()
+        p = db.session.get_one(ProcessTable, process_id)
     except NoResultFound as e:
         raise ValueError(f"Failed to write step to process: process with PID {process_id} not found") from e
 

--- a/test/integration_tests/services/test_processes.py
+++ b/test/integration_tests/services/test_processes.py
@@ -115,7 +115,7 @@ def test_process_log_db_step_success(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state_data = {"foo": "bar"}
     state = Success(state_data)
 
@@ -132,9 +132,9 @@ def test_process_log_db_step_success(simple_workflow):
     assert p.last_status == ProcessStatus.RUNNING
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state)
     assert not result.isfailed()
 
@@ -148,7 +148,7 @@ def test_process_log_db_step_success(simple_workflow):
     assert p.last_status == ProcessStatus.RUNNING
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_db_log_step_strips_subscription_models_inside_transactional(
@@ -170,7 +170,7 @@ def test_db_log_step_strips_subscription_models_inside_transactional(
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state = Success({"subscription": subscription})
 
     with transactional(db, MagicMock()):
@@ -239,7 +239,7 @@ def test_process_log_db_step_skipped(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state_data = {"foo": "bar"}
     state = Skipped(state_data)
 
@@ -256,9 +256,9 @@ def test_process_log_db_step_skipped(simple_workflow):
     assert p.last_status == ProcessStatus.RUNNING
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state)
     assert not result.isfailed()
 
@@ -272,7 +272,7 @@ def test_process_log_db_step_skipped(simple_workflow):
     assert p.last_status == ProcessStatus.RUNNING
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_process_log_db_step_suspend(simple_workflow):
@@ -287,7 +287,7 @@ def test_process_log_db_step_suspend(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state_data = {"foo": "bar"}
     state = Suspend(state_data)
 
@@ -304,9 +304,9 @@ def test_process_log_db_step_suspend(simple_workflow):
     assert p.last_status == ProcessStatus.SUSPENDED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state)
     assert not result.isfailed()
 
@@ -320,7 +320,7 @@ def test_process_log_db_step_suspend(simple_workflow):
     assert p.last_status == ProcessStatus.SUSPENDED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_process_log_db_step_waiting(simple_workflow):
@@ -335,7 +335,7 @@ def test_process_log_db_step_waiting(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state_data = "expected failure"
     state = Waiting(error_state_to_dict(Exception(state_data)))
 
@@ -352,9 +352,9 @@ def test_process_log_db_step_waiting(simple_workflow):
     assert p.last_status == ProcessStatus.WAITING
     assert p.last_step == "step"
     assert p.failed_reason == state_data
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state)
     assert result.iswaiting()
 
@@ -371,7 +371,7 @@ def test_process_log_db_step_waiting(simple_workflow):
     assert p.last_status == ProcessStatus.WAITING
     assert p.last_step == "step"
     assert p.failed_reason == state_data
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_process_log_db_step_failed(simple_workflow):
@@ -442,7 +442,7 @@ def test_process_log_db_step_assertion_failed(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
 
     state_data = AssertionError("Assertion failure")
     state = Failed(state_data)
@@ -459,12 +459,12 @@ def test_process_log_db_step_assertion_failed(simple_workflow):
     saved_state.pop("traceback")
     assert psteps[0].state == saved_state
     assert psteps[0].created_by == "user"
-    assert p.last_status == ProcessStatus.INCONSISTENT_DATA
+    assert p.last_status == ProcessStatus.FAILED
     assert p.last_step == "step"
     assert p.failed_reason == "Assertion failure"
-    assert p.assignee == Assignee.NOC
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state.on_failed(error_state_to_dict))
     assert result.isfailed()
 
@@ -479,10 +479,10 @@ def test_process_log_db_step_assertion_failed(simple_workflow):
     del pstep_state["class"]
     assert pstep_state == {"error": "Assertion failure", "retries": 1}
     assert psteps[0].created_by == "user"
-    assert p.last_status == ProcessStatus.INCONSISTENT_DATA
+    assert p.last_status == ProcessStatus.FAILED
     assert p.last_step == "step"
     assert p.failed_reason == "Assertion failure"
-    assert p.assignee == Assignee.NOC
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_process_log_db_step_api_failed(simple_workflow):
@@ -498,7 +498,7 @@ def test_process_log_db_step_api_failed(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
 
     state_data = ApiException(HTTPStatus.BAD_GATEWAY, "API failure")
     state = Failed(state_data)
@@ -518,9 +518,9 @@ def test_process_log_db_step_api_failed(simple_workflow):
     assert p.last_status == ProcessStatus.API_UNAVAILABLE
     assert p.last_step == "step"
     assert p.failed_reason == "API failure"
-    assert p.assignee == Assignee.SYSTEM
+    assert p.assignee == Assignee.KLANTSUPPORT
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     result = _db_log_step(pstat, step, state.on_failed(error_state_to_dict))
     assert result.isfailed()
 
@@ -544,7 +544,7 @@ def test_process_log_db_step_api_failed(simple_workflow):
     assert p.last_status == ProcessStatus.API_UNAVAILABLE
     assert p.last_step == "step"
     assert p.failed_reason == "API failure"
-    assert p.assignee == Assignee.SYSTEM
+    assert p.assignee == Assignee.KLANTSUPPORT
 
 
 def test_process_log_db_step_abort(simple_workflow):
@@ -559,7 +559,7 @@ def test_process_log_db_step_abort(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     state_data = {"foo": "bar"}
     state = Abort(state_data)
 
@@ -576,9 +576,9 @@ def test_process_log_db_step_abort(simple_workflow):
     assert p.last_status == ProcessStatus.ABORTED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.NOC
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     result = _db_log_step(pstat, step, state)
     assert not result.isfailed()
 
@@ -592,7 +592,7 @@ def test_process_log_db_step_abort(simple_workflow):
     assert p.last_status == ProcessStatus.ABORTED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.NOC
 
 
 def test_process_log_db_step_complete(simple_workflow):
@@ -607,7 +607,7 @@ def test_process_log_db_step_complete(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     state_data = {"foo": "bar"}
     state = Complete(state_data)
 
@@ -624,9 +624,9 @@ def test_process_log_db_step_complete(simple_workflow):
     assert p.last_status == ProcessStatus.COMPLETED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.NOC
 
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     result = _db_log_step(pstat, step, state)
     assert not result.isfailed()
 
@@ -640,7 +640,7 @@ def test_process_log_db_step_complete(simple_workflow):
     assert p.last_status == ProcessStatus.COMPLETED
     assert p.last_step == "step"
     assert p.failed_reason is None
-    assert p.assignee == "assignee"
+    assert p.assignee == Assignee.NOC
 
 
 @pytest.fixture
@@ -680,11 +680,11 @@ def test_run_process_async_broadcasts_after_status_commit(simple_workflow):
 
     def broadcast_func(broadcast_process_id):
         with db.database_scope():
-            process = db.session.get(ProcessTable, broadcast_process_id)
+            process = db.session.get_one(ProcessTable, broadcast_process_id)
             observed_statuses.append(process.last_status)
 
     def run_func():
-        process = db.session.get(ProcessTable, process_id)
+        process = db.session.get_one(ProcessTable, process_id)
         process.last_status = ProcessStatus.COMPLETED
         return Complete({"foo": "bar"})
 
@@ -705,7 +705,7 @@ def test_run_process_async_swallows_final_broadcast_exception(simple_workflow):
     db.session.commit()
 
     def run_func():
-        process = db.session.get(ProcessTable, process_id)
+        process = db.session.get_one(ProcessTable, process_id)
         process.last_status = ProcessStatus.COMPLETED
         return Complete({"foo": "bar"})
 
@@ -735,7 +735,7 @@ async def test_broadcast_process_update_async_invalidates_subscription_cache_on_
     from orchestrator.core.websocket import broadcast_process_update_to_websocket_async
 
     process_id, subscription_id = process_with_subscription
-    process = db.session.get(ProcessTable, process_id)
+    process = db.session.get_one(ProcessTable, process_id)
     process.last_status = terminal_status
     db.session.commit()
 
@@ -773,7 +773,7 @@ async def test_broadcast_process_update_async_does_not_invalidate_subscription_c
     from orchestrator.core.websocket import broadcast_process_update_to_websocket_async
 
     process_id, _ = process_with_subscription
-    process = db.session.get(ProcessTable, process_id)
+    process = db.session.get_one(ProcessTable, process_id)
     process.last_status = non_terminal_status
     db.session.commit()
 
@@ -792,13 +792,13 @@ def test_process_log_db_step_no_process_id(simple_workflow):
     process_id = uuid4()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     state_data = {"foo": "bar"}
     state = Complete(state_data)
 
     with pytest.raises(ValueError) as exc_info:
         _db_log_step(pstat, step, state)
-    assert f"Failed to write failure step to process: process with PID {process_id} not found" in str(exc_info.value)
+    assert f"Failed to write step to process: process with PID {process_id} not found" in str(exc_info.value)
 
 
 def test_process_log_db_step_deduplication(simple_workflow):
@@ -870,7 +870,7 @@ def test_safe_logstep(simple_workflow):
     db.session.commit()
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.KLANTSUPPORT)
     state_data = {"not_serializable": object()}
     state = Complete(state_data)
 
@@ -912,7 +912,7 @@ def test_safe_logstep_critical_failure():
     # Skip storing the actual process to let `_db_log_step` fail
 
     pstat = ProcessStat(process_id, None, None, None, current_user="user")
-    step = make_step_function(lambda: None, "step", None, "assignee")
+    step = make_step_function(lambda: None, "step", None, Assignee.NOC)
     state_data = {"not_serializable": object()}
     state = Complete(state_data)
 
@@ -933,7 +933,7 @@ def test_safe_logstep_critical_failure():
                         Failed(
                             {
                                 "class": "Exception",
-                                "error": f"Failed to write failure step to process: process with PID {process_id} not found",
+                                "error": f"Failed to write step to process: process with PID {process_id} not found",
                                 "traceback": mock.ANY,
                             }
                         ),
@@ -941,7 +941,7 @@ def test_safe_logstep_critical_failure():
                 ]
             )
 
-        assert f"Failed to write failure step to process: process with PID {process_id} not found" in str(e.value)
+        assert f"Failed to write step to process: process with PID {process_id} not found" in str(e.value)
 
 
 @mock.patch("orchestrator.core.services.processes._get_process")
@@ -1257,7 +1257,7 @@ def test_load_process_with_altered_steps(num_steps_finished, step_names):
     workflow_1 = workflow_decorator(lambda: init >> step1 >> done)
     with WorkflowInstanceForTests(workflow_1, "test_wf"):
         _, p_stat, steps = run_workflow("test_wf", [{"test_field": "test"}])
-        process_table = db.session.get(ProcessTable, p_stat.process_id)
+        process_table = db.session.get_one(ProcessTable, p_stat.process_id)
 
         for step_fn, wf_process in steps[:num_steps_finished]:
             process_table.steps.append(


### PR DESCRIPTION
## Summary
Allow for custom handling of storing the process state after each step in the subscription database.
Also removes some SURF-specific behaviour and prevents drift on how we match error names to process states.

## Related Issues
Fixes #1729 

## Type of change
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
