### PR TITLE
Fix DB reference docs admonition

### DIFF
--- a/docs/reference-docs/database.md
+++ b/docs/reference-docs/database.md
@@ -10,9 +10,9 @@ these technologies, you should definitely read up on them to get a better unders
 database components work. The database models we use for the orchestrator-core live in `orchestrator-core/db/models.py`.
 
 ??? example "Example: `orchestrator-core/db/models.py`"
-    `python linenums="1"
+    ```python linenums="1"
     {% include '../../orchestrator/core/db/models.py' %}
-    `
+    ```
 
 ## Setting Up the Database Initially
 
@@ -27,8 +27,8 @@ appropriate saving in the database occurs. You can see how we do this with the `
 the SQLAlchemy `Session` object:
 
 ::: orchestrator.core.db.database.WrappedSession
-options:
-heading_level: 3
+    options:
+        heading_level: 3
 
 ## Multiple Heads
 


### PR DESCRIPTION
## Summary

Small fix to database reference docs layout.


## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
