### PR TITLE
Fix MemoryWebsocketManager not cleaning up clients connections that die mid-send

### DIFF
--- a/orchestrator/core/websocket/managers/memory_websocket_manager.py
+++ b/orchestrator/core/websocket/managers/memory_websocket_manager.py
@@ -12,6 +12,10 @@
 # limitations under the License.
 
 
+from collections.abc import Iterable
+from contextlib import suppress
+from itertools import chain
+
 from fastapi import WebSocket, WebSocketDisconnect, status
 from starlette.websockets import WebSocketState
 from structlog import get_logger
@@ -48,25 +52,47 @@ class MemoryWebsocketManager:
             await websocket.send_text(json_dumps(reason))
         await websocket.close(code=code)
 
+    def _connections(self, channels: Iterable[str]) -> list[tuple[str, WebSocket]]:
+        """Snapshot of (channel, websocket) pairs, safe to iterate while remove_ws mutates the registry."""
+        return list(
+            chain.from_iterable(
+                ((channel, websocket) for websocket in self.connections_by_pid.get(channel, []))
+                for channel in list(channels)
+            )
+        )
+
     async def disconnect_all(self) -> None:
-        for channel in self.connections_by_pid:
-            for websocket in self.connections_by_pid[channel]:
-                await self.remove_ws(websocket, channel)
+        for channel, websocket in self._connections(self.connections_by_pid):
+            await self.remove_ws(websocket, channel)
+
+    async def _send_text(self, websocket: WebSocket, payload: str) -> bool:
+        """Send to one client; False when the connection is gone and the client should be dropped."""
+        try:
+            await websocket.send_text(payload)
+        except (RuntimeError, ValueError, WebSocketDisconnect):
+            return False
+        return True
 
     async def broadcast_data(self, channels: list[str], data: dict) -> None:
-        try:
-            for channel in channels:
-                if channel in self.connections_by_pid:
-                    for websocket in self.connections_by_pid[channel]:
-                        await websocket.send_text(json_dumps(data))
-                        if "close" in data and data["close"]:
-                            await self.remove_ws(websocket, channel)
-        except (RuntimeError, ValueError):
-            pass
+        payload = json_dumps(data)
+        # Drop clients the send failed on, plus everyone when the message closes the channel. Failing
+        # one client must not abort the broadcast to the others.
+        stale = [
+            (channel, websocket)
+            for channel, websocket in self._connections(channels)
+            if not await self._send_text(websocket, payload) or data.get("close")
+        ]
+        for channel, websocket in stale:
+            await self.remove_ws(websocket, channel)
 
     async def remove_ws(self, websocket: WebSocket, channel: str) -> None:
-        if websocket.client_state != WebSocketState.DISCONNECTED:
-            await self.disconnect(websocket)
+        # Guard on application_state, which is what starlette's send() checks. It goes DISCONNECTED
+        # while client_state stays CONNECTED when a send fails rather than the client disconnecting,
+        # and closing then raises. Suppress as well: the close itself races with the peer going away,
+        # and the registry must be cleaned up either way.
+        if websocket.application_state != WebSocketState.DISCONNECTED:
+            with suppress(RuntimeError, WebSocketDisconnect):
+                await self.disconnect(websocket)
         if channel in self.connections_by_pid and websocket in self.connections_by_pid[channel]:
             self.connections_by_pid[channel].remove(websocket)
             if not len(self.connections_by_pid[channel]):

--- a/test/unit_tests/websocket/test_websocket_manager.py
+++ b/test/unit_tests/websocket/test_websocket_manager.py
@@ -28,9 +28,11 @@ REDIS_URL = "redis://localhost:6379"
 MEMORY_URL = "memory://"
 
 
-def _make_mock_ws(client_state=WebSocketState.CONNECTED):
+def _make_mock_ws(client_state=WebSocketState.CONNECTED, application_state=None):
+    """Mock websocket. application_state defaults to client_state; pass it to model the two diverging."""
     ws = AsyncMock(spec=WebSocket)
     ws.client_state = client_state
+    ws.application_state = client_state if application_state is None else application_state
     return ws
 
 
@@ -288,6 +290,76 @@ async def test_memory_remove_ws_not_in_channel(memory_mgr):
     memory_mgr.connections_by_pid = {"ch1": []}
     await memory_mgr.remove_ws(ws, "ch1")
     assert memory_mgr.connections_by_pid == {"ch1": []}
