### PR TITLE
Fix product generator creating empty directories in --dryrun mode

### DIFF
--- a/orchestrator/core/cli/generate.py
+++ b/orchestrator/core/cli/generate.py
@@ -119,6 +119,7 @@ def create_context(
         "tdd": tdd,
         "writer": create_writer(dryrun=dryrun, force=force),
         "skip_existing_blocks": skip_existing_blocks,
+        "dryrun": dryrun,
     }
 
 

--- a/orchestrator/core/cli/generator/generator/helpers.py
+++ b/orchestrator/core/cli/generator/generator/helpers.py
@@ -36,6 +36,7 @@ class ProdGenContext(TypedDict):
     tdd: bool | None
     writer: Callable
     skip_existing_blocks: bool
+    dryrun: bool
 
 
 def get_workflow(config: dict, workflow_name: str) -> dict:

--- a/orchestrator/core/cli/generator/generator/unittest.py
+++ b/orchestrator/core/cli/generator/generator/unittest.py
@@ -49,7 +49,6 @@ def get_test_workflow_path(config: dict, workflow_type: str) -> Path:
     folder = file_name
 
     workflow_folder = settings.TEST_WORKFLOWS_PATH / Path(folder)
-    Path(workflow_folder).mkdir(parents=True, exist_ok=True)
 
     return workflow_folder / Path(f"test_{workflow_type}_{file_name}").with_suffix(".py")
 

--- a/orchestrator/core/cli/generator/generator/workflow.py
+++ b/orchestrator/core/cli/generator/generator/workflow.py
@@ -90,7 +90,7 @@ def generate_workflows(context: ProdGenContext) -> None:
     environment = context["environment"]
     writer = context["writer"]
 
-    create_product_workflow_paths(config)
+    create_product_workflow_paths(config, dryrun=context["dryrun"])
 
     # TODO: Remove from core and extend config from client specific code
     config = add_optional_nso_config(config)
@@ -116,7 +116,9 @@ def shared_product_workflow_folder(config: dict) -> Path:
     return product_workflow_folder(config) / Path("shared")
 
 
-def create_product_workflow_paths(config: dict) -> None:
+def create_product_workflow_paths(config: dict, dryrun: bool) -> None:
+    if dryrun:
+        return
     path = product_workflow_folder(config) / Path("shared")
     path.mkdir(parents=True, exist_ok=True)
     create_dunder_init_files(path)

--- a/test/unit_tests/cli/test_cli_generate.py
+++ b/test/unit_tests/cli/test_cli_generate.py
@@ -11,10 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pathlib
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from typer.testing import CliRunner
 
 from orchestrator.core.cli.generate import app
@@ -34,6 +34,17 @@ class MyExistingProductBlockProvisioning(
 
 class MyExistingProductBlock(MyExistingProductBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
     pass
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    """Run every test in this module inside an empty directory.
+
+    The generator writes paths relative to the current working directory, so any
+    filesystem side effect that escapes the `--dryrun` guard would otherwise land
+    wherever pytest happens to be invoked from.
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 def read_file(path: str) -> str:
@@ -85,9 +96,23 @@ def test_generate_workflows():
     assert result.exit_code == 0
 
 
-@mock.patch.object(pathlib.Path, "mkdir")
-def test_generate_unit_tests(mkdir_mock):
+def test_generate_unit_tests():
     runner = CliRunner()
     result = runner.invoke(app, ["unit-tests", "--config-file", read_file("product_config3.yaml"), "--dryrun"])
     assert "def test_" in result.stdout
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["product", "product-blocks", "workflows", "unit-tests"],
+)
+def test_dryrun_does_not_write_to_disk(command, tmp_path):
+    runner = CliRunner()
+    with mock.patch(
+        "orchestrator.core.cli.generator.generator.product_block.get_existing_product_blocks", return_value={}
+    ):
+        result = runner.invoke(app, [command, "--config-file", read_file("product_config3.yaml"), "--dryrun"])
+
+    assert result.exit_code == 0
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary

Fixes the product generator creating empty directories with init.py files while in `--dryrun` mode.

## Related Issues

n/a

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "Require a release-notes label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build, area/search)
are applied automatically from the files you changed; set the rest yourself.

A PR lands in only the FIRST matching release-notes section, and Breaking
Changes comes first — so a breaking feature is listed there rather than under
Features. That is intended: it is the section people read when upgrading.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), an `area/*` label, or `skip-changelog` if it should be left out of the notes.
- [x] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release and need an entry in [`docs/guides/upgrading/`](https://github.com/workfloworchestrator/orchestrator-core/tree/main/docs/guides/upgrading) describing what users must do.

## Checklist
- [x] I have updated relevant documentation.
- [x] I have updated AI context (i.e., CLAUDE.md) as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md), if applicable.
- [x] My code follows the style guidelines of this project as described in [CONTRIBUTING](https://github.com/workfloworchestrator/orchestrator-core/blob/main/docs/contributing/guidelines.md).
