### PR TITLE
Fix/highlight indices punctuation

### DIFF
--- a/orchestrator/core/cli/search/display.py
+++ b/orchestrator/core/cli/search/display.py
@@ -70,7 +70,9 @@ def display_results(
 
         # If we have matching fields from fuzzy/structured search, display only those
         if result.matching_fields:
-            logger.info(f"Entity ID: {entity_id}")
+            logger.info(
+                f"Entity: {result.entity_title} ({entity_id}) score={score:.4f} perfect_match={result.perfect_match}"
+            )
             for mf in result.matching_fields:
                 logger.info(f"Matched field ({mf.path}): {mf.text}")
             logger.info(f"{score_label}: {score:.4f}\n" + "-" * 20)

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -197,14 +197,16 @@ def truncate_text_with_highlights(
 
 
 def generate_highlight_indices(text: str, term: str) -> list[tuple[int, int]]:
-    """Finds all occurrences of individual words from the term, including both word boundary and substring matches."""
-    import re
+    """Finds all occurrences of individual words from the term, including both word boundary and substring matches.
 
+    Leading and trailing punctuation is stripped from each word (``"Node`` matches ``Node``), mirroring
+    pg_trgm, which ignores non-alphanumeric characters when matching.
+    """
     if not text or not term:
         return []
 
     all_matches = []
-    words = [w.strip() for w in term.split() if w.strip()]
+    words = [w for w in (re.sub(r"^\W+|\W+$", "", w) for w in term.split()) if w]
 
     for word in words:
         # First find word boundary matches

--- a/orchestrator/core/search/query/results.py
+++ b/orchestrator/core/search/query/results.py
@@ -196,17 +196,24 @@ def truncate_text_with_highlights(
     return truncated_text, adjusted_indices if adjusted_indices else None
 
 
+# Trims punctuation that wraps or terminates a word in prose (quotes of any flavour, brackets, commas)
+# from both ends of a query word. ``+``, ``#`` and ``@`` are kept because they carry meaning at a word
+# edge (``C++``, ``#1234``, ``@user``) and trimming them would highlight the bare remainder everywhere.
+EDGE_PUNCTUATION_RE = re.compile(r"^[^\w+#@]+|[^\w+#@]+$")
+
+
 def generate_highlight_indices(text: str, term: str) -> list[tuple[int, int]]:
     """Finds all occurrences of individual words from the term, including both word boundary and substring matches.
 
-    Leading and trailing punctuation is stripped from each word (``"Node`` matches ``Node``), mirroring
-    pg_trgm, which ignores non-alphanumeric characters when matching.
+    Wrapping punctuation is stripped from the edges of each word, so a quoted query highlights the words
+    it wraps (``"Node`` highlights ``Node``). Identifiers keep their inner punctuation and are matched
+    whole, so ``asd066d-jnp-02`` is one word rather than three.
     """
     if not text or not term:
         return []
 
     all_matches = []
-    words = [w for w in (re.sub(r"^\W+|\W+$", "", w) for w in term.split()) if w]
+    words = [w for w in (EDGE_PUNCTUATION_RE.sub("", w) for w in term.split()) if w]
 
     for word in words:
         # First find word boundary matches

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -551,7 +551,7 @@ def test_resolve_contains_filter_highlights_regex_matches(pattern, text, expecte
 @pytest.mark.parametrize(
     "pattern, text",
     [
-        pytest.param("[foo", "FOO BAR baz", id="invalid-regex"),
+        pytest.param("[qux", "FOO BAR baz", id="invalid-regex-word-not-in-text"),
         pytest.param(".*", "FOO BAR baz", id="match-all-wildcard-only"),
         pytest.param(".*banana.*", "widget assembly", id="pattern-not-in-text"),
     ],
@@ -565,6 +565,14 @@ def test_resolve_contains_filter_falls_back_to_full_text(pattern, text):
     result = _resolve_structured_matching_fields(row, tree)
     assert len(result) == 1
     assert result[0].highlight_indices == [(0, len(text))]
+
+
+def test_resolve_contains_filter_invalid_regex_highlights_literal_words():
+    """An invalid regex falls back to word highlighting, ignoring the punctuation that broke the pattern."""
+    tree = _single_leaf_filter_tree(ContainsFilter(op=FilterOp.CONTAINS, value="[foo"), path="subscription.description")
+    row = _row_with_highlights([("FOO BAR baz", "subscription.description")])
+    result = _resolve_structured_matching_fields(row, tree)
+    assert result[0].highlight_indices == [(0, 3)]
 
 
 def test_resolve_neq_filter_returns_null_highlight_indices():

--- a/test/unit_tests/search/query/test_results.py
+++ b/test/unit_tests/search/query/test_results.py
@@ -569,7 +569,10 @@ def test_resolve_contains_filter_falls_back_to_full_text(pattern, text):
 
 def test_resolve_contains_filter_invalid_regex_highlights_literal_words():
     """An invalid regex falls back to word highlighting, ignoring the punctuation that broke the pattern."""
-    tree = _single_leaf_filter_tree(ContainsFilter(op=FilterOp.CONTAINS, value="[foo"), path="subscription.description")
+    tree = _single_leaf_filter_tree(
+        ContainsFilter(op=FilterOp.CONTAINS, value="[foo"),
+        path="subscription.description",
+    )
     row = _row_with_highlights([("FOO BAR baz", "subscription.description")])
     result = _resolve_structured_matching_fields(row, tree)
     assert result[0].highlight_indices == [(0, 3)]

--- a/test/unit_tests/search/retrieval/test_utils.py
+++ b/test/unit_tests/search/retrieval/test_utils.py
@@ -40,8 +40,15 @@ from orchestrator.core.search.query.results import generate_highlight_indices, t
             "Node asd066d-jnp-03", '"Node Peering asd066d-jnp-0"', [(0, 4), (5, 18)], id="quoted-query-partial"
         ),
         pytest.param("The quick brown fox jumps", "fox,", [(16, 19)], id="trailing-punctuation"),
+        pytest.param("Node Peering asd066d-jnp-02", "«Node» ‘Peering’", [(0, 4), (5, 12)], id="unicode-quotes"),
         pytest.param("The quick brown fox jumps", "fox -", [(16, 19)], id="punctuation-only-word-ignored"),
         pytest.param("asd066d-jnp-02 port", "asd066d-jnp", [(0, 11)], id="inner-hyphen-preserved"),
+        pytest.param(
+            "Corelink Amsterdam connectivity course",
+            "C++ course",
+            [(32, 38)],
+            id="symbol-token-kept-whole",
+        ),
         pytest.param("(fox)", "(fox)", [(1, 4)], id="wrapped-in-parentheses"),
     ],
 )

--- a/test/unit_tests/search/retrieval/test_utils.py
+++ b/test/unit_tests/search/retrieval/test_utils.py
@@ -30,6 +30,19 @@ from orchestrator.core.search.query.results import generate_highlight_indices, t
         pytest.param("The quick brown fox jumps", "elephant", [], id="no-match"),
         pytest.param("fox fox fox", "fox", [(0, 3), (4, 7), (8, 11)], id="duplicate-matches"),
         pytest.param("The Cat sat on the catalog.", "cat", [(4, 7), (19, 22)], id="word-and-substring"),
+        pytest.param(
+            "Node Peering asd066d-jnp-02",
+            '"Node Peering asd066d-jnp-0"',
+            [(0, 4), (5, 12), (13, 26)],
+            id="quoted-query",
+        ),
+        pytest.param(
+            "Node asd066d-jnp-03", '"Node Peering asd066d-jnp-0"', [(0, 4), (5, 18)], id="quoted-query-partial"
+        ),
+        pytest.param("The quick brown fox jumps", "fox,", [(16, 19)], id="trailing-punctuation"),
+        pytest.param("The quick brown fox jumps", "fox -", [(16, 19)], id="punctuation-only-word-ignored"),
+        pytest.param("asd066d-jnp-02 port", "asd066d-jnp", [(0, 11)], id="inner-hyphen-preserved"),
+        pytest.param("(fox)", "(fox)", [(1, 4)], id="wrapped-in-parentheses"),
     ],
 )
 def test_generate_highlight_indices(text: str, term: str, expected: list):

--- a/test/unit_tests/workflows/tasks/__init__.py
+++ b/test/unit_tests/workflows/tasks/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2019-2026 ESnet, GÉANT, SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## Summary
Search results highlight the query's words inside the matched field. Words carrying
punctuation at their edges were matched literally, punctuation included, so they never
highlighted. Searching `"Node Peering asd066d-jnp-02"` with quotes matched the subscription
of that name in SQL but highlighted only `Peering`, because `"Node` and `asd066d-jnp-02"`
were searched for verbatim.

Trims punctuation that wraps or terminates a word from both ends of each query word, so a quoted or comma-terminated query highlights the words it wraps instead of nothing. Characters inside identifiers and the edge-meaningful +, # and @ are kept, so asd066d-jnp-02 and C++ still match whole and behaviour is unchanged from main for every other input.

This fixes a common use case: a shared search URL, where the UI wraps the query in quotes.

## Related Issues
Fixes # (issue number)

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
