### PR TITLE
(5.4.0a3) Fix missing relationship loaders from async refactor

### DIFF
--- a/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
+++ b/orchestrator/core/api/api_v1/endpoints/mcp_tools.py
@@ -60,7 +60,14 @@ from sqlalchemy.orm import joinedload, raiseload
 from starlette.concurrency import run_in_threadpool
 
 from orchestrator.core.api.error_handling import raise_status
-from orchestrator.core.db import ProcessTable, ProductTable, SubscriptionTable, WorkflowTable, get_async_session
+from orchestrator.core.db import (
+    ProcessSubscriptionTable,
+    ProcessTable,
+    ProductTable,
+    SubscriptionTable,
+    WorkflowTable,
+    get_async_session,
+)
 from orchestrator.core.mcp.server import AGENT_EXPOSED_TAG, READONLY_TOOL
 from orchestrator.core.schemas.mcp_search import (
     AggregateToolRequest,
@@ -217,7 +224,15 @@ async def get_process_status_endpoint(params: ProcessIdRequest, session: AsyncSe
     If the process is SUSPENDED, the response includes the form schema for the
     input needed to resume it.
     """
-    process = await get_process_async(UUID(params.process_id), session)
+    process = await get_process_async(
+        UUID(params.process_id),
+        session,
+        options=[
+            joinedload(ProcessTable.process_subscriptions)
+            .joinedload(ProcessSubscriptionTable.subscription)
+            .joinedload(SubscriptionTable.product),
+        ],
+    )
     pstat = load_process(process)
     enriched = enrich_process(process, pstat)
     return ProcessStatusResponse(

--- a/orchestrator/core/api/api_v1/endpoints/processes.py
+++ b/orchestrator/core/api/api_v1/endpoints/processes.py
@@ -30,7 +30,7 @@ from more_itertools import chunked, first, last
 from sentry_sdk.tracing import trace
 from sqlalchemy import CompoundSelect, Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.functions import count
 from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
@@ -427,7 +427,18 @@ async def update_process(
     data: ProcessPatchSchema = Body(...),
     session: AsyncSession = Depends(get_async_session)
 ) -> ProcessTable:
-    process = await get_process_async(process_id, session)
+    process = await get_process_async(
+        process_id,
+        session,
+        options=[
+            joinedload(ProcessTable.process_subscriptions)
+            .joinedload(ProcessSubscriptionTable.subscription)
+            .options(
+                joinedload(SubscriptionTable.product),
+                selectinload(SubscriptionTable.customer_descriptions),
+            ),
+        ],
+    )
     if not process:
         raise_status(HTTPStatus.NOT_FOUND, f"Process id {process_id} not found")
 

--- a/orchestrator/core/api/api_v1/endpoints/processes.py
+++ b/orchestrator/core/api/api_v1/endpoints/processes.py
@@ -30,7 +30,7 @@ from more_itertools import chunked, first, last
 from sentry_sdk.tracing import trace
 from sqlalchemy import CompoundSelect, Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import defer, joinedload
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.functions import count
 from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
@@ -413,7 +413,7 @@ async def abort_process_endpoint(
 
 async def _index_processes(process_id: UUID) -> AsyncGenerator[None, Any]:
     yield
-    run_indexing_for_entity(EntityType.PROCESS, str(process_id))
+    await run_in_threadpool(run_indexing_for_entity, EntityType.PROCESS, str(process_id))
 
 
 @router.patch(
@@ -472,7 +472,7 @@ async def status_counts(session: AsyncSession = Depends(get_async_session)) -> P
 
 @router.get("/{process_id}", response_model=ProcessSchema)
 async def show(process_id: UUID) -> dict[str, Any]:
-    process =await run_in_threadpool(_get_process, process_id)
+    process = await run_in_threadpool(_get_process, process_id)
     p = load_process(process)
 
     return enrich_process(process, p)
@@ -508,13 +508,12 @@ async def processes_filterable(  # noqa: C901
     _filter: list[str] | None = filter.split(",") if filter else None
 
     # the joinedload on ProcessSubscriptionTable.subscription via ProcessBaseSchema.process_subscriptions prevents a query for every subscription later.
-    # tracebacks are not presented in the list of processes and can be really large.
     processes: Select | CompoundSelect
     processes = select(ProcessTable).options(
+        joinedload(ProcessTable.workflow),
         joinedload(ProcessTable.process_subscriptions)
         .joinedload(ProcessSubscriptionTable.subscription)
         .joinedload(SubscriptionTable.product),
-        defer(ProcessTable.traceback),
     )
 
     if _filter is not None:

--- a/orchestrator/core/api/api_v1/endpoints/product_blocks.py
+++ b/orchestrator/core/api/api_v1/endpoints/product_blocks.py
@@ -53,7 +53,9 @@ async def patch_product_block_by_id(
     data: ProductBlockPatchSchema = Body(...),
     session: AsyncSession = Depends(get_async_session),
 ) -> ProductBlockTable:
-    product_block = await session.get(ProductBlockTable, product_block_id)
+    product_block = await session.get(
+        ProductBlockTable, product_block_id, options=[selectinload(ProductBlockTable.resource_types)]
+    )
     if not product_block:
         raise_status(HTTPStatus.NOT_FOUND, f"Product_block id {product_block_id} not found")
 

--- a/orchestrator/core/api/api_v1/endpoints/products.py
+++ b/orchestrator/core/api/api_v1/endpoints/products.py
@@ -88,7 +88,7 @@ async def _product_by_id(product_id: UUID, session: AsyncSession) -> ProductTabl
         select(ProductTable)
         .options(
             joinedload(ProductTable.fixed_inputs),
-            joinedload(ProductTable.product_blocks),
+            joinedload(ProductTable.product_blocks).joinedload(ProductBlockTable.resource_types),
             joinedload(ProductTable.workflows),
         )
         .filter(ProductTable.product_id == product_id)

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -36,7 +36,6 @@ from orchestrator.core.db import (
     ProcessStepTable,
     ProcessSubscriptionTable,
     ProcessTable,
-    SubscriptionTable,
     db,
 )
 from orchestrator.core.db.database import transactional
@@ -454,14 +453,28 @@ def _get_process(process_id: UUID) -> ProcessTable:
     return process
 
 
-async def get_process_async(process_id: UUID, session: AsyncSession) -> ProcessTable:
+async def get_process_async(
+    process_id: UUID, session: AsyncSession, options: Sequence[Any] | None = None
+) -> ProcessTable:
+    """Async counterpart to :func:`_get_process` for use in async endpoints.
+
+    Args:
+        process_id: The process_id
+        session: Async database session
+        options: Additional SQLAlchemy loader options, e.g. to eagerly load relationships that
+            would otherwise trigger an implicit (unsupported) lazy load on an async session.
+            The workflow and steps of the process are always loaded.
+
+    Returns: A process object
+
+    """
     stmt = (
         select(ProcessTable)
         .where(ProcessTable.process_id == process_id)
         .options(
             joinedload(ProcessTable.workflow),
             joinedload(ProcessTable.steps),
-            joinedload(ProcessTable.process_subscriptions).joinedload(ProcessSubscriptionTable.subscription).joinedload(SubscriptionTable.product),
+            *(options or []),
         )
     )
     result = await session.execute(stmt)

--- a/orchestrator/core/services/processes.py
+++ b/orchestrator/core/services/processes.py
@@ -31,7 +31,14 @@ from sqlalchemy.orm import joinedload
 from nwastdlib.ex import show_ex
 from oauth2_lib.fastapi import OIDCUserModel
 from orchestrator.core.api.error_handling import raise_status
-from orchestrator.core.db import EngineSettingsTable, ProcessStepTable, ProcessSubscriptionTable, ProcessTable, db
+from orchestrator.core.db import (
+    EngineSettingsTable,
+    ProcessStepTable,
+    ProcessSubscriptionTable,
+    ProcessTable,
+    SubscriptionTable,
+    db,
+)
 from orchestrator.core.db.database import transactional
 from orchestrator.core.db.models import FAILED_REASON_LENGTH, TRACEBACK_LENGTH
 from orchestrator.core.distlock import distlock_manager
@@ -452,8 +459,9 @@ async def get_process_async(process_id: UUID, session: AsyncSession) -> ProcessT
         select(ProcessTable)
         .where(ProcessTable.process_id == process_id)
         .options(
+            joinedload(ProcessTable.workflow),
             joinedload(ProcessTable.steps),
-            joinedload(ProcessTable.process_subscriptions).joinedload(ProcessSubscriptionTable.subscription),
+            joinedload(ProcessTable.process_subscriptions).joinedload(ProcessSubscriptionTable.subscription).joinedload(SubscriptionTable.product),
         )
     )
     result = await session.execute(stmt)

--- a/test/integration_tests/_async_session.py
+++ b/test/integration_tests/_async_session.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 
 from orchestrator.core.db import db
+from test.integration_tests import _lazy_load_guard
 
 
 @contextlib.asynccontextmanager
@@ -34,4 +35,5 @@ async def session_joined_async() -> AsyncIterator[AsyncSession]:
         expire_on_commit=False,
         join_transaction_mode="create_savepoint",
     ) as session:
+        _lazy_load_guard.install(session)
         yield session

--- a/test/integration_tests/_lazy_load_guard.py
+++ b/test/integration_tests/_lazy_load_guard.py
@@ -1,0 +1,90 @@
+# Copyright 2019-2026 SURF, GÉANT.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fail tests on ORM loads an ``AsyncSession`` could not have performed.
+
+An ``AsyncSession`` runs every awaited operation inside a greenlet that SQLAlchemy spawns
+for it. Attribute access that falls outside such a greenlet — a lazy relationship load or a
+deferred column read during response serialization, for instance — has no way to suspend for
+IO and raises ``MissingGreenlet`` against a real async driver.
+
+Integration tests bind their ``AsyncSession`` to the synchronous test connection, which makes
+those loads succeed as ordinary blocking queries and hides the failure. Registering
+:func:`install` on such a session restores the distinction: it reproduces the driver's own
+precondition without needing the driver.
+"""
+
+import greenlet
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import ORMExecuteState
+
+# Relationship and column loads that are known to be emitted outside greenlet context and have
+# not been given eager loading yet. Entries are "<Mapper>.<attribute>" as reported below.
+#
+# This allowlist must only ever SHRINK. Fix the query that owns the load — add the relationship
+# to its loader options — and delete the entry.
+KNOWN_IMPLICIT_LOADS: frozenset[str] = frozenset()
+
+
+class ImplicitAsyncLoadError(AssertionError):
+    """An ORM load was emitted where a real async driver would have raised ``MissingGreenlet``."""
+
+
+def _can_suspend_for_io() -> bool:
+    """Whether the current greenlet is one SQLAlchemy spawned to await IO on."""
+    return bool(getattr(greenlet.getcurrent(), "__sqlalchemy_greenlet_provider__", False))
+
+
+def _describe(execute_state: ORMExecuteState) -> str:
+    """Name the attribute being loaded as "<Mapper>.<attribute>", falling back to the mapper."""
+    path = execute_state.loader_strategy_path
+    if path is not None:
+        entity = getattr(path.parent, "entity", None)
+        mapper = getattr(entity, "class_", None) or getattr(entity, "entity", None)
+        prop = getattr(path, "prop", None)
+        if mapper is not None and prop is not None:
+            return f"{mapper.__name__}.{prop.key}"
+
+    if (loaded_from := execute_state.lazy_loaded_from) is not None:
+        return f"{loaded_from.class_.__name__}.<unknown>"
+
+    bind_mapper = execute_state.bind_mapper
+    return f"{bind_mapper.class_.__name__}.<unknown>" if bind_mapper is not None else "<unknown>"
+
+
+def _handler(execute_state: ORMExecuteState) -> None:
+    if _can_suspend_for_io():
+        return
+    if not (execute_state.is_relationship_load or execute_state.is_column_load):
+        return
+
+    description = _describe(execute_state)
+    if description in KNOWN_IMPLICIT_LOADS:
+        return
+
+    raise ImplicitAsyncLoadError(
+        f"{description} was loaded outside greenlet context. Against the async driver this "
+        f"raises MissingGreenlet, so the query that produced this object must eager-load it. "
+        f"Statement: {execute_state.statement}"
+    )
+
+
+def install(session: AsyncSession) -> None:
+    """Fail this session on any relationship or column load emitted outside greenlet context."""
+    event.listen(session.sync_session, "do_orm_execute", _handler)
+
+
+def uninstall(session: AsyncSession) -> None:
+    """Remove the guard registered by :func:`install`."""
+    event.remove(session.sync_session, "do_orm_execute", _handler)

--- a/test/integration_tests/api/test_async_engine_endpoints.py
+++ b/test/integration_tests/api/test_async_engine_endpoints.py
@@ -1,0 +1,366 @@
+# Copyright 2019-2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Endpoint tests that run against the real async engine.
+
+Every other integration test resolves ``get_async_session`` through the shared
+``test_client`` fixture, which overrides it with ``session_joined_async()`` — an
+``AsyncSession`` bound to the *sync* per-test connection. That keeps fixture data and
+endpoint reads inside one roll-back-able transaction, at the cost of never exercising the
+async psycopg driver: greenlet context, connection pooling and lazy-load behaviour are all
+the sync engine's.
+
+The tests here drop that override, so endpoints run on ``db.async_session()`` and the async
+engine's own pool. That is the whole point of the module: it is the only place where
+async-only failure modes are reachable. Add a test here whenever an endpoint's behaviour
+depends on actually being async rather than merely being declared ``async def``.
+
+The failure mode covered so far is lazy loading. An ORM attribute that a query did not
+eager-load, but that response serialization reads, triggers a lazy load on the event
+loop's main greenlet; it reaches ``AsyncAdaptedQueuePool._checkout()`` outside
+``greenlet_spawn`` and raises ``MissingGreenlet``. Under the sync binding the same read is
+merely an extra round-trip, which is why the regular suite is green while production is
+not.
+
+Running on the real engine means fixture data has to be committed — the async engine reads
+on its own connection and cannot see the uncommitted rows ``db_session`` stages.
+``committed_session`` provides that, and every seed fixture cleans up after itself.
+"""
+
+from http import HTTPStatus
+
+import pytest
+from sqlalchemy import create_engine, delete, select
+from sqlalchemy.orm import Session
+
+from orchestrator.core.config.assignee import Assignee
+from orchestrator.core.db import get_async_session
+from orchestrator.core.db.models import (
+    ProcessStepTable,
+    ProcessTable,
+    ProductBlockTable,
+    ProductTable,
+    ResourceTypeTable,
+    WorkflowTable,
+)
+from orchestrator.core.domain.lifecycle import ProductLifecycle
+from orchestrator.core.targets import Target
+from orchestrator.core.workflow import (
+    CALLBACK_TOKEN_KEY,
+    DEFAULT_CALLBACK_PROGRESS_KEY,
+    ProcessStatus,
+    StepStatus,
+)
+from test.integration_tests._fixtures import JsonTestClient
+
+WORKFLOW_NAME = "test_async_engine_endpoints_workflow"
+CALLBACK_WORKFLOW_NAME = "test_async_engine_endpoints_callback_workflow"
+PRODUCT_BLOCK_NAME = "AsyncEngineEndpointsBlock"
+STANDALONE_PRODUCT_BLOCK_NAME = "AsyncEngineEndpointsStandaloneBlock"
+PRODUCT_NAME = "AsyncEngineEndpointsProduct"
+RESOURCE_TYPE_NAME = "async_engine_endpoints_resource_type"
+STANDALONE_RESOURCE_TYPE_NAME = "async_engine_endpoints_standalone_resource_type"
+TRACEBACK = "Traceback (most recent call last): ..."
+CALLBACK_TOKEN = "async-engine-endpoints-token"  # noqa: S105
+
+
+@pytest.fixture
+def async_engine_test_client(fastapi_app, test_client):
+    """Test client whose endpoints resolve ``get_async_session`` to the real async engine.
+
+    Depends on ``test_client`` purely for ordering: that fixture installs the
+    ``session_joined_async`` override, and this one removes it again so the endpoints fall
+    back to ``db.async_session()``.
+    """
+    fastapi_app.dependency_overrides.pop(get_async_session, None)
+    return JsonTestClient(fastapi_app)
+
+
+@pytest.fixture
+def committed_session(db_uri):
+    """Session on its own connection whose commits are real.
+
+    The autouse ``db_session`` fixture wraps each test in a transaction it rolls back, so
+    the rows it writes are invisible to every other connection. Endpoints driven through
+    ``async_engine_test_client`` read from the async engine's own pool, so their fixture
+    data has to be committed — and cleaned up — explicitly.
+    """
+    engine = create_engine(db_uri)
+    try:
+        with Session(engine, expire_on_commit=False) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def committed_process(committed_session):
+    """Yield the id of a committed process with a workflow but no steps or subscriptions.
+
+    ``traceback`` is populated because ``processes_filterable`` defers that column while
+    ``enrich_process`` reads it, making the deferred-column load observable in the response.
+    """
+    workflow = WorkflowTable(
+        name=WORKFLOW_NAME,
+        target=Target.SYSTEM,
+        description="Workflow backing the async engine endpoint tests",
+        is_task=True,
+    )
+    process = ProcessTable(
+        workflow=workflow,
+        last_status=ProcessStatus.FAILED,
+        assignee=Assignee.SYSTEM,
+        is_task=True,
+        traceback=TRACEBACK,
+    )
+    committed_session.add(process)
+    committed_session.commit()
+
+    yield process.process_id
+
+    committed_session.execute(delete(ProcessTable).where(ProcessTable.process_id == process.process_id))
+    committed_session.execute(delete(WorkflowTable).where(WorkflowTable.workflow_id == workflow.workflow_id))
+    committed_session.commit()
+
+
+@pytest.fixture
+def committed_awaiting_callback_process(committed_session):
+    """Yield the id of a committed process parked on an awaiting-callback step.
+
+    The step carries the callback token in its state, which is what
+    ``ensure_correct_callback_token`` checks once ``load_process`` has rebuilt the
+    ``ProcessStat``. The workflow is deliberately not registered: ``load_process`` falls
+    back to ``removed_workflow``, which is enough to exercise the endpoint without
+    standing up the workflow engine.
+    """
+    workflow = WorkflowTable(
+        name=CALLBACK_WORKFLOW_NAME,
+        target=Target.CREATE,
+        description="Workflow backing the async engine callback test",
+    )
+    process = ProcessTable(
+        workflow=workflow,
+        last_status=ProcessStatus.AWAITING_CALLBACK,
+        assignee=Assignee.SYSTEM,
+        is_task=False,
+    )
+    committed_session.add(process)
+    committed_session.commit()
+
+    # ProcessTable.steps sets cascade="delete", which switches off the default save-update
+    # cascade, so the step has to be added to the session in its own right.
+    committed_session.add(
+        ProcessStepTable(
+            process_id=process.process_id,
+            name="callback_step",
+            status=StepStatus.AWAITING_CALLBACK,
+            state={CALLBACK_TOKEN_KEY: CALLBACK_TOKEN},
+        )
+    )
+    committed_session.commit()
+
+    yield process.process_id
+
+    # process_steps.pid cascades on delete at the database level.
+    committed_session.execute(delete(ProcessTable).where(ProcessTable.process_id == process.process_id))
+    committed_session.execute(delete(WorkflowTable).where(WorkflowTable.workflow_id == workflow.workflow_id))
+    committed_session.commit()
+
+
+@pytest.fixture
+def committed_product_block(committed_session):
+    """Yield the id of a committed product block owning one resource type.
+
+    Shared by the GET and PATCH tests below so the two endpoints are compared on identical
+    data: same row, same response schema, same relationship — only the loader options differ.
+    """
+    resource_type = ResourceTypeTable(resource_type=STANDALONE_RESOURCE_TYPE_NAME, description="Resource type")
+    product_block = ProductBlockTable(
+        name=STANDALONE_PRODUCT_BLOCK_NAME,
+        description="Original description",
+        tag="AEEB",
+        status=ProductLifecycle.ACTIVE,
+        resource_types=[resource_type],
+    )
+    committed_session.add(product_block)
+    committed_session.commit()
+
+    yield product_block.product_block_id
+
+    # Deleted through the ORM so the secondary association rows go with them.
+    committed_session.delete(product_block)
+    committed_session.delete(resource_type)
+    committed_session.commit()
+
+
+@pytest.fixture
+def committed_product(committed_session):
+    """Yield the id of a committed product owning one product block with one resource type."""
+    resource_type = ResourceTypeTable(resource_type=RESOURCE_TYPE_NAME, description="Resource type")
+    product_block = ProductBlockTable(
+        name=PRODUCT_BLOCK_NAME,
+        description="Product block",
+        tag="AEEP",
+        status=ProductLifecycle.ACTIVE,
+        resource_types=[resource_type],
+    )
+    product = ProductTable(
+        name=PRODUCT_NAME,
+        description="Original description",
+        product_type="AsyncEngineEndpoints",
+        tag="AEEP",
+        status=ProductLifecycle.ACTIVE,
+        product_blocks=[product_block],
+    )
+    committed_session.add(product)
+    committed_session.commit()
+
+    yield product.product_id
+
+    # Deleted through the ORM so the secondary association rows go with them.
+    committed_session.delete(product)
+    committed_session.delete(product_block)
+    committed_session.delete(resource_type)
+    committed_session.commit()
+
+
+def test_patch_process_note_serializes_workflow_name(async_engine_test_client, committed_process):
+    """``PATCH /api/processes/{process_id}`` must serialize ``workflow_name``.
+
+    ``get_process_async`` eager-loads ``steps`` and ``process_subscriptions`` but not
+    ``workflow``, while ``ProcessSchema`` inherits the required ``workflow_name`` field,
+    which reads the ``ProcessTable.workflow.name`` property. The note itself commits before
+    serialization, so the write lands and the response still fails.
+    """
+    response = async_engine_test_client.patch(f"/api/processes/{committed_process}", json={"note": "a note"})
+
+    assert HTTPStatus.OK == response.status_code
+    body = response.json()
+    assert body["note"] == "a note"
+    assert body["workflow_name"] == WORKFLOW_NAME
+
+
+def test_list_processes_serializes_workflow_and_traceback(async_engine_test_client, committed_process):
+    """``GET /api/processes/`` must serialize the workflow fields and the deferred traceback.
+
+    ``processes_filterable`` loads neither ``workflow`` — which ``enrich_process`` reads for
+    ``workflow_name`` and ``workflow_target`` — nor ``traceback``, which it explicitly
+    defers and then reads anyway. Both are lazy loads during serialization.
+    """
+    response = async_engine_test_client.get("/api/processes/")
+
+    assert HTTPStatus.OK == response.status_code
+    processes = {process["process_id"]: process for process in response.json()}
+    process = processes[str(committed_process)]
+    assert process["workflow_name"] == WORKFLOW_NAME
+    assert process["workflow_target"] == Target.SYSTEM
+    assert process["traceback"] == TRACEBACK
+
+
+def test_process_callback_progress_loads_workflow(
+    async_engine_test_client, committed_awaiting_callback_process, committed_session
+):
+    """``POST /api/processes/{id}/callback/{token}/progress`` must reach ``load_process``.
+
+    ``load_process`` opens with ``process.workflow.name``, so the endpoint fails on the
+    lazy load before it can validate the callback token. The progress data is written onto
+    the current step's state, which is asserted from a separate connection.
+    """
+    response = async_engine_test_client.post(
+        f"/api/processes/{committed_awaiting_callback_process}/callback/{CALLBACK_TOKEN}/progress",
+        json={"percentage": 50},
+    )
+
+    assert HTTPStatus.OK == response.status_code
+    committed_session.expire_all()
+    step = committed_session.scalars(
+        select(ProcessStepTable).where(ProcessStepTable.process_id == committed_awaiting_callback_process)
+    ).one()
+    assert step.state[DEFAULT_CALLBACK_PROGRESS_KEY] == {"percentage": 50}
+
+
+def test_get_process_status_tool_loads_workflow(async_engine_test_client, committed_process):
+    """``POST /api/agent/get_process_status`` must reach ``load_process`` and ``enrich_process``.
+
+    The MCP tool loads the process through ``get_process_async`` and then reads
+    ``process.workflow`` twice: once inside ``load_process`` and once when building the
+    response. The sibling ``list_recent_processes`` tool eager-loads ``workflow``; this one
+    does not.
+    """
+    response = async_engine_test_client.post(
+        "/api/agent/get_process_status", json={"process_id": str(committed_process)}
+    )
+
+    assert HTTPStatus.OK == response.status_code
+    body = response.json()
+    assert body["workflow_name"] == WORKFLOW_NAME
+    assert body["traceback"] == TRACEBACK
+
+
+def test_get_product_block_serializes_resource_types(async_engine_test_client, committed_product_block):
+    """``GET /api/product_blocks/{product_block_id}`` eager-loads correctly and must stay green.
+
+    This is the module's control. It exercises the same fixture, response schema and
+    relationship as the PATCH below, but passes
+    ``options=[selectinload(ProductBlockTable.resource_types)]`` — the pattern every async
+    endpoint returning an ORM object needs. A failure here means the harness is broken
+    (committed fixture data, the dropped override, the async engine itself), not the endpoint.
+    """
+    response = async_engine_test_client.get(f"/api/product_blocks/{committed_product_block}")
+
+    assert HTTPStatus.OK == response.status_code
+    body = response.json()
+    assert body["description"] == "Original description"
+    assert [rt["resource_type"] for rt in body["resource_types"]] == [STANDALONE_RESOURCE_TYPE_NAME]
+
+
+def test_patch_product_block_serializes_resource_types(async_engine_test_client, committed_product_block):
+    """``PATCH /api/product_blocks/{product_block_id}`` must serialize ``resource_types``.
+
+    ``ProductBlockSchema.resource_types`` is backed by a relationship that this endpoint's
+    bare ``session.get`` does not load — the one difference from the GET above, which is
+    green on exactly the same data.
+    """
+    response = async_engine_test_client.patch(
+        f"/api/product_blocks/{committed_product_block}", json={"description": "updated description"}
+    )
+
+    assert HTTPStatus.CREATED == response.status_code
+    body = response.json()
+    assert body["description"] == "updated description"
+    assert [rt["resource_type"] for rt in body["resource_types"]] == [STANDALONE_RESOURCE_TYPE_NAME]
+
+
+@pytest.mark.parametrize(
+    ("method", "body", "expected_status"),
+    [
+        pytest.param("get", None, HTTPStatus.OK, id="get_product"),
+        pytest.param("patch", {"description": "updated description"}, HTTPStatus.CREATED, id="patch_product"),
+    ],
+)
+def test_product_endpoints_serialize_nested_resource_types(
+    async_engine_test_client, committed_product, method, body, expected_status
+):
+    """``GET`` and ``PATCH /api/products/{product_id}`` must serialize nested resource types.
+
+    Both go through ``_product_by_id``, which eager-loads ``product_blocks`` but not
+    ``product_blocks.resource_types``. The nested ``ProductBlockSchema`` reads that
+    relationship one level down during serialization. ``fetch`` (the list endpoint) chains
+    the nested ``selectinload`` correctly; ``_product_by_id`` does not.
+    """
+    kwargs = {"json": body} if body is not None else {}
+    response = getattr(async_engine_test_client, method)(f"/api/products/{committed_product}", **kwargs)
+
+    assert expected_status == response.status_code
+    product_block = response.json()["product_blocks"][0]
+    assert [rt["resource_type"] for rt in product_block["resource_types"]] == [RESOURCE_TYPE_NAME]


### PR DESCRIPTION
## Summary

After the async API refactor (#1870) in 5.4.0a3, some endpoints were missing sqlalchemy relationship loaders.
This was not detected by the existing integration tests as they use a sync session from a fixture.

In our sentry this was resulted in errors such as `MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place?`

Added a separate set of integration tests that explicitly use an async session, as well as a guard to the other integration tests that detect whenever a relationship is used without it being explicitly loaded.

## Related Issues

No issue, this bug only exists in 5.4.0a3.

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