+
+
+# --- MemoryWebsocketManager cleanup of sockets whose peer vanished (#1903) ---
+
+
+@pytest.mark.parametrize(
+    "application_state,expect_close",
+    [
+        pytest.param(WebSocketState.CONNECTED, True, id="app-connected-closes"),
+        # A failed send leaves client_state CONNECTED but application_state DISCONNECTED; closing
+        # such a socket is what starlette rejects, so it must be skipped.
+        pytest.param(WebSocketState.DISCONNECTED, False, id="app-disconnected-skips-close"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_memory_remove_ws_guards_on_application_state(memory_mgr, application_state, expect_close: bool):
+    ws = _make_mock_ws(WebSocketState.CONNECTED, application_state)
+    memory_mgr.connections_by_pid = {"ch1": [ws]}
+    await memory_mgr.remove_ws(ws, "ch1")
+    assert ws.close.await_count == (1 if expect_close else 0)
+    assert "ch1" not in memory_mgr.connections_by_pid
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(RuntimeError('Cannot call "send" once a close message has been sent.'), id="already-closed"),
+        pytest.param(WebSocketDisconnect(1006), id="disconnect-mid-close"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_memory_remove_ws_cleans_up_when_close_raises(memory_mgr, exc):
+    """A close racing the peer must still evict the socket instead of propagating."""
+    ws = _make_mock_ws()
+    ws.close.side_effect = exc
+    memory_mgr.connections_by_pid = {"ch1": [ws]}
+    await memory_mgr.remove_ws(ws, "ch1")
+    assert "ch1" not in memory_mgr.connections_by_pid
+
+
+@pytest.mark.asyncio
+async def test_memory_connect_does_not_raise_when_send_failed(memory_mgr):
+    """The __pong__ write fails, so starlette raises WebSocketDisconnect and marks the app side closed."""
+    ws = _make_mock_ws(WebSocketState.CONNECTED, WebSocketState.DISCONNECTED)
+    ws.receive_text.side_effect = ["__ping__"]
+    ws.send_text.side_effect = WebSocketDisconnect(1006)
+    # As starlette does once application_state is DISCONNECTED.
+    ws.close.side_effect = RuntimeError('Cannot call "send" once a close message has been sent.')
+    await memory_mgr.connect(ws, "ch1")
+    assert memory_mgr.connections_by_pid == {}
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(RuntimeError("closed"), id="runtime"),
+        pytest.param(ValueError("bad"), id="value"),
+        pytest.param(WebSocketDisconnect(1006), id="disconnect"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_memory_broadcast_skips_dead_client_and_reaches_the_rest(memory_mgr, exc):
+    """One failing client must not swallow the broadcast for the clients after it."""
+    dead = _make_mock_ws()
+    dead.send_text.side_effect = exc
+    healthy = _make_mock_ws()
+    memory_mgr.connections_by_pid = {"ch1": [dead, healthy]}
+    await memory_mgr.broadcast_data(["ch1"], {"key": "value"})
+    healthy.send_text.assert_awaited_once()
+    assert memory_mgr.connections_by_pid["ch1"] == [healthy]
 
 
 # --- MemoryWebsocketManager redis no-ops ---


### PR DESCRIPTION
Fixes #1903.

A client whose TCP connection dies without a close handshake left a dead websocket registered in
`connections_by_pid`, and every later broadcast on that channel then reached nobody.

### Changes

**`remove_ws` guards on `application_state`.** `WebSocket.send()` gates on `application_state`, not
`client_state`. The two diverge when a send fails rather than the client disconnecting: starlette
sets `application_state = DISCONNECTED` and raises `WebSocketDisconnect(1006)`, while `client_state`
stays `CONNECTED` because no disconnect message ever arrived. The old guard therefore called
`close()` on an already-closed socket and starlette raised `RuntimeError`.

**The close is suppressed and cleanup always runs.** The close inherently races the peer going away,
so `RuntimeError`/`WebSocketDisconnect` no longer escape and the socket is removed from the registry
either way. This also stops the traceback surfacing as `Exception in ASGI application`.

**`broadcast_data` sends per client.** The blanket `try`/`except` around the whole nested loop meant
one failing socket abandoned the broadcast for every client after it. Each send is now guarded
individually; clients that fail are dropped afterwards.

A `_connections()` helper returns a snapshot of `(channel, websocket)` pairs so the registry can be
mutated while iterating.

### Tests

Seven new parametrized cases covering the state guard, cleanup when the close raises, `connect()`
after a failed send, and a broadcast reaching clients queued behind a dead one. All seven fail on
`main` and pass here.

The mock websocket helper now sets `application_state` (defaulting to `client_state`, with an
override to model the two diverging). No existing assertion needed changing.

`1568 passed` in `test/unit_tests`; ruff and mypy clean.
